### PR TITLE
Bypassing Web scraper detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-# Web scraper
+# PricePinion-Backend
 
-This repo is for building the web scraper we will need to use for PricePinion.
 ![Web Scraping](https://github.com/PricePinion/Webscraper/actions/workflows/unit_tests.yml/badge.svg)
 
 ## Development Instructions
 
 ### Getting the packages.
-
-Just like any JavaScript/Typescript project we need to install all the packages.
 
 If you have just cloned the repo run the command `npm i` or `npm install`
 
@@ -16,10 +13,10 @@ The package.json contains all the packages required. If you run into any issues 
 ### Starting the development server
 
 To work smarter and not harder, we have bundled the tsc compile command and node AppServer.ts into one simple command called: `npm run dev`
-Now you no longer have to stress about diagnosing bugs because you forgot to compile the code. 
-We also use tsc-alias for cleaner imports, so this command makes it much easier. See the section Formatting for more info.
+Now you no longer have to stress about bugs because you forgot to compile the code. 
+We also use tsc-alias for cleaner imports, see the section Formatting for more info.
 
-On the topic of compilation, with some Typescript projects .js.map and .js files littered throughout the project files. In this project tsc is set to store
+On the topic of compilation, with some Typescript projects .js.map and .js files are littered throughout the project files. In this project tsc is set to store
 these compilation artifacts into a directory called dist.  This folder is git ignored so it won't show up on our GitHub repo.
 
 ### All the other commands
@@ -31,8 +28,7 @@ these compilation artifacts into a directory called dist.  This folder is git ig
 To format the codebase, so it's easier to read (because TS/JS can get pretty ugly) run `npm run format`. When 
 
 ##### Tsc Alias
-Aliasing is something that can be found in NodeJS projects. The whole goal of this is imports can get very ugly with all the directories for modules.
-When building a class or a new function, a rule of thumb to follow is if it's going to be used more than once, make an alias for it.
+Relative imports can get very ugly with all the directories for modules. When building a class, a rule of thumb to follow is if it's going to be used more than once, make an alias for it.
 
 To make an alias go to the file "tsconfig.json" and under the "paths" key you can specify the alias to associate your class with.
 As an example, to import our Winston Logger, we simply type `import { logger } from "@logger";`
@@ -44,6 +40,5 @@ this is cleaner than `import { logger } from "./src/utils/WinstonLogger.ts;`
 These tests will run when a pull request is made, and they must pass in order to push your changes to main.
 To run tests locally execute the command `npm run test` to run tests using Mocha and Chai.
 ##### Route API Testing
-To write tests for the API route's please create a folder called routes in the tests directory.
 To run tests for routes execute the command `npm run test:routes` to run ONLY the route tests.
 

--- a/angularDist/chunk-LPDIY7FO.js
+++ b/angularDist/chunk-LPDIY7FO.js
@@ -1,7 +1,10635 @@
-var Xl=Object.defineProperty,ed=Object.defineProperties;var td=Object.getOwnPropertyDescriptors;var fn=Object.getOwnPropertySymbols;var $s=Object.prototype.hasOwnProperty,Hs=Object.prototype.propertyIsEnumerable;var Bs=(e,t,n)=>t in e?Xl(e,t,{enumerable:!0,configurable:!0,writable:!0,value:n}):e[t]=n,xe=(e,t)=>{for(var n in t||={})$s.call(t,n)&&Bs(e,n,t[n]);if(fn)for(var n of fn(t))Hs.call(t,n)&&Bs(e,n,t[n]);return e},lt=(e,t)=>ed(e,td(t));var XD=(e,t)=>{var n={};for(var r in e)$s.call(e,r)&&t.indexOf(r)<0&&(n[r]=e[r]);if(e!=null&&fn)for(var r of fn(e))t.indexOf(r)<0&&Hs.call(e,r)&&(n[r]=e[r]);return n};var nd=(e,t,n)=>new Promise((r,o)=>{var i=u=>{try{a(n.next(u))}catch(c){o(c)}},s=u=>{try{a(n.throw(u))}catch(c){o(c)}},a=u=>u.done?r(u.value):Promise.resolve(u.value).then(i,s);a((n=n.apply(e,t)).next())});var Us=null,pn=!1,Wr=1,gn=Symbol("SIGNAL");function M(e){let t=Us;return Us=e,t}function rd(){return pn}var Yr={version:0,lastCleanEpoch:0,dirty:!1,producerNode:void 0,producerLastReadVersion:void 0,producerIndexOfThis:void 0,nextProducerIndex:0,liveConsumerNode:void 0,liveConsumerIndexOfThis:void 0,consumerAllowSignalWrites:!1,consumerIsAlwaysLive:!1,producerMustRecompute:()=>!1,producerRecomputeValue:()=>{},consumerMarkedDirty:()=>{},consumerOnSignalRead:()=>{}};function od(e){if(!(Xr(e)&&!e.dirty)&&!(!e.dirty&&e.lastCleanEpoch===Wr)){if(!e.producerMustRecompute(e)&&!mn(e)){e.dirty=!1,e.lastCleanEpoch=Wr;return}e.producerRecomputeValue(e),e.dirty=!1,e.lastCleanEpoch=Wr}}function id(e){if(e.liveConsumerNode===void 0)return;let t=pn;pn=!0;try{for(let n of e.liveConsumerNode)n.dirty||Gs(n)}finally{pn=t}}function Gs(e){e.dirty=!0,id(e),e.consumerMarkedDirty?.(e)}function Qr(e){return e&&(e.nextProducerIndex=0),M(e)}function Zr(e,t){if(M(t),!(!e||e.producerNode===void 0||e.producerIndexOfThis===void 0||e.producerLastReadVersion===void 0)){if(Xr(e))for(let n=e.nextProducerIndex;n<e.producerNode.length;n++)Jr(e.producerNode[n],e.producerIndexOfThis[n]);for(;e.producerNode.length>e.nextProducerIndex;)e.producerNode.pop(),e.producerLastReadVersion.pop(),e.producerIndexOfThis.pop()}}function mn(e){hn(e);for(let t=0;t<e.producerNode.length;t++){let n=e.producerNode[t],r=e.producerLastReadVersion[t];if(r!==n.version||(od(n),r!==n.version))return!0}return!1}function Kr(e){if(hn(e),Xr(e))for(let t=0;t<e.producerNode.length;t++)Jr(e.producerNode[t],e.producerIndexOfThis[t]);e.producerNode.length=e.producerLastReadVersion.length=e.producerIndexOfThis.length=0,e.liveConsumerNode&&(e.liveConsumerNode.length=e.liveConsumerIndexOfThis.length=0)}function Jr(e,t){if(sd(e),hn(e),e.liveConsumerNode.length===1)for(let r=0;r<e.producerNode.length;r++)Jr(e.producerNode[r],e.producerIndexOfThis[r]);let n=e.liveConsumerNode.length-1;if(e.liveConsumerNode[t]=e.liveConsumerNode[n],e.liveConsumerIndexOfThis[t]=e.liveConsumerIndexOfThis[n],e.liveConsumerNode.length--,e.liveConsumerIndexOfThis.length--,t<e.liveConsumerNode.length){let r=e.liveConsumerIndexOfThis[t],o=e.liveConsumerNode[t];hn(o),o.producerIndexOfThis[r]=t}}function Xr(e){return e.consumerIsAlwaysLive||(e?.liveConsumerNode?.length??0)>0}function hn(e){e.producerNode??=[],e.producerIndexOfThis??=[],e.producerLastReadVersion??=[]}function sd(e){e.liveConsumerNode??=[],e.liveConsumerIndexOfThis??=[]}function ad(){throw new Error}var ud=ad;function zs(e){ud=e}function Ws(e,t,n){let r=Object.create(cd);n&&(r.consumerAllowSignalWrites=!0),r.fn=e,r.schedule=t;let o=u=>{r.cleanupFn=u};function i(u){return u.fn===null&&u.schedule===null}function s(u){i(u)||(Kr(u),u.cleanupFn(),u.fn=null,u.schedule=null,u.cleanupFn=qr)}let a=()=>{if(r.fn===null)return;if(rd())throw new Error("Schedulers cannot synchronously execute watches while scheduling.");if(r.dirty=!1,r.hasRun&&!mn(r))return;r.hasRun=!0;let u=Qr(r);try{r.cleanupFn(),r.cleanupFn=qr,r.fn(o)}finally{Zr(r,u)}};return r.ref={notify:()=>Gs(r),run:a,cleanup:()=>r.cleanupFn(),destroy:()=>s(r),[gn]:r},r.ref}var qr=()=>{},cd=lt(xe({},Yr),{consumerIsAlwaysLive:!0,consumerAllowSignalWrites:!1,consumerMarkedDirty:e=>{e.schedule!==null&&e.schedule(e.ref)},hasRun:!1,cleanupFn:qr});function g(e){return typeof e=="function"}function dt(e){let n=e(r=>{Error.call(r),r.stack=new Error().stack});return n.prototype=Object.create(Error.prototype),n.prototype.constructor=n,n}var yn=dt(e=>function(n){e(this),this.message=n?`${n.length} errors occurred during unsubscription:
-${n.map((r,o)=>`${o+1}) ${r.toString()}`).join(`
-  `)}`:"",this.name="UnsubscriptionError",this.errors=n});function Ve(e,t){if(e){let n=e.indexOf(t);0<=n&&e.splice(n,1)}}var L=class e{constructor(t){this.initialTeardown=t,this.closed=!1,this._parentage=null,this._finalizers=null}unsubscribe(){let t;if(!this.closed){this.closed=!0;let{_parentage:n}=this;if(n)if(this._parentage=null,Array.isArray(n))for(let i of n)i.remove(this);else n.remove(this);let{initialTeardown:r}=this;if(g(r))try{r()}catch(i){t=i instanceof yn?i.errors:[i]}let{_finalizers:o}=this;if(o){this._finalizers=null;for(let i of o)try{qs(i)}catch(s){t=t??[],s instanceof yn?t=[...t,...s.errors]:t.push(s)}}if(t)throw new yn(t)}}add(t){var n;if(t&&t!==this)if(this.closed)qs(t);else{if(t instanceof e){if(t.closed||t._hasParent(this))return;t._addParent(this)}(this._finalizers=(n=this._finalizers)!==null&&n!==void 0?n:[]).push(t)}}_hasParent(t){let{_parentage:n}=this;return n===t||Array.isArray(n)&&n.includes(t)}_addParent(t){let{_parentage:n}=this;this._parentage=Array.isArray(n)?(n.push(t),n):n?[n,t]:t}_removeParent(t){let{_parentage:n}=this;n===t?this._parentage=null:Array.isArray(n)&&Ve(n,t)}remove(t){let{_finalizers:n}=this;n&&Ve(n,t),t instanceof e&&t._removeParent(this)}};L.EMPTY=(()=>{let e=new L;return e.closed=!0,e})();var eo=L.EMPTY;function Dn(e){return e instanceof L||e&&"closed"in e&&g(e.remove)&&g(e.add)&&g(e.unsubscribe)}function qs(e){g(e)?e():e.unsubscribe()}var te={onUnhandledError:null,onStoppedNotification:null,Promise:void 0,useDeprecatedSynchronousErrorHandling:!1,useDeprecatedNextContext:!1};var ft={setTimeout(e,t,...n){let{delegate:r}=ft;return r?.setTimeout?r.setTimeout(e,t,...n):setTimeout(e,t,...n)},clearTimeout(e){let{delegate:t}=ft;return(t?.clearTimeout||clearTimeout)(e)},delegate:void 0};function vn(e){ft.setTimeout(()=>{let{onUnhandledError:t}=te;if(t)t(e);else throw e})}function Be(){}var Ys=to("C",void 0,void 0);function Qs(e){return to("E",void 0,e)}function Zs(e){return to("N",e,void 0)}function to(e,t,n){return{kind:e,value:t,error:n}}var $e=null;function pt(e){if(te.useDeprecatedSynchronousErrorHandling){let t=!$e;if(t&&($e={errorThrown:!1,error:null}),e(),t){let{errorThrown:n,error:r}=$e;if($e=null,n)throw r}}else e()}function Ks(e){te.useDeprecatedSynchronousErrorHandling&&$e&&($e.errorThrown=!0,$e.error=e)}var He=class extends L{constructor(t){super(),this.isStopped=!1,t?(this.destination=t,Dn(t)&&t.add(this)):this.destination=fd}static create(t,n,r){return new ye(t,n,r)}next(t){this.isStopped?ro(Zs(t),this):this._next(t)}error(t){this.isStopped?ro(Qs(t),this):(this.isStopped=!0,this._error(t))}complete(){this.isStopped?ro(Ys,this):(this.isStopped=!0,this._complete())}unsubscribe(){this.closed||(this.isStopped=!0,super.unsubscribe(),this.destination=null)}_next(t){this.destination.next(t)}_error(t){try{this.destination.error(t)}finally{this.unsubscribe()}}_complete(){try{this.destination.complete()}finally{this.unsubscribe()}}},ld=Function.prototype.bind;function no(e,t){return ld.call(e,t)}var oo=class{constructor(t){this.partialObserver=t}next(t){let{partialObserver:n}=this;if(n.next)try{n.next(t)}catch(r){In(r)}}error(t){let{partialObserver:n}=this;if(n.error)try{n.error(t)}catch(r){In(r)}else In(t)}complete(){let{partialObserver:t}=this;if(t.complete)try{t.complete()}catch(n){In(n)}}},ye=class extends He{constructor(t,n,r){super();let o;if(g(t)||!t)o={next:t??void 0,error:n??void 0,complete:r??void 0};else{let i;this&&te.useDeprecatedNextContext?(i=Object.create(t),i.unsubscribe=()=>this.unsubscribe(),o={next:t.next&&no(t.next,i),error:t.error&&no(t.error,i),complete:t.complete&&no(t.complete,i)}):o=t}this.destination=new oo(o)}};function In(e){te.useDeprecatedSynchronousErrorHandling?Ks(e):vn(e)}function dd(e){throw e}function ro(e,t){let{onStoppedNotification:n}=te;n&&ft.setTimeout(()=>n(e,t))}var fd={closed:!0,next:Be,error:dd,complete:Be};var ht=typeof Symbol=="function"&&Symbol.observable||"@@observable";function B(e){return e}function pd(...e){return io(e)}function io(e){return e.length===0?B:e.length===1?e[0]:function(n){return e.reduce((r,o)=>o(r),n)}}var C=(()=>{class e{constructor(n){n&&(this._subscribe=n)}lift(n){let r=new e;return r.source=this,r.operator=n,r}subscribe(n,r,o){let i=gd(n)?n:new ye(n,r,o);return pt(()=>{let{operator:s,source:a}=this;i.add(s?s.call(i,a):a?this._subscribe(i):this._trySubscribe(i))}),i}_trySubscribe(n){try{return this._subscribe(n)}catch(r){n.error(r)}}forEach(n,r){return r=Js(r),new r((o,i)=>{let s=new ye({next:a=>{try{n(a)}catch(u){i(u),s.unsubscribe()}},error:i,complete:o});this.subscribe(s)})}_subscribe(n){var r;return(r=this.source)===null||r===void 0?void 0:r.subscribe(n)}[ht](){return this}pipe(...n){return io(n)(this)}toPromise(n){return n=Js(n),new n((r,o)=>{let i;this.subscribe(s=>i=s,s=>o(s),()=>r(i))})}}return e.create=t=>new e(t),e})();function Js(e){var t;return(t=e??te.Promise)!==null&&t!==void 0?t:Promise}function hd(e){return e&&g(e.next)&&g(e.error)&&g(e.complete)}function gd(e){return e&&e instanceof He||hd(e)&&Dn(e)}function so(e){return g(e?.lift)}function D(e){return t=>{if(so(t))return t.lift(function(n){try{return e(n,this)}catch(r){this.error(r)}});throw new TypeError("Unable to lift unknown Observable type")}}function y(e,t,n,r,o){return new ao(e,t,n,r,o)}var ao=class extends He{constructor(t,n,r,o,i,s){super(t),this.onFinalize=i,this.shouldUnsubscribe=s,this._next=n?function(a){try{n(a)}catch(u){t.error(u)}}:super._next,this._error=o?function(a){try{o(a)}catch(u){t.error(u)}finally{this.unsubscribe()}}:super._error,this._complete=r?function(){try{r()}catch(a){t.error(a)}finally{this.unsubscribe()}}:super._complete}unsubscribe(){var t;if(!this.shouldUnsubscribe||this.shouldUnsubscribe()){let{closed:n}=this;super.unsubscribe(),!n&&((t=this.onFinalize)===null||t===void 0||t.call(this))}}};function uo(){return D((e,t)=>{let n=null;e._refCount++;let r=y(t,void 0,void 0,void 0,()=>{if(!e||e._refCount<=0||0<--e._refCount){n=null;return}let o=e._connection,i=n;n=null,o&&(!i||o===i)&&o.unsubscribe(),t.unsubscribe()});e.subscribe(r),r.closed||(n=e.connect())})}var co=class extends C{constructor(t,n){super(),this.source=t,this.subjectFactory=n,this._subject=null,this._refCount=0,this._connection=null,so(t)&&(this.lift=t.lift)}_subscribe(t){return this.getSubject().subscribe(t)}getSubject(){let t=this._subject;return(!t||t.isStopped)&&(this._subject=this.subjectFactory()),this._subject}_teardown(){this._refCount=0;let{_connection:t}=this;this._subject=this._connection=null,t?.unsubscribe()}connect(){let t=this._connection;if(!t){t=this._connection=new L;let n=this.getSubject();t.add(this.source.subscribe(y(n,void 0,()=>{this._teardown(),n.complete()},r=>{this._teardown(),n.error(r)},()=>this._teardown()))),t.closed&&(this._connection=null,t=L.EMPTY)}return t}refCount(){return uo()(this)}};var Xs=dt(e=>function(){e(this),this.name="ObjectUnsubscribedError",this.message="object unsubscribed"});var ce=(()=>{class e extends C{constructor(){super(),this.closed=!1,this.currentObservers=null,this.observers=[],this.isStopped=!1,this.hasError=!1,this.thrownError=null}lift(n){let r=new wn(this,this);return r.operator=n,r}_throwIfClosed(){if(this.closed)throw new Xs}next(n){pt(()=>{if(this._throwIfClosed(),!this.isStopped){this.currentObservers||(this.currentObservers=Array.from(this.observers));for(let r of this.currentObservers)r.next(n)}})}error(n){pt(()=>{if(this._throwIfClosed(),!this.isStopped){this.hasError=this.isStopped=!0,this.thrownError=n;let{observers:r}=this;for(;r.length;)r.shift().error(n)}})}complete(){pt(()=>{if(this._throwIfClosed(),!this.isStopped){this.isStopped=!0;let{observers:n}=this;for(;n.length;)n.shift().complete()}})}unsubscribe(){this.isStopped=this.closed=!0,this.observers=this.currentObservers=null}get observed(){var n;return((n=this.observers)===null||n===void 0?void 0:n.length)>0}_trySubscribe(n){return this._throwIfClosed(),super._trySubscribe(n)}_subscribe(n){return this._throwIfClosed(),this._checkFinalizedStatuses(n),this._innerSubscribe(n)}_innerSubscribe(n){let{hasError:r,isStopped:o,observers:i}=this;return r||o?eo:(this.currentObservers=null,i.push(n),new L(()=>{this.currentObservers=null,Ve(i,n)}))}_checkFinalizedStatuses(n){let{hasError:r,thrownError:o,isStopped:i}=this;r?n.error(o):i&&n.complete()}asObservable(){let n=new C;return n.source=this,n}}return e.create=(t,n)=>new wn(t,n),e})(),wn=class extends ce{constructor(t,n){super(),this.destination=t,this.source=n}next(t){var n,r;(r=(n=this.destination)===null||n===void 0?void 0:n.next)===null||r===void 0||r.call(n,t)}error(t){var n,r;(r=(n=this.destination)===null||n===void 0?void 0:n.error)===null||r===void 0||r.call(n,t)}complete(){var t,n;(n=(t=this.destination)===null||t===void 0?void 0:t.complete)===null||n===void 0||n.call(t)}_subscribe(t){var n,r;return(r=(n=this.source)===null||n===void 0?void 0:n.subscribe(t))!==null&&r!==void 0?r:eo}};var $t=class extends ce{constructor(t){super(),this._value=t}get value(){return this.getValue()}_subscribe(t){let n=super._subscribe(t);return!n.closed&&t.next(this._value),n}getValue(){let{hasError:t,thrownError:n,_value:r}=this;if(t)throw n;return this._throwIfClosed(),r}next(t){super.next(this._value=t)}};var lo={now(){return(lo.delegate||Date).now()},delegate:void 0};var En=class extends L{constructor(t,n){super()}schedule(t,n=0){return this}};var Ht={setInterval(e,t,...n){let{delegate:r}=Ht;return r?.setInterval?r.setInterval(e,t,...n):setInterval(e,t,...n)},clearInterval(e){let{delegate:t}=Ht;return(t?.clearInterval||clearInterval)(e)},delegate:void 0};var gt=class extends En{constructor(t,n){super(t,n),this.scheduler=t,this.work=n,this.pending=!1}schedule(t,n=0){var r;if(this.closed)return this;this.state=t;let o=this.id,i=this.scheduler;return o!=null&&(this.id=this.recycleAsyncId(i,o,n)),this.pending=!0,this.delay=n,this.id=(r=this.id)!==null&&r!==void 0?r:this.requestAsyncId(i,this.id,n),this}requestAsyncId(t,n,r=0){return Ht.setInterval(t.flush.bind(t,this),r)}recycleAsyncId(t,n,r=0){if(r!=null&&this.delay===r&&this.pending===!1)return n;n!=null&&Ht.clearInterval(n)}execute(t,n){if(this.closed)return new Error("executing a cancelled action");this.pending=!1;let r=this._execute(t,n);if(r)return r;this.pending===!1&&this.id!=null&&(this.id=this.recycleAsyncId(this.scheduler,this.id,null))}_execute(t,n){let r=!1,o;try{this.work(t)}catch(i){r=!0,o=i||new Error("Scheduled action threw falsy error")}if(r)return this.unsubscribe(),o}unsubscribe(){if(!this.closed){let{id:t,scheduler:n}=this,{actions:r}=n;this.work=this.state=this.scheduler=null,this.pending=!1,Ve(r,this),t!=null&&(this.id=this.recycleAsyncId(n,t,null)),this.delay=null,super.unsubscribe()}}};var md=1,fo,po={};function ea(e){return e in po?(delete po[e],!0):!1}var ta={setImmediate(e){let t=md++;return po[t]=!0,fo||(fo=Promise.resolve()),fo.then(()=>ea(t)&&e()),t},clearImmediate(e){ea(e)}};var{setImmediate:yd,clearImmediate:Dd}=ta,Ut={setImmediate(...e){let{delegate:t}=Ut;return(t?.setImmediate||yd)(...e)},clearImmediate(e){let{delegate:t}=Ut;return(t?.clearImmediate||Dd)(e)},delegate:void 0};var Cn=class extends gt{constructor(t,n){super(t,n),this.scheduler=t,this.work=n}requestAsyncId(t,n,r=0){return r!==null&&r>0?super.requestAsyncId(t,n,r):(t.actions.push(this),t._scheduled||(t._scheduled=Ut.setImmediate(t.flush.bind(t,void 0))))}recycleAsyncId(t,n,r=0){var o;if(r!=null?r>0:this.delay>0)return super.recycleAsyncId(t,n,r);let{actions:i}=t;n!=null&&((o=i[i.length-1])===null||o===void 0?void 0:o.id)!==n&&(Ut.clearImmediate(n),t._scheduled===n&&(t._scheduled=void 0))}};var mt=class e{constructor(t,n=e.now){this.schedulerActionCtor=t,this.now=n}schedule(t,n=0,r){return new this.schedulerActionCtor(this,t).schedule(r,n)}};mt.now=lo.now;var yt=class extends mt{constructor(t,n=mt.now){super(t,n),this.actions=[],this._active=!1}flush(t){let{actions:n}=this;if(this._active){n.push(t);return}let r;this._active=!0;do if(r=t.execute(t.state,t.delay))break;while(t=n.shift());if(this._active=!1,r){for(;t=n.shift();)t.unsubscribe();throw r}}};var bn=class extends yt{flush(t){this._active=!0;let n=this._scheduled;this._scheduled=void 0;let{actions:r}=this,o;t=t||r.shift();do if(o=t.execute(t.state,t.delay))break;while((t=r[0])&&t.id===n&&r.shift());if(this._active=!1,o){for(;(t=r[0])&&t.id===n&&r.shift();)t.unsubscribe();throw o}}};var vd=new bn(Cn);var Ue=new yt(gt),na=Ue;var Ge=new C(e=>e.complete());function _n(e){return e&&g(e.schedule)}function ho(e){return e[e.length-1]}function Mn(e){return g(ho(e))?e.pop():void 0}function le(e){return _n(ho(e))?e.pop():void 0}function ra(e,t){return typeof ho(e)=="number"?e.pop():t}function ia(e,t,n,r){function o(i){return i instanceof n?i:new n(function(s){s(i)})}return new(n||(n=Promise))(function(i,s){function a(l){try{c(r.next(l))}catch(d){s(d)}}function u(l){try{c(r.throw(l))}catch(d){s(d)}}function c(l){l.done?i(l.value):o(l.value).then(a,u)}c((r=r.apply(e,t||[])).next())})}function oa(e){var t=typeof Symbol=="function"&&Symbol.iterator,n=t&&e[t],r=0;if(n)return n.call(e);if(e&&typeof e.length=="number")return{next:function(){return e&&r>=e.length&&(e=void 0),{value:e&&e[r++],done:!e}}};throw new TypeError(t?"Object is not iterable.":"Symbol.iterator is not defined.")}function ze(e){return this instanceof ze?(this.v=e,this):new ze(e)}function sa(e,t,n){if(!Symbol.asyncIterator)throw new TypeError("Symbol.asyncIterator is not defined.");var r=n.apply(e,t||[]),o,i=[];return o={},s("next"),s("throw"),s("return"),o[Symbol.asyncIterator]=function(){return this},o;function s(f){r[f]&&(o[f]=function(p){return new Promise(function(h,w){i.push([f,p,h,w])>1||a(f,p)})})}function a(f,p){try{u(r[f](p))}catch(h){d(i[0][3],h)}}function u(f){f.value instanceof ze?Promise.resolve(f.value.v).then(c,l):d(i[0][2],f)}function c(f){a("next",f)}function l(f){a("throw",f)}function d(f,p){f(p),i.shift(),i.length&&a(i[0][0],i[0][1])}}function aa(e){if(!Symbol.asyncIterator)throw new TypeError("Symbol.asyncIterator is not defined.");var t=e[Symbol.asyncIterator],n;return t?t.call(e):(e=typeof oa=="function"?oa(e):e[Symbol.iterator](),n={},r("next"),r("throw"),r("return"),n[Symbol.asyncIterator]=function(){return this},n);function r(i){n[i]=e[i]&&function(s){return new Promise(function(a,u){s=e[i](s),o(a,u,s.done,s.value)})}}function o(i,s,a,u){Promise.resolve(u).then(function(c){i({value:c,done:a})},s)}}var Dt=e=>e&&typeof e.length=="number"&&typeof e!="function";function xn(e){return g(e?.then)}function Sn(e){return g(e[ht])}function Tn(e){return Symbol.asyncIterator&&g(e?.[Symbol.asyncIterator])}function Nn(e){return new TypeError(`You provided ${e!==null&&typeof e=="object"?"an invalid object":`'${e}'`} where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.`)}function Id(){return typeof Symbol!="function"||!Symbol.iterator?"@@iterator":Symbol.iterator}var An=Id();function On(e){return g(e?.[An])}function Fn(e){return sa(this,arguments,function*(){let n=e.getReader();try{for(;;){let{value:r,done:o}=yield ze(n.read());if(o)return yield ze(void 0);yield yield ze(r)}}finally{n.releaseLock()}})}function Rn(e){return g(e?.getReader)}function x(e){if(e instanceof C)return e;if(e!=null){if(Sn(e))return wd(e);if(Dt(e))return Ed(e);if(xn(e))return Cd(e);if(Tn(e))return ua(e);if(On(e))return bd(e);if(Rn(e))return _d(e)}throw Nn(e)}function wd(e){return new C(t=>{let n=e[ht]();if(g(n.subscribe))return n.subscribe(t);throw new TypeError("Provided object does not correctly implement Symbol.observable")})}function Ed(e){return new C(t=>{for(let n=0;n<e.length&&!t.closed;n++)t.next(e[n]);t.complete()})}function Cd(e){return new C(t=>{e.then(n=>{t.closed||(t.next(n),t.complete())},n=>t.error(n)).then(null,vn)})}function bd(e){return new C(t=>{for(let n of e)if(t.next(n),t.closed)return;t.complete()})}function ua(e){return new C(t=>{Md(e,t).catch(n=>t.error(n))})}function _d(e){return ua(Fn(e))}function Md(e,t){var n,r,o,i;return ia(this,void 0,void 0,function*(){try{for(n=aa(e);r=yield n.next(),!r.done;){let s=r.value;if(t.next(s),t.closed)return}}catch(s){o={error:s}}finally{try{r&&!r.done&&(i=n.return)&&(yield i.call(n))}finally{if(o)throw o.error}}t.complete()})}function G(e,t,n,r=0,o=!1){let i=t.schedule(function(){n(),o?e.add(this.schedule(null,r)):this.unsubscribe()},r);if(e.add(i),!o)return i}function Pn(e,t=0){return D((n,r)=>{n.subscribe(y(r,o=>G(r,e,()=>r.next(o),t),()=>G(r,e,()=>r.complete(),t),o=>G(r,e,()=>r.error(o),t)))})}function kn(e,t=0){return D((n,r)=>{r.add(e.schedule(()=>n.subscribe(r),t))})}function ca(e,t){return x(e).pipe(kn(t),Pn(t))}function la(e,t){return x(e).pipe(kn(t),Pn(t))}function da(e,t){return new C(n=>{let r=0;return t.schedule(function(){r===e.length?n.complete():(n.next(e[r++]),n.closed||this.schedule())})})}function fa(e,t){return new C(n=>{let r;return G(n,t,()=>{r=e[An](),G(n,t,()=>{let o,i;try{({value:o,done:i}=r.next())}catch(s){n.error(s);return}i?n.complete():n.next(o)},0,!0)}),()=>g(r?.return)&&r.return()})}function Ln(e,t){if(!e)throw new Error("Iterable cannot be null");return new C(n=>{G(n,t,()=>{let r=e[Symbol.asyncIterator]();G(n,t,()=>{r.next().then(o=>{o.done?n.complete():n.next(o.value)})},0,!0)})})}function pa(e,t){return Ln(Fn(e),t)}function ha(e,t){if(e!=null){if(Sn(e))return ca(e,t);if(Dt(e))return da(e,t);if(xn(e))return la(e,t);if(Tn(e))return Ln(e,t);if(On(e))return fa(e,t);if(Rn(e))return pa(e,t)}throw Nn(e)}function de(e,t){return t?ha(e,t):x(e)}function xd(...e){let t=le(e);return de(e,t)}function Sd(e,t){let n=g(e)?e:()=>e,r=o=>o.error(n());return new C(t?o=>t.schedule(r,0,o):r)}function Td(e){return!!e&&(e instanceof C||g(e.lift)&&g(e.subscribe))}var We=dt(e=>function(){e(this),this.name="EmptyError",this.message="no elements in sequence"});function ga(e){return e instanceof Date&&!isNaN(e)}function De(e,t){return D((n,r)=>{let o=0;n.subscribe(y(r,i=>{r.next(e.call(t,i,o++))}))})}var{isArray:Nd}=Array;function Ad(e,t){return Nd(t)?e(...t):e(t)}function vt(e){return De(t=>Ad(e,t))}var{isArray:Od}=Array,{getPrototypeOf:Fd,prototype:Rd,keys:Pd}=Object;function jn(e){if(e.length===1){let t=e[0];if(Od(t))return{args:t,keys:null};if(kd(t)){let n=Pd(t);return{args:n.map(r=>t[r]),keys:n}}}return{args:e,keys:null}}function kd(e){return e&&typeof e=="object"&&Fd(e)===Rd}function Vn(e,t){return e.reduce((n,r,o)=>(n[r]=t[o],n),{})}function Ld(...e){let t=le(e),n=Mn(e),{args:r,keys:o}=jn(e);if(r.length===0)return de([],t);let i=new C(jd(r,t,o?s=>Vn(o,s):B));return n?i.pipe(vt(n)):i}function jd(e,t,n=B){return r=>{ma(t,()=>{let{length:o}=e,i=new Array(o),s=o,a=o;for(let u=0;u<o;u++)ma(t,()=>{let c=de(e[u],t),l=!1;c.subscribe(y(r,d=>{i[u]=d,l||(l=!0,a--),a||r.next(n(i.slice()))},()=>{--s||r.complete()}))},r)},r)}}function ma(e,t,n){e?G(n,e,t):t()}function ya(e,t,n,r,o,i,s,a){let u=[],c=0,l=0,d=!1,f=()=>{d&&!u.length&&!c&&t.complete()},p=w=>c<r?h(w):u.push(w),h=w=>{i&&t.next(w),c++;let k=!1;x(n(w,l++)).subscribe(y(t,N=>{o?.(N),i?p(N):t.next(N)},()=>{k=!0},void 0,()=>{if(k)try{for(c--;u.length&&c<r;){let N=u.shift();s?G(t,s,()=>h(N)):h(N)}f()}catch(N){t.error(N)}}))};return e.subscribe(y(t,p,()=>{d=!0,f()})),()=>{a?.()}}function ne(e,t,n=1/0){return g(t)?ne((r,o)=>De((i,s)=>t(r,i,o,s))(x(e(r,o))),n):(typeof t=="number"&&(n=t),D((r,o)=>ya(r,o,e,n)))}function Gt(e=1/0){return ne(B,e)}function Da(){return Gt(1)}function It(...e){return Da()(de(e,le(e)))}function Vd(e){return new C(t=>{x(e()).subscribe(t)})}function Bd(...e){let t=Mn(e),{args:n,keys:r}=jn(e),o=new C(i=>{let{length:s}=n;if(!s){i.complete();return}let a=new Array(s),u=s,c=s;for(let l=0;l<s;l++){let d=!1;x(n[l]).subscribe(y(i,f=>{d||(d=!0,c--),a[l]=f},()=>u--,void 0,()=>{(!u||!d)&&(c||i.next(r?Vn(r,a):a),i.complete())}))}});return t?o.pipe(vt(t)):o}var $d=["addListener","removeListener"],Hd=["addEventListener","removeEventListener"],Ud=["on","off"];function go(e,t,n,r){if(g(n)&&(r=n,n=void 0),r)return go(e,t,n).pipe(vt(r));let[o,i]=Wd(e)?Hd.map(s=>a=>e[s](t,a,n)):Gd(e)?$d.map(va(e,t)):zd(e)?Ud.map(va(e,t)):[];if(!o&&Dt(e))return ne(s=>go(s,t,n))(x(e));if(!o)throw new TypeError("Invalid event target");return new C(s=>{let a=(...u)=>s.next(1<u.length?u:u[0]);return o(a),()=>i(a)})}function va(e,t){return n=>r=>e[n](t,r)}function Gd(e){return g(e.addListener)&&g(e.removeListener)}function zd(e){return g(e.on)&&g(e.off)}function Wd(e){return g(e.addEventListener)&&g(e.removeEventListener)}function Bn(e=0,t,n=na){let r=-1;return t!=null&&(_n(t)?n=t:r=t),new C(o=>{let i=ga(e)?+e-n.now():e;i<0&&(i=0);let s=0;return n.schedule(function(){o.closed||(o.next(s++),0<=r?this.schedule(void 0,r):o.complete())},i)})}function qd(...e){let t=le(e),n=ra(e,1/0),r=e;return r.length?r.length===1?x(r[0]):Gt(n)(de(r,t)):Ge}function qe(e,t){return D((n,r)=>{let o=0;n.subscribe(y(r,i=>e.call(t,i,o++)&&r.next(i)))})}function Ia(e){return D((t,n)=>{let r=!1,o=null,i=null,s=!1,a=()=>{if(i?.unsubscribe(),i=null,r){r=!1;let c=o;o=null,n.next(c)}s&&n.complete()},u=()=>{i=null,s&&n.complete()};t.subscribe(y(n,c=>{r=!0,o=c,i||x(e(c)).subscribe(i=y(n,a,u))},()=>{s=!0,(!r||!i||i.closed)&&n.complete()}))})}function Yd(e,t=Ue){return Ia(()=>Bn(e,t))}function wa(e){return D((t,n)=>{let r=null,o=!1,i;r=t.subscribe(y(n,void 0,void 0,s=>{i=x(e(s,wa(e)(t))),r?(r.unsubscribe(),r=null,i.subscribe(n)):o=!0})),o&&(r.unsubscribe(),r=null,i.subscribe(n))})}function Ea(e,t,n,r,o){return(i,s)=>{let a=n,u=t,c=0;i.subscribe(y(s,l=>{let d=c++;u=a?e(u,l,d):(a=!0,l),r&&s.next(u)},o&&(()=>{a&&s.next(u),s.complete()})))}}function Qd(e,t){return g(t)?ne(e,t,1):ne(e,1)}function Zd(e,t=Ue){return D((n,r)=>{let o=null,i=null,s=null,a=()=>{if(o){o.unsubscribe(),o=null;let c=i;i=null,r.next(c)}};function u(){let c=s+e,l=t.now();if(l<c){o=this.schedule(void 0,c-l),r.add(o);return}a()}n.subscribe(y(r,c=>{i=c,s=t.now(),o||(o=t.schedule(u,e),r.add(o))},()=>{a(),r.complete()},void 0,()=>{i=o=null}))})}function zt(e){return D((t,n)=>{let r=!1;t.subscribe(y(n,o=>{r=!0,n.next(o)},()=>{r||n.next(e),n.complete()}))})}function wt(e){return e<=0?()=>Ge:D((t,n)=>{let r=0;t.subscribe(y(n,o=>{++r<=e&&(n.next(o),e<=r&&n.complete())}))})}function Ca(){return D((e,t)=>{e.subscribe(y(t,Be))})}function mo(e){return De(()=>e)}function yo(e,t){return t?n=>It(t.pipe(wt(1),Ca()),n.pipe(yo(e))):ne((n,r)=>x(e(n,r)).pipe(wt(1),mo(n)))}function Kd(e,t=Ue){let n=Bn(e,t);return yo(()=>n)}function Jd(e,t=B){return e=e??Xd,D((n,r)=>{let o,i=!0;n.subscribe(y(r,s=>{let a=t(s);(i||!e(o,a))&&(i=!1,o=a,r.next(s))}))})}function Xd(e,t){return e===t}function $n(e=ef){return D((t,n)=>{let r=!1;t.subscribe(y(n,o=>{r=!0,n.next(o)},()=>r?n.complete():n.error(e())))})}function ef(){return new We}function tf(e){return D((t,n)=>{try{t.subscribe(n)}finally{n.add(e)}})}function ba(e,t){let n=arguments.length>=2;return r=>r.pipe(e?qe((o,i)=>e(o,i,r)):B,wt(1),n?zt(t):$n(()=>new We))}function Do(e){return e<=0?()=>Ge:D((t,n)=>{let r=[];t.subscribe(y(n,o=>{r.push(o),e<r.length&&r.shift()},()=>{for(let o of r)n.next(o);n.complete()},void 0,()=>{r=null}))})}function nf(e,t){let n=arguments.length>=2;return r=>r.pipe(e?qe((o,i)=>e(o,i,r)):B,Do(1),n?zt(t):$n(()=>new We))}function rf(e,t){return D(Ea(e,t,arguments.length>=2,!0))}function of(e={}){let{connector:t=()=>new ce,resetOnError:n=!0,resetOnComplete:r=!0,resetOnRefCountZero:o=!0}=e;return i=>{let s,a,u,c=0,l=!1,d=!1,f=()=>{a?.unsubscribe(),a=void 0},p=()=>{f(),s=u=void 0,l=d=!1},h=()=>{let w=s;p(),w?.unsubscribe()};return D((w,k)=>{c++,!d&&!l&&f();let N=u=u??t();k.add(()=>{c--,c===0&&!d&&!l&&(a=vo(h,o))}),N.subscribe(k),!s&&c>0&&(s=new ye({next:Z=>N.next(Z),error:Z=>{d=!0,f(),a=vo(p,n,Z),N.error(Z)},complete:()=>{l=!0,f(),a=vo(p,r),N.complete()}}),x(w).subscribe(s))})(i)}}function vo(e,t,...n){if(t===!0){e();return}if(t===!1)return;let r=new ye({next:()=>{r.unsubscribe(),e()}});return x(t(...n)).subscribe(r)}function sf(e){return qe((t,n)=>e<=n)}function af(...e){let t=le(e);return D((n,r)=>{(t?It(e,n,t):It(e,n)).subscribe(r)})}function uf(e,t){return D((n,r)=>{let o=null,i=0,s=!1,a=()=>s&&!o&&r.complete();n.subscribe(y(r,u=>{o?.unsubscribe();let c=0,l=i++;x(e(u,l)).subscribe(o=y(r,d=>r.next(t?t(u,d,l,c++):d),()=>{o=null,a()}))},()=>{s=!0,a()}))})}function cf(e){return D((t,n)=>{x(e).subscribe(y(n,()=>n.complete(),Be)),!n.closed&&t.subscribe(n)})}function lf(e,t,n){let r=g(e)||t||n?{next:e,error:t,complete:n}:e;return r?D((o,i)=>{var s;(s=r.subscribe)===null||s===void 0||s.call(r);let a=!0;o.subscribe(y(i,u=>{var c;(c=r.next)===null||c===void 0||c.call(r,u),i.next(u)},()=>{var u;a=!1,(u=r.complete)===null||u===void 0||u.call(r),i.complete()},u=>{var c;a=!1,(c=r.error)===null||c===void 0||c.call(r,u),i.error(u)},()=>{var u,c;a&&((u=r.unsubscribe)===null||u===void 0||u.call(r)),(c=r.finalize)===null||c===void 0||c.call(r)}))}):B}var lu="https://g.co/ng/security#xss",_=class extends Error{constructor(t,n){super(du(t,n)),this.code=t}};function du(e,t){return`${`NG0${Math.abs(e)}`}${t?": "+t:""}`}function on(e){return{toString:e}.toString()}var Hn="__parameters__";function df(e){return function(...n){if(e){let r=e(...n);for(let o in r)this[o]=r[o]}}}function fu(e,t,n){return on(()=>{let r=df(t);function o(...i){if(this instanceof o)return r.apply(this,i),this;let s=new o(...i);return a.annotation=s,a;function a(u,c,l){let d=u.hasOwnProperty(Hn)?u[Hn]:Object.defineProperty(u,Hn,{value:[]})[Hn];for(;d.length<=l;)d.push(null);return(d[l]=d[l]||[]).push(s),u}}return n&&(o.prototype=Object.create(n.prototype)),o.prototype.ngMetadataName=e,o.annotationCls=o,o})}var ve=globalThis;function A(e){for(let t in e)if(e[t]===A)return t;throw Error("Could not find renamed property on target object.")}function ff(e,t){for(let n in t)t.hasOwnProperty(n)&&!e.hasOwnProperty(n)&&(e[n]=t[n])}function H(e){if(typeof e=="string")return e;if(Array.isArray(e))return"["+e.map(H).join(", ")+"]";if(e==null)return""+e;if(e.overriddenName)return`${e.overriddenName}`;if(e.name)return`${e.name}`;let t=e.toString();if(t==null)return""+t;let n=t.indexOf(`
-`);return n===-1?t:t.substring(0,n)}function Fo(e,t){return e==null||e===""?t===null?"":t:t==null||t===""?e:e+" "+t}var pf=A({__forward_ref__:A});function pu(e){return e.__forward_ref__=pu,e.toString=function(){return H(this())},e}function $(e){return hu(e)?e():e}function hu(e){return typeof e=="function"&&e.hasOwnProperty(pf)&&e.__forward_ref__===pu}function O(e){return{token:e.token,providedIn:e.providedIn||null,factory:e.factory,value:void 0}}function Bi(e){return{providers:e.providers||[],imports:e.imports||[]}}function Mr(e){return _a(e,gu)||_a(e,mu)}function R_(e){return Mr(e)!==null}function _a(e,t){return e.hasOwnProperty(t)?e[t]:null}function hf(e){let t=e&&(e[gu]||e[mu]);return t||null}function Ma(e){return e&&(e.hasOwnProperty(xa)||e.hasOwnProperty(gf))?e[xa]:null}var gu=A({\u0275prov:A}),xa=A({\u0275inj:A}),mu=A({ngInjectableDef:A}),gf=A({ngInjectorDef:A}),T=class{constructor(t,n){this._desc=t,this.ngMetadataName="InjectionToken",this.\u0275prov=void 0,typeof n=="number"?this.__NG_ELEMENT_ID__=n:n!==void 0&&(this.\u0275prov=O({token:this,providedIn:n.providedIn||"root",factory:n.factory}))}get multi(){return this}toString(){return`InjectionToken ${this._desc}`}};function yu(e){return e&&!!e.\u0275providers}var mf=A({\u0275cmp:A}),yf=A({\u0275dir:A}),Df=A({\u0275pipe:A}),vf=A({\u0275mod:A}),nr=A({\u0275fac:A}),Wt=A({__NG_ELEMENT_ID__:A}),Sa=A({__NG_ENV_ID__:A});function xr(e){return typeof e=="string"?e:e==null?"":String(e)}function If(e){return typeof e=="function"?e.name||e.toString():typeof e=="object"&&e!=null&&typeof e.type=="function"?e.type.name||e.type.toString():xr(e)}function wf(e,t){let n=t?`. Dependency path: ${t.join(" > ")} > ${e}`:"";throw new _(-200,e)}function $i(e,t){throw new _(-201,!1)}var b=function(e){return e[e.Default=0]="Default",e[e.Host=1]="Host",e[e.Self=2]="Self",e[e.SkipSelf=4]="SkipSelf",e[e.Optional=8]="Optional",e}(b||{}),Ro;function Du(){return Ro}function K(e){let t=Ro;return Ro=e,t}function vu(e,t,n){let r=Mr(e);if(r&&r.providedIn=="root")return r.value===void 0?r.value=r.factory():r.value;if(n&b.Optional)return null;if(t!==void 0)return t;$i(e,"Injector")}var Ef={},Yt=Ef,Po="__NG_DI_FLAG__",rr="ngTempTokenPath",Cf="ngTokenPath",bf=/\n/gm,_f="\u0275",Ta="__source",Mt;function Mf(){return Mt}function Se(e){let t=Mt;return Mt=e,t}function xf(e,t=b.Default){if(Mt===void 0)throw new _(-203,!1);return Mt===null?vu(e,void 0,t):Mt.get(e,t&b.Optional?null:void 0,t)}function R(e,t=b.Default){return(Du()||xf)($(e),t)}function S(e,t=b.Default){return R(e,Sr(t))}function Sr(e){return typeof e>"u"||typeof e=="number"?e:0|(e.optional&&8)|(e.host&&1)|(e.self&&2)|(e.skipSelf&&4)}function ko(e){let t=[];for(let n=0;n<e.length;n++){let r=$(e[n]);if(Array.isArray(r)){if(r.length===0)throw new _(900,!1);let o,i=b.Default;for(let s=0;s<r.length;s++){let a=r[s],u=Sf(a);typeof u=="number"?u===-1?o=a.token:i|=u:o=a}t.push(R(o,i))}else t.push(R(r))}return t}function Iu(e,t){return e[Po]=t,e.prototype[Po]=t,e}function Sf(e){return e[Po]}function Tf(e,t,n,r){let o=e[rr];throw t[Ta]&&o.unshift(t[Ta]),e.message=Nf(`
-`+e.message,o,n,r),e[Cf]=o,e[rr]=null,e}function Nf(e,t,n,r=null){e=e&&e.charAt(0)===`
-`&&e.charAt(1)==_f?e.slice(2):e;let o=H(t);if(Array.isArray(t))o=t.map(H).join(" -> ");else if(typeof t=="object"){let i=[];for(let s in t)if(t.hasOwnProperty(s)){let a=t[s];i.push(s+":"+(typeof a=="string"?JSON.stringify(a):H(a)))}o=`{${i.join(", ")}}`}return`${n}${r?"("+r+")":""}[${o}]: ${e.replace(bf,`
-  `)}`}var Af=Iu(fu("Optional"),8);var Of=Iu(fu("SkipSelf"),4);function St(e,t){let n=e.hasOwnProperty(nr);return n?e[nr]:null}function Ff(e,t,n){if(e.length!==t.length)return!1;for(let r=0;r<e.length;r++){let o=e[r],i=t[r];if(n&&(o=n(o),i=n(i)),i!==o)return!1}return!0}function Rf(e){return e.flat(Number.POSITIVE_INFINITY)}function Hi(e,t){e.forEach(n=>Array.isArray(n)?Hi(n,t):t(n))}function wu(e,t,n){t>=e.length?e.push(n):e.splice(t,0,n)}function or(e,t){return t>=e.length-1?e.pop():e.splice(t,1)[0]}function Pf(e,t){let n=[];for(let r=0;r<e;r++)n.push(t);return n}function kf(e,t,n,r){let o=e.length;if(o==t)e.push(n,r);else if(o===1)e.push(r,e[0]),e[0]=n;else{for(o--,e.push(e[o-1],e[o]);o>t;){let i=o-2;e[o]=e[i],o--}e[t]=n,e[t+1]=r}}function Ui(e,t,n){let r=sn(e,t);return r>=0?e[r|1]=n:(r=~r,kf(e,r,t,n)),r}function Io(e,t){let n=sn(e,t);if(n>=0)return e[n|1]}function sn(e,t){return Lf(e,t,1)}function Lf(e,t,n){let r=0,o=e.length>>n;for(;o!==r;){let i=r+(o-r>>1),s=e[i<<n];if(t===s)return i<<n;s>t?o=i:r=i+1}return~(o<<n)}var Tt={},z=[],ir=new T(""),Eu=new T("",-1),Cu=new T(""),sr=class{get(t,n=Yt){if(n===Yt){let r=new Error(`NullInjectorError: No provider for ${H(t)}!`);throw r.name="NullInjectorError",r}return n}},bu=function(e){return e[e.OnPush=0]="OnPush",e[e.Default=1]="Default",e}(bu||{}),Qt=function(e){return e[e.Emulated=0]="Emulated",e[e.None=2]="None",e[e.ShadowDom=3]="ShadowDom",e}(Qt||{}),Ze=function(e){return e[e.None=0]="None",e[e.SignalBased=1]="SignalBased",e[e.HasDecoratorInputTransform=2]="HasDecoratorInputTransform",e}(Ze||{});function jf(e,t,n){let r=e.length;for(;;){let o=e.indexOf(t,n);if(o===-1)return o;if(o===0||e.charCodeAt(o-1)<=32){let i=t.length;if(o+i===r||e.charCodeAt(o+i)<=32)return o}n=o+1}}function Lo(e,t,n){let r=0;for(;r<n.length;){let o=n[r];if(typeof o=="number"){if(o!==0)break;r++;let i=n[r++],s=n[r++],a=n[r++];e.setAttribute(t,s,a,i)}else{let i=o,s=n[++r];Vf(i)?e.setProperty(t,i,s):e.setAttribute(t,i,s),r++}}return r}function _u(e){return e===3||e===4||e===6}function Vf(e){return e.charCodeAt(0)===64}function Zt(e,t){if(!(t===null||t.length===0))if(e===null||e.length===0)e=t.slice();else{let n=-1;for(let r=0;r<t.length;r++){let o=t[r];typeof o=="number"?n=o:n===0||(n===-1||n===2?Na(e,n,o,null,t[++r]):Na(e,n,o,null,null))}}return e}function Na(e,t,n,r,o){let i=0,s=e.length;if(t===-1)s=-1;else for(;i<e.length;){let a=e[i++];if(typeof a=="number"){if(a===t){s=-1;break}else if(a>t){s=i-1;break}}}for(;i<e.length;){let a=e[i];if(typeof a=="number")break;if(a===n){if(r===null){o!==null&&(e[i+1]=o);return}else if(r===e[i+1]){e[i+2]=o;return}}i++,r!==null&&i++,o!==null&&i++}s!==-1&&(e.splice(s,0,t),i=s+1),e.splice(i++,0,n),r!==null&&e.splice(i++,0,r),o!==null&&e.splice(i++,0,o)}var Mu="ng-template";function Bf(e,t,n,r){let o=0;if(r){for(;o<t.length&&typeof t[o]=="string";o+=2)if(t[o]==="class"&&jf(t[o+1].toLowerCase(),n,0)!==-1)return!0}else if(Gi(e))return!1;if(o=t.indexOf(1,o),o>-1){let i;for(;++o<t.length&&typeof(i=t[o])=="string";)if(i.toLowerCase()===n)return!0}return!1}function Gi(e){return e.type===4&&e.value!==Mu}function $f(e,t,n){let r=e.type===4&&!n?Mu:e.value;return t===r}function Hf(e,t,n){let r=4,o=e.attrs,i=o!==null?zf(o):0,s=!1;for(let a=0;a<t.length;a++){let u=t[a];if(typeof u=="number"){if(!s&&!re(r)&&!re(u))return!1;if(s&&re(u))continue;s=!1,r=u|r&1;continue}if(!s)if(r&4){if(r=2|r&1,u!==""&&!$f(e,u,n)||u===""&&t.length===1){if(re(r))return!1;s=!0}}else if(r&8){if(o===null||!Bf(e,o,u,n)){if(re(r))return!1;s=!0}}else{let c=t[++a],l=Uf(u,o,Gi(e),n);if(l===-1){if(re(r))return!1;s=!0;continue}if(c!==""){let d;if(l>i?d="":d=o[l+1].toLowerCase(),r&2&&c!==d){if(re(r))return!1;s=!0}}}}return re(r)||s}function re(e){return(e&1)===0}function Uf(e,t,n,r){if(t===null)return-1;let o=0;if(r||!n){let i=!1;for(;o<t.length;){let s=t[o];if(s===e)return o;if(s===3||s===6)i=!0;else if(s===1||s===2){let a=t[++o];for(;typeof a=="string";)a=t[++o];continue}else{if(s===4)break;if(s===0){o+=4;continue}}o+=i?1:2}return-1}else return Wf(t,e)}function xu(e,t,n=!1){for(let r=0;r<t.length;r++)if(Hf(e,t[r],n))return!0;return!1}function Gf(e){let t=e.attrs;if(t!=null){let n=t.indexOf(5);if(!(n&1))return t[n+1]}return null}function zf(e){for(let t=0;t<e.length;t++){let n=e[t];if(_u(n))return t}return e.length}function Wf(e,t){let n=e.indexOf(4);if(n>-1)for(n++;n<e.length;){let r=e[n];if(typeof r=="number")return-1;if(r===t)return n;n++}return-1}function qf(e,t){e:for(let n=0;n<t.length;n++){let r=t[n];if(e.length===r.length){for(let o=0;o<e.length;o++)if(e[o]!==r[o])continue e;return!0}}return!1}function Aa(e,t){return e?":not("+t.trim()+")":t}function Yf(e){let t=e[0],n=1,r=2,o="",i=!1;for(;n<e.length;){let s=e[n];if(typeof s=="string")if(r&2){let a=e[++n];o+="["+s+(a.length>0?'="'+a+'"':"")+"]"}else r&8?o+="."+s:r&4&&(o+=" "+s);else o!==""&&!re(s)&&(t+=Aa(i,o),o=""),r=s,i=i||!re(r);n++}return o!==""&&(t+=Aa(i,o)),t}function Qf(e){return e.map(Yf).join(",")}function Zf(e){let t=[],n=[],r=1,o=2;for(;r<e.length;){let i=e[r];if(typeof i=="string")o===2?i!==""&&t.push(i,e[++r]):o===8&&n.push(i);else{if(!re(o))break;o=i}r++}return{attrs:t,classes:n}}function P_(e){return on(()=>{let t=Au(e),n=lt(xe({},t),{decls:e.decls,vars:e.vars,template:e.template,consts:e.consts||null,ngContentSelectors:e.ngContentSelectors,onPush:e.changeDetection===bu.OnPush,directiveDefs:null,pipeDefs:null,dependencies:t.standalone&&e.dependencies||null,getStandaloneInjector:null,signals:e.signals??!1,data:e.data||{},encapsulation:e.encapsulation||Qt.Emulated,styles:e.styles||z,_:null,schemas:e.schemas||null,tView:null,id:""});Ou(n);let r=e.dependencies;return n.directiveDefs=Fa(r,!1),n.pipeDefs=Fa(r,!0),n.id=ep(n),n})}function Kf(e){return Ne(e)||Su(e)}function Jf(e){return e!==null}function zi(e){return on(()=>({type:e.type,bootstrap:e.bootstrap||z,declarations:e.declarations||z,imports:e.imports||z,exports:e.exports||z,transitiveCompileScopes:null,schemas:e.schemas||null,id:e.id||null}))}function Oa(e,t){if(e==null)return Tt;let n={};for(let r in e)if(e.hasOwnProperty(r)){let o=e[r],i,s,a=Ze.None;Array.isArray(o)?(a=o[0],i=o[1],s=o[2]??i):(i=o,s=o),t?(n[i]=a!==Ze.None?[r,a]:r,t[i]=s):n[i]=r}return n}function Wi(e){return on(()=>{let t=Au(e);return Ou(t),t})}function Ne(e){return e[mf]||null}function Su(e){return e[yf]||null}function Tu(e){return e[Df]||null}function Xf(e){let t=Ne(e)||Su(e)||Tu(e);return t!==null?t.standalone:!1}function Nu(e,t){let n=e[vf]||null;if(!n&&t===!0)throw new Error(`Type ${H(e)} does not have '\u0275mod' property.`);return n}function Au(e){let t={};return{type:e.type,providersResolver:null,factory:null,hostBindings:e.hostBindings||null,hostVars:e.hostVars||0,hostAttrs:e.hostAttrs||null,contentQueries:e.contentQueries||null,declaredInputs:t,inputTransforms:null,inputConfig:e.inputs||Tt,exportAs:e.exportAs||null,standalone:e.standalone===!0,signals:e.signals===!0,selectors:e.selectors||z,viewQuery:e.viewQuery||null,features:e.features||null,setInput:null,findHostDirectiveDefs:null,hostDirectives:null,inputs:Oa(e.inputs,t),outputs:Oa(e.outputs),debugInfo:null}}function Ou(e){e.features?.forEach(t=>t(e))}function Fa(e,t){if(!e)return null;let n=t?Tu:Kf;return()=>(typeof e=="function"?e():e).map(r=>n(r)).filter(Jf)}function ep(e){let t=0,n=[e.selectors,e.ngContentSelectors,e.hostVars,e.hostAttrs,e.consts,e.vars,e.decls,e.encapsulation,e.standalone,e.signals,e.exportAs,JSON.stringify(e.inputs),JSON.stringify(e.outputs),Object.getOwnPropertyNames(e.type.prototype),!!e.contentQueries,!!e.viewQuery].join("|");for(let o of n)t=Math.imul(31,t)+o.charCodeAt(0)<<0;return t+=2147483648,"c"+t}function k_(e){return{\u0275providers:e}}function tp(...e){return{\u0275providers:Fu(!0,e),\u0275fromNgModule:!0}}function Fu(e,...t){let n=[],r=new Set,o,i=s=>{n.push(s)};return Hi(t,s=>{let a=s;jo(a,i,[],r)&&(o||=[],o.push(a))}),o!==void 0&&Ru(o,i),n}function Ru(e,t){for(let n=0;n<e.length;n++){let{ngModule:r,providers:o}=e[n];qi(o,i=>{t(i,r)})}}function jo(e,t,n,r){if(e=$(e),!e)return!1;let o=null,i=Ma(e),s=!i&&Ne(e);if(!i&&!s){let u=e.ngModule;if(i=Ma(u),i)o=u;else return!1}else{if(s&&!s.standalone)return!1;o=e}let a=r.has(o);if(s){if(a)return!1;if(r.add(o),s.dependencies){let u=typeof s.dependencies=="function"?s.dependencies():s.dependencies;for(let c of u)jo(c,t,n,r)}}else if(i){if(i.imports!=null&&!a){r.add(o);let c;try{Hi(i.imports,l=>{jo(l,t,n,r)&&(c||=[],c.push(l))})}finally{}c!==void 0&&Ru(c,t)}if(!a){let c=St(o)||(()=>new o);t({provide:o,useFactory:c,deps:z},o),t({provide:Cu,useValue:o,multi:!0},o),t({provide:ir,useValue:()=>R(o),multi:!0},o)}let u=i.providers;if(u!=null&&!a){let c=e;qi(u,l=>{t(l,c)})}}else return!1;return o!==e&&e.providers!==void 0}function qi(e,t){for(let n of e)yu(n)&&(n=n.\u0275providers),Array.isArray(n)?qi(n,t):t(n)}var np=A({provide:String,useValue:A});function Pu(e){return e!==null&&typeof e=="object"&&np in e}function rp(e){return!!(e&&e.useExisting)}function op(e){return!!(e&&e.useFactory)}function Nt(e){return typeof e=="function"}function ip(e){return!!e.useClass}var ku=new T(""),Qn={},sp={},wo;function Yi(){return wo===void 0&&(wo=new sr),wo}var Ae=class{},Kt=class extends Ae{get destroyed(){return this._destroyed}constructor(t,n,r,o){super(),this.parent=n,this.source=r,this.scopes=o,this.records=new Map,this._ngOnDestroyHooks=new Set,this._onDestroyHooks=[],this._destroyed=!1,Bo(t,s=>this.processProvider(s)),this.records.set(Eu,Et(void 0,this)),o.has("environment")&&this.records.set(Ae,Et(void 0,this));let i=this.records.get(ku);i!=null&&typeof i.value=="string"&&this.scopes.add(i.value),this.injectorDefTypes=new Set(this.get(Cu,z,b.Self))}destroy(){this.assertNotDestroyed(),this._destroyed=!0;let t=M(null);try{for(let r of this._ngOnDestroyHooks)r.ngOnDestroy();let n=this._onDestroyHooks;this._onDestroyHooks=[];for(let r of n)r()}finally{this.records.clear(),this._ngOnDestroyHooks.clear(),this.injectorDefTypes.clear(),M(t)}}onDestroy(t){return this.assertNotDestroyed(),this._onDestroyHooks.push(t),()=>this.removeOnDestroy(t)}runInContext(t){this.assertNotDestroyed();let n=Se(this),r=K(void 0),o;try{return t()}finally{Se(n),K(r)}}get(t,n=Yt,r=b.Default){if(this.assertNotDestroyed(),t.hasOwnProperty(Sa))return t[Sa](this);r=Sr(r);let o,i=Se(this),s=K(void 0);try{if(!(r&b.SkipSelf)){let u=this.records.get(t);if(u===void 0){let c=dp(t)&&Mr(t);c&&this.injectableDefInScope(c)?u=Et(Vo(t),Qn):u=null,this.records.set(t,u)}if(u!=null)return this.hydrate(t,u)}let a=r&b.Self?Yi():this.parent;return n=r&b.Optional&&n===Yt?null:n,a.get(t,n)}catch(a){if(a.name==="NullInjectorError"){if((a[rr]=a[rr]||[]).unshift(H(t)),i)throw a;return Tf(a,t,"R3InjectorError",this.source)}else throw a}finally{K(s),Se(i)}}resolveInjectorInitializers(){let t=M(null),n=Se(this),r=K(void 0),o;try{let i=this.get(ir,z,b.Self);for(let s of i)s()}finally{Se(n),K(r),M(t)}}toString(){let t=[],n=this.records;for(let r of n.keys())t.push(H(r));return`R3Injector[${t.join(", ")}]`}assertNotDestroyed(){if(this._destroyed)throw new _(205,!1)}processProvider(t){t=$(t);let n=Nt(t)?t:$(t&&t.provide),r=up(t);if(!Nt(t)&&t.multi===!0){let o=this.records.get(n);o||(o=Et(void 0,Qn,!0),o.factory=()=>ko(o.multi),this.records.set(n,o)),n=t,o.multi.push(t)}this.records.set(n,r)}hydrate(t,n){let r=M(null);try{return n.value===Qn&&(n.value=sp,n.value=n.factory()),typeof n.value=="object"&&n.value&&lp(n.value)&&this._ngOnDestroyHooks.add(n.value),n.value}finally{M(r)}}injectableDefInScope(t){if(!t.providedIn)return!1;let n=$(t.providedIn);return typeof n=="string"?n==="any"||this.scopes.has(n):this.injectorDefTypes.has(n)}removeOnDestroy(t){let n=this._onDestroyHooks.indexOf(t);n!==-1&&this._onDestroyHooks.splice(n,1)}};function Vo(e){let t=Mr(e),n=t!==null?t.factory:St(e);if(n!==null)return n;if(e instanceof T)throw new _(204,!1);if(e instanceof Function)return ap(e);throw new _(204,!1)}function ap(e){if(e.length>0)throw new _(204,!1);let n=hf(e);return n!==null?()=>n.factory(e):()=>new e}function up(e){if(Pu(e))return Et(void 0,e.useValue);{let t=Lu(e);return Et(t,Qn)}}function Lu(e,t,n){let r;if(Nt(e)){let o=$(e);return St(o)||Vo(o)}else if(Pu(e))r=()=>$(e.useValue);else if(op(e))r=()=>e.useFactory(...ko(e.deps||[]));else if(rp(e))r=()=>R($(e.useExisting));else{let o=$(e&&(e.useClass||e.provide));if(cp(e))r=()=>new o(...ko(e.deps));else return St(o)||Vo(o)}return r}function Et(e,t,n=!1){return{factory:e,value:t,multi:n?[]:void 0}}function cp(e){return!!e.deps}function lp(e){return e!==null&&typeof e=="object"&&typeof e.ngOnDestroy=="function"}function dp(e){return typeof e=="function"||typeof e=="object"&&e instanceof T}function Bo(e,t){for(let n of e)Array.isArray(n)?Bo(n,t):n&&yu(n)?Bo(n.\u0275providers,t):t(n)}function fp(e,t){e instanceof Kt&&e.assertNotDestroyed();let n,r=Se(e),o=K(void 0);try{return t()}finally{Se(r),K(o)}}function ju(){return Du()!==void 0||Mf()!=null}function Vu(e){if(!ju())throw new _(-203,!1)}function pp(e){let t=ve.ng;if(t&&t.\u0275compilerFacade)return t.\u0275compilerFacade;throw new Error("JIT compiler unavailable")}function hp(e){return typeof e=="function"}var Ee=0,v=1,m=2,j=3,se=4,Q=5,Jt=6,Xt=7,J=8,At=9,ae=10,F=11,en=12,Ra=13,kt=14,ue=15,an=16,Ct=17,Ie=18,Tr=19,Bu=20,Te=21,Zn=22,Ke=23,Y=25,$u=1;var Je=7,ar=8,Ot=9,W=10,Qi=function(e){return e[e.None=0]="None",e[e.HasTransplantedViews=2]="HasTransplantedViews",e}(Qi||{});function Ye(e){return Array.isArray(e)&&typeof e[$u]=="object"}function Ce(e){return Array.isArray(e)&&e[$u]===!0}function Zi(e){return(e.flags&4)!==0}function Nr(e){return e.componentOffset>-1}function Ar(e){return(e.flags&1)===1}function Oe(e){return!!e.template}function gp(e){return(e[m]&512)!==0}var $o=class{constructor(t,n,r){this.previousValue=t,this.currentValue=n,this.firstChange=r}isFirstChange(){return this.firstChange}};function Hu(e,t,n,r){t!==null?t.applyValueToInputSignal(t,r):e[n]=r}function Uu(){return Gu}function Gu(e){return e.type.prototype.ngOnChanges&&(e.setInput=yp),mp}Uu.ngInherit=!0;function mp(){let e=Wu(this),t=e?.current;if(t){let n=e.previous;if(n===Tt)e.previous=t;else for(let r in t)n[r]=t[r];e.current=null,this.ngOnChanges(t)}}function yp(e,t,n,r,o){let i=this.declaredInputs[r],s=Wu(e)||Dp(e,{previous:Tt,current:null}),a=s.current||(s.current={}),u=s.previous,c=u[i];a[i]=new $o(c&&c.currentValue,n,u===Tt),Hu(e,t,o,n)}var zu="__ngSimpleChanges__";function Wu(e){return e[zu]||null}function Dp(e,t){return e[zu]=t}var Pa=null;var fe=function(e,t,n){Pa?.(e,t,n)},qu="svg",vp="math",Ip=!1;function wp(){return Ip}function he(e){for(;Array.isArray(e);)e=e[Ee];return e}function Yu(e,t){return he(t[e])}function X(e,t){return he(t[e.index])}function Ki(e,t){return e.data[t]}function Ep(e,t){return e[t]}function ke(e,t){let n=t[e];return Ye(n)?n:n[Ee]}function Cp(e){return(e[m]&4)===4}function Ji(e){return(e[m]&128)===128}function bp(e){return Ce(e[j])}function Ft(e,t){return t==null?null:e[t]}function Qu(e){e[Ct]=0}function _p(e){e[m]&1024||(e[m]|=1024,Ji(e)&&tn(e))}function Mp(e,t){for(;e>0;)t=t[kt],e--;return t}function Xi(e){return!!(e[m]&9216||e[Ke]?.dirty)}function Ho(e){e[ae].changeDetectionScheduler?.notify(1),Xi(e)?tn(e):e[m]&64&&(wp()?(e[m]|=1024,tn(e)):e[ae].changeDetectionScheduler?.notify())}function tn(e){e[ae].changeDetectionScheduler?.notify();let t=nn(e);for(;t!==null&&!(t[m]&8192||(t[m]|=8192,!Ji(t)));)t=nn(t)}function Zu(e,t){if((e[m]&256)===256)throw new _(911,!1);e[Te]===null&&(e[Te]=[]),e[Te].push(t)}function xp(e,t){if(e[Te]===null)return;let n=e[Te].indexOf(t);n!==-1&&e[Te].splice(n,1)}function nn(e){let t=e[j];return Ce(t)?t[j]:t}var I={lFrame:oc(null),bindingsEnabled:!0,skipHydrationRootTNode:null};function Sp(){return I.lFrame.elementDepthCount}function Tp(){I.lFrame.elementDepthCount++}function Np(){I.lFrame.elementDepthCount--}function Ku(){return I.bindingsEnabled}function Ju(){return I.skipHydrationRootTNode!==null}function Ap(e){return I.skipHydrationRootTNode===e}function Op(){I.skipHydrationRootTNode=null}function E(){return I.lFrame.lView}function P(){return I.lFrame.tView}function L_(e){return I.lFrame.contextLView=e,e[J]}function j_(e){return I.lFrame.contextLView=null,e}function V(){let e=Xu();for(;e!==null&&e.type===64;)e=e.parent;return e}function Xu(){return I.lFrame.currentTNode}function Fp(){let e=I.lFrame,t=e.currentTNode;return e.isParent?t:t.parent}function it(e,t){let n=I.lFrame;n.currentTNode=e,n.isParent=t}function es(){return I.lFrame.isParent}function ts(){I.lFrame.isParent=!1}function Rp(){return I.lFrame.contextLView}function Pp(){let e=I.lFrame,t=e.bindingRootIndex;return t===-1&&(t=e.bindingRootIndex=e.tView.bindingStartIndex),t}function kp(e){return I.lFrame.bindingIndex=e}function un(){return I.lFrame.bindingIndex++}function ec(e){let t=I.lFrame,n=t.bindingIndex;return t.bindingIndex=t.bindingIndex+e,n}function Lp(){return I.lFrame.inI18n}function jp(e,t){let n=I.lFrame;n.bindingIndex=n.bindingRootIndex=e,Uo(t)}function Vp(){return I.lFrame.currentDirectiveIndex}function Uo(e){I.lFrame.currentDirectiveIndex=e}function Bp(e){let t=I.lFrame.currentDirectiveIndex;return t===-1?null:e[t]}function tc(){return I.lFrame.currentQueryIndex}function ns(e){I.lFrame.currentQueryIndex=e}function $p(e){let t=e[v];return t.type===2?t.declTNode:t.type===1?e[Q]:null}function nc(e,t,n){if(n&b.SkipSelf){let o=t,i=e;for(;o=o.parent,o===null&&!(n&b.Host);)if(o=$p(i),o===null||(i=i[kt],o.type&10))break;if(o===null)return!1;t=o,e=i}let r=I.lFrame=rc();return r.currentTNode=t,r.lView=e,!0}function rs(e){let t=rc(),n=e[v];I.lFrame=t,t.currentTNode=n.firstChild,t.lView=e,t.tView=n,t.contextLView=e,t.bindingIndex=n.bindingStartIndex,t.inI18n=!1}function rc(){let e=I.lFrame,t=e===null?null:e.child;return t===null?oc(e):t}function oc(e){let t={currentTNode:null,isParent:!0,lView:null,tView:null,selectedIndex:-1,contextLView:null,elementDepthCount:0,currentNamespace:null,currentDirectiveIndex:-1,bindingRootIndex:-1,bindingIndex:-1,currentQueryIndex:0,parent:e,child:null,inI18n:!1};return e!==null&&(e.child=t),t}function ic(){let e=I.lFrame;return I.lFrame=e.parent,e.currentTNode=null,e.lView=null,e}var sc=ic;function os(){let e=ic();e.isParent=!0,e.tView=null,e.selectedIndex=-1,e.contextLView=null,e.elementDepthCount=0,e.currentDirectiveIndex=-1,e.currentNamespace=null,e.bindingRootIndex=-1,e.bindingIndex=-1,e.currentQueryIndex=0}function Hp(e){return(I.lFrame.contextLView=Mp(e,I.lFrame.contextLView))[J]}function st(){return I.lFrame.selectedIndex}function Xe(e){I.lFrame.selectedIndex=e}function Or(){let e=I.lFrame;return Ki(e.tView,e.selectedIndex)}function V_(){I.lFrame.currentNamespace=qu}function Up(){return I.lFrame.currentNamespace}var ac=!0;function Fr(){return ac}function Rr(e){ac=e}function Gp(e,t,n){let{ngOnChanges:r,ngOnInit:o,ngDoCheck:i}=t.type.prototype;if(r){let s=Gu(t);(n.preOrderHooks??=[]).push(e,s),(n.preOrderCheckHooks??=[]).push(e,s)}o&&(n.preOrderHooks??=[]).push(0-e,o),i&&((n.preOrderHooks??=[]).push(e,i),(n.preOrderCheckHooks??=[]).push(e,i))}function Pr(e,t){for(let n=t.directiveStart,r=t.directiveEnd;n<r;n++){let i=e.data[n].type.prototype,{ngAfterContentInit:s,ngAfterContentChecked:a,ngAfterViewInit:u,ngAfterViewChecked:c,ngOnDestroy:l}=i;s&&(e.contentHooks??=[]).push(-n,s),a&&((e.contentHooks??=[]).push(n,a),(e.contentCheckHooks??=[]).push(n,a)),u&&(e.viewHooks??=[]).push(-n,u),c&&((e.viewHooks??=[]).push(n,c),(e.viewCheckHooks??=[]).push(n,c)),l!=null&&(e.destroyHooks??=[]).push(n,l)}}function Kn(e,t,n){uc(e,t,3,n)}function Jn(e,t,n,r){(e[m]&3)===n&&uc(e,t,n,r)}function Eo(e,t){let n=e[m];(n&3)===t&&(n&=16383,n+=1,e[m]=n)}function uc(e,t,n,r){let o=r!==void 0?e[Ct]&65535:0,i=r??-1,s=t.length-1,a=0;for(let u=o;u<s;u++)if(typeof t[u+1]=="number"){if(a=t[u],r!=null&&a>=r)break}else t[u]<0&&(e[Ct]+=65536),(a<i||i==-1)&&(zp(e,n,t,u),e[Ct]=(e[Ct]&4294901760)+u+2),u++}function ka(e,t){fe(4,e,t);let n=M(null);try{t.call(e)}finally{M(n),fe(5,e,t)}}function zp(e,t,n,r){let o=n[r]<0,i=n[r+1],s=o?-n[r]:n[r],a=e[s];o?e[m]>>14<e[Ct]>>16&&(e[m]&3)===t&&(e[m]+=16384,ka(a,i)):ka(a,i)}var xt=-1,et=class{constructor(t,n,r){this.factory=t,this.resolving=!1,this.canSeeViewProviders=n,this.injectImpl=r}};function Wp(e){return e instanceof et}function qp(e){return(e.flags&8)!==0}function Yp(e){return(e.flags&16)!==0}function cc(e){return e!==xt}function ur(e){return e&32767}function Qp(e){return e>>16}function cr(e,t){let n=Qp(e),r=t;for(;n>0;)r=r[kt],n--;return r}var Go=!0;function La(e){let t=Go;return Go=e,t}var Zp=256,lc=Zp-1,dc=5,Kp=0,pe={};function Jp(e,t,n){let r;typeof n=="string"?r=n.charCodeAt(0)||0:n.hasOwnProperty(Wt)&&(r=n[Wt]),r==null&&(r=n[Wt]=Kp++);let o=r&lc,i=1<<o;t.data[e+(o>>dc)]|=i}function lr(e,t){let n=fc(e,t);if(n!==-1)return n;let r=t[v];r.firstCreatePass&&(e.injectorIndex=t.length,Co(r.data,e),Co(t,null),Co(r.blueprint,null));let o=is(e,t),i=e.injectorIndex;if(cc(o)){let s=ur(o),a=cr(o,t),u=a[v].data;for(let c=0;c<8;c++)t[i+c]=a[s+c]|u[s+c]}return t[i+8]=o,i}function Co(e,t){e.push(0,0,0,0,0,0,0,0,t)}function fc(e,t){return e.injectorIndex===-1||e.parent&&e.parent.injectorIndex===e.injectorIndex||t[e.injectorIndex+8]===null?-1:e.injectorIndex}function is(e,t){if(e.parent&&e.parent.injectorIndex!==-1)return e.parent.injectorIndex;let n=0,r=null,o=t;for(;o!==null;){if(r=yc(o),r===null)return xt;if(n++,o=o[kt],r.injectorIndex!==-1)return r.injectorIndex|n<<16}return xt}function zo(e,t,n){Jp(e,t,n)}function Xp(e,t){if(t==="class")return e.classes;if(t==="style")return e.styles;let n=e.attrs;if(n){let r=n.length,o=0;for(;o<r;){let i=n[o];if(_u(i))break;if(i===0)o=o+2;else if(typeof i=="number")for(o++;o<r&&typeof n[o]=="string";)o++;else{if(i===t)return n[o+1];o=o+2}}}return null}function pc(e,t,n){if(n&b.Optional||e!==void 0)return e;$i(t,"NodeInjector")}function hc(e,t,n,r){if(n&b.Optional&&r===void 0&&(r=null),!(n&(b.Self|b.Host))){let o=e[At],i=K(void 0);try{return o?o.get(t,r,n&b.Optional):vu(t,r,n&b.Optional)}finally{K(i)}}return pc(r,t,n)}function gc(e,t,n,r=b.Default,o){if(e!==null){if(t[m]&2048&&!(r&b.Self)){let s=rh(e,t,n,r,pe);if(s!==pe)return s}let i=mc(e,t,n,r,pe);if(i!==pe)return i}return hc(t,n,r,o)}function mc(e,t,n,r,o){let i=th(n);if(typeof i=="function"){if(!nc(t,e,r))return r&b.Host?pc(o,n,r):hc(t,n,r,o);try{let s;if(s=i(r),s==null&&!(r&b.Optional))$i(n);else return s}finally{sc()}}else if(typeof i=="number"){let s=null,a=fc(e,t),u=xt,c=r&b.Host?t[ue][Q]:null;for((a===-1||r&b.SkipSelf)&&(u=a===-1?is(e,t):t[a+8],u===xt||!Va(r,!1)?a=-1:(s=t[v],a=ur(u),t=cr(u,t)));a!==-1;){let l=t[v];if(ja(i,a,l.data)){let d=eh(a,t,n,s,r,c);if(d!==pe)return d}u=t[a+8],u!==xt&&Va(r,t[v].data[a+8]===c)&&ja(i,a,t)?(s=l,a=ur(u),t=cr(u,t)):a=-1}}return o}function eh(e,t,n,r,o,i){let s=t[v],a=s.data[e+8],u=r==null?Nr(a)&&Go:r!=s&&(a.type&3)!==0,c=o&b.Host&&i===a,l=Xn(a,s,n,u,c);return l!==null?tt(t,s,l,a):pe}function Xn(e,t,n,r,o){let i=e.providerIndexes,s=t.data,a=i&1048575,u=e.directiveStart,c=e.directiveEnd,l=i>>20,d=r?a:a+l,f=o?a+l:c;for(let p=d;p<f;p++){let h=s[p];if(p<u&&n===h||p>=u&&h.type===n)return p}if(o){let p=s[u];if(p&&Oe(p)&&p.type===n)return u}return null}function tt(e,t,n,r){let o=e[n],i=t.data;if(Wp(o)){let s=o;s.resolving&&wf(If(i[n]));let a=La(s.canSeeViewProviders);s.resolving=!0;let u,c=s.injectImpl?K(s.injectImpl):null,l=nc(e,r,b.Default);try{o=e[n]=s.factory(void 0,i,e,r),t.firstCreatePass&&n>=r.directiveStart&&Gp(n,i[n],t)}finally{c!==null&&K(c),La(a),s.resolving=!1,sc()}}return o}function th(e){if(typeof e=="string")return e.charCodeAt(0)||0;let t=e.hasOwnProperty(Wt)?e[Wt]:void 0;return typeof t=="number"?t>=0?t&lc:nh:t}function ja(e,t,n){let r=1<<e;return!!(n[t+(e>>dc)]&r)}function Va(e,t){return!(e&b.Self)&&!(e&b.Host&&t)}var Qe=class{constructor(t,n){this._tNode=t,this._lView=n}get(t,n,r){return gc(this._tNode,this._lView,t,Sr(r),n)}};function nh(){return new Qe(V(),E())}function B_(e){return on(()=>{let t=e.prototype.constructor,n=t[nr]||Wo(t),r=Object.prototype,o=Object.getPrototypeOf(e.prototype).constructor;for(;o&&o!==r;){let i=o[nr]||Wo(o);if(i&&i!==n)return i;o=Object.getPrototypeOf(o)}return i=>new i})}function Wo(e){return hu(e)?()=>{let t=Wo($(e));return t&&t()}:St(e)}function rh(e,t,n,r,o){let i=e,s=t;for(;i!==null&&s!==null&&s[m]&2048&&!(s[m]&512);){let a=mc(i,s,n,r|b.Self,pe);if(a!==pe)return a;let u=i.parent;if(!u){let c=s[Bu];if(c){let l=c.get(n,pe,r);if(l!==pe)return l}u=yc(s),s=s[kt]}i=u}return o}function yc(e){let t=e[v],n=t.type;return n===2?t.declTNode:n===1?e[Q]:null}function oh(e){return Xp(V(),e)}function Ba(e,t=null,n=null,r){let o=Dc(e,t,n,r);return o.resolveInjectorInitializers(),o}function Dc(e,t=null,n=null,r,o=new Set){let i=[n||z,tp(e)];return r=r||(typeof e=="object"?void 0:H(e)),new Kt(i,t||Yi(),r||null,o)}var Le=(()=>{let t=class t{static create(r,o){if(Array.isArray(r))return Ba({name:""},o,r,"");{let i=r.name??"";return Ba({name:i},r.parent,r.providers,i)}}};t.THROW_IF_NOT_FOUND=Yt,t.NULL=new sr,t.\u0275prov=O({token:t,providedIn:"any",factory:()=>R(Eu)}),t.__NG_ELEMENT_ID__=-1;let e=t;return e})();var ih="ngOriginalError";function bo(e){return e[ih]}var Fe=class{constructor(){this._console=console}handleError(t){let n=this._findOriginalError(t);this._console.error("ERROR",t),n&&this._console.error("ORIGINAL ERROR",n)}_findOriginalError(t){let n=t&&bo(t);for(;n&&bo(n);)n=bo(n);return n||null}},vc=new T("",{providedIn:"root",factory:()=>S(Fe).handleError.bind(void 0)}),kr=(()=>{let t=class t{};t.__NG_ELEMENT_ID__=sh,t.__NG_ENV_ID__=r=>r;let e=t;return e})(),qo=class extends kr{constructor(t){super(),this._lView=t}onDestroy(t){return Zu(this._lView,t),()=>xp(this._lView,t)}};function sh(){return new qo(E())}function ah(){return Lt(V(),E())}function Lt(e,t){return new jt(X(e,t))}var jt=(()=>{let t=class t{constructor(r){this.nativeElement=r}};t.__NG_ELEMENT_ID__=ah;let e=t;return e})();function uh(e){return e instanceof jt?e.nativeElement:e}var Yo=class extends ce{constructor(t=!1){super(),this.destroyRef=void 0,this.__isAsync=t,ju()&&(this.destroyRef=S(kr,{optional:!0})??void 0)}emit(t){let n=M(null);try{super.next(t)}finally{M(n)}}subscribe(t,n,r){let o=t,i=n||(()=>null),s=r;if(t&&typeof t=="object"){let u=t;o=u.next?.bind(u),i=u.error?.bind(u),s=u.complete?.bind(u)}this.__isAsync&&(i=_o(i),o&&(o=_o(o)),s&&(s=_o(s)));let a=super.subscribe({next:o,error:i,complete:s});return t instanceof L&&t.add(a),a}};function _o(e){return t=>{setTimeout(e,void 0,t)}}var ie=Yo;function ch(){return this._results[Symbol.iterator]()}var Qo=class e{get changes(){return this._changes??=new ie}constructor(t=!1){this._emitDistinctChangesOnly=t,this.dirty=!0,this._onDirty=void 0,this._results=[],this._changesDetected=!1,this._changes=void 0,this.length=0,this.first=void 0,this.last=void 0;let n=e.prototype;n[Symbol.iterator]||(n[Symbol.iterator]=ch)}get(t){return this._results[t]}map(t){return this._results.map(t)}filter(t){return this._results.filter(t)}find(t){return this._results.find(t)}reduce(t,n){return this._results.reduce(t,n)}forEach(t){this._results.forEach(t)}some(t){return this._results.some(t)}toArray(){return this._results.slice()}toString(){return this._results.toString()}reset(t,n){this.dirty=!1;let r=Rf(t);(this._changesDetected=!Ff(this._results,r,n))&&(this._results=r,this.length=r.length,this.last=r[this.length-1],this.first=r[0])}notifyOnChanges(){this._changes!==void 0&&(this._changesDetected||!this._emitDistinctChangesOnly)&&this._changes.emit(this)}onDirty(t){this._onDirty=t}setDirty(){this.dirty=!0,this._onDirty?.()}destroy(){this._changes!==void 0&&(this._changes.complete(),this._changes.unsubscribe())}};function Ic(e){return(e.flags&128)===128}var wc=new Map,lh=0;function dh(){return lh++}function fh(e){wc.set(e[Tr],e)}function ph(e){wc.delete(e[Tr])}var $a="__ngContext__";function Re(e,t){Ye(t)?(e[$a]=t[Tr],fh(t)):e[$a]=t}function Ec(e){return bc(e[en])}function Cc(e){return bc(e[se])}function bc(e){for(;e!==null&&!Ce(e);)e=e[se];return e}var Zo;function $_(e){Zo=e}function hh(){if(Zo!==void 0)return Zo;if(typeof document<"u")return document;throw new _(210,!1)}var H_=new T("",{providedIn:"root",factory:()=>gh}),gh="ng",mh=new T(""),ss=new T("",{providedIn:"platform",factory:()=>"unknown"});var U_=new T(""),G_=new T("",{providedIn:"root",factory:()=>hh().body?.querySelector("[ngCspNonce]")?.getAttribute("ngCspNonce")||null});var yh="h",Dh="b";var vh=()=>null;function as(e,t,n=!1){return vh(e,t,n)}var _c=!1,Ih=new T("",{providedIn:"root",factory:()=>_c});var Un;function wh(){if(Un===void 0&&(Un=null,ve.trustedTypes))try{Un=ve.trustedTypes.createPolicy("angular",{createHTML:e=>e,createScript:e=>e,createScriptURL:e=>e})}catch{}return Un}function Lr(e){return wh()?.createHTML(e)||e}var Gn;function Eh(){if(Gn===void 0&&(Gn=null,ve.trustedTypes))try{Gn=ve.trustedTypes.createPolicy("angular#unsafe-bypass",{createHTML:e=>e,createScript:e=>e,createScriptURL:e=>e})}catch{}return Gn}function Ha(e){return Eh()?.createScriptURL(e)||e}var we=class{constructor(t){this.changingThisBreaksApplicationSecurity=t}toString(){return`SafeValue must use [property]=binding: ${this.changingThisBreaksApplicationSecurity} (see ${lu})`}},Ko=class extends we{getTypeName(){return"HTML"}},Jo=class extends we{getTypeName(){return"Style"}},Xo=class extends we{getTypeName(){return"Script"}},ei=class extends we{getTypeName(){return"URL"}},ti=class extends we{getTypeName(){return"ResourceURL"}};function cn(e){return e instanceof we?e.changingThisBreaksApplicationSecurity:e}function Mc(e,t){let n=Ch(e);if(n!=null&&n!==t){if(n==="ResourceURL"&&t==="URL")return!0;throw new Error(`Required a safe ${t}, got a ${n} (see ${lu})`)}return n===t}function Ch(e){return e instanceof we&&e.getTypeName()||null}function z_(e){return new Ko(e)}function W_(e){return new Jo(e)}function q_(e){return new Xo(e)}function Y_(e){return new ei(e)}function Q_(e){return new ti(e)}function bh(e){let t=new ri(e);return _h()?new ni(t):t}var ni=class{constructor(t){this.inertDocumentHelper=t}getInertBodyElement(t){t="<body><remove></remove>"+t;try{let n=new window.DOMParser().parseFromString(Lr(t),"text/html").body;return n===null?this.inertDocumentHelper.getInertBodyElement(t):(n.removeChild(n.firstChild),n)}catch{return null}}},ri=class{constructor(t){this.defaultDoc=t,this.inertDocument=this.defaultDoc.implementation.createHTMLDocument("sanitization-inert")}getInertBodyElement(t){let n=this.inertDocument.createElement("template");return n.innerHTML=Lr(t),n}};function _h(){try{return!!new window.DOMParser().parseFromString(Lr(""),"text/html")}catch{return!1}}var Mh=/^(?!javascript:)(?:[a-z0-9+.-]+:|[^&:\/?#]*(?:[\/?#]|$))/i;function xc(e){return e=String(e),e.match(Mh)?e:"unsafe:"+e}function be(e){let t={};for(let n of e.split(","))t[n]=!0;return t}function ln(...e){let t={};for(let n of e)for(let r in n)n.hasOwnProperty(r)&&(t[r]=!0);return t}var Sc=be("area,br,col,hr,img,wbr"),Tc=be("colgroup,dd,dt,li,p,tbody,td,tfoot,th,thead,tr"),Nc=be("rp,rt"),xh=ln(Nc,Tc),Sh=ln(Tc,be("address,article,aside,blockquote,caption,center,del,details,dialog,dir,div,dl,figure,figcaption,footer,h1,h2,h3,h4,h5,h6,header,hgroup,hr,ins,main,map,menu,nav,ol,pre,section,summary,table,ul")),Th=ln(Nc,be("a,abbr,acronym,audio,b,bdi,bdo,big,br,cite,code,del,dfn,em,font,i,img,ins,kbd,label,map,mark,picture,q,ruby,rp,rt,s,samp,small,source,span,strike,strong,sub,sup,time,track,tt,u,var,video")),Ua=ln(Sc,Sh,Th,xh),Ac=be("background,cite,href,itemtype,longdesc,poster,src,xlink:href"),Nh=be("abbr,accesskey,align,alt,autoplay,axis,bgcolor,border,cellpadding,cellspacing,class,clear,color,cols,colspan,compact,controls,coords,datetime,default,dir,download,face,headers,height,hidden,hreflang,hspace,ismap,itemscope,itemprop,kind,label,lang,language,loop,media,muted,nohref,nowrap,open,preload,rel,rev,role,rows,rowspan,rules,scope,scrolling,shape,size,sizes,span,srclang,srcset,start,summary,tabindex,target,title,translate,type,usemap,valign,value,vspace,width"),Ah=be("aria-activedescendant,aria-atomic,aria-autocomplete,aria-busy,aria-checked,aria-colcount,aria-colindex,aria-colspan,aria-controls,aria-current,aria-describedby,aria-details,aria-disabled,aria-dropeffect,aria-errormessage,aria-expanded,aria-flowto,aria-grabbed,aria-haspopup,aria-hidden,aria-invalid,aria-keyshortcuts,aria-label,aria-labelledby,aria-level,aria-live,aria-modal,aria-multiline,aria-multiselectable,aria-orientation,aria-owns,aria-placeholder,aria-posinset,aria-pressed,aria-readonly,aria-relevant,aria-required,aria-roledescription,aria-rowcount,aria-rowindex,aria-rowspan,aria-selected,aria-setsize,aria-sort,aria-valuemax,aria-valuemin,aria-valuenow,aria-valuetext"),Oh=ln(Ac,Nh,Ah),Fh=be("script,style,template"),oi=class{constructor(){this.sanitizedSomething=!1,this.buf=[]}sanitizeChildren(t){let n=t.firstChild,r=!0,o=[];for(;n;){if(n.nodeType===Node.ELEMENT_NODE?r=this.startElement(n):n.nodeType===Node.TEXT_NODE?this.chars(n.nodeValue):this.sanitizedSomething=!0,r&&n.firstChild){o.push(n),n=kh(n);continue}for(;n;){n.nodeType===Node.ELEMENT_NODE&&this.endElement(n);let i=Ph(n);if(i){n=i;break}n=o.pop()}}return this.buf.join("")}startElement(t){let n=Ga(t).toLowerCase();if(!Ua.hasOwnProperty(n))return this.sanitizedSomething=!0,!Fh.hasOwnProperty(n);this.buf.push("<"),this.buf.push(n);let r=t.attributes;for(let o=0;o<r.length;o++){let i=r.item(o),s=i.name,a=s.toLowerCase();if(!Oh.hasOwnProperty(a)){this.sanitizedSomething=!0;continue}let u=i.value;Ac[a]&&(u=xc(u)),this.buf.push(" ",s,'="',za(u),'"')}return this.buf.push(">"),!0}endElement(t){let n=Ga(t).toLowerCase();Ua.hasOwnProperty(n)&&!Sc.hasOwnProperty(n)&&(this.buf.push("</"),this.buf.push(n),this.buf.push(">"))}chars(t){this.buf.push(za(t))}};function Rh(e,t){return(e.compareDocumentPosition(t)&Node.DOCUMENT_POSITION_CONTAINED_BY)!==Node.DOCUMENT_POSITION_CONTAINED_BY}function Ph(e){let t=e.nextSibling;if(t&&e!==t.previousSibling)throw Oc(t);return t}function kh(e){let t=e.firstChild;if(t&&Rh(e,t))throw Oc(t);return t}function Ga(e){let t=e.nodeName;return typeof t=="string"?t:"FORM"}function Oc(e){return new Error(`Failed to sanitize html because the element is clobbered: ${e.outerHTML}`)}var Lh=/[\uD800-\uDBFF][\uDC00-\uDFFF]/g,jh=/([^\#-~ |!])/g;function za(e){return e.replace(/&/g,"&amp;").replace(Lh,function(t){let n=t.charCodeAt(0),r=t.charCodeAt(1);return"&#"+((n-55296)*1024+(r-56320)+65536)+";"}).replace(jh,function(t){return"&#"+t.charCodeAt(0)+";"}).replace(/</g,"&lt;").replace(/>/g,"&gt;")}var zn;function Z_(e,t){let n=null;try{zn=zn||bh(e);let r=t?String(t):"";n=zn.getInertBodyElement(r);let o=5,i=r;do{if(o===0)throw new Error("Failed to sanitize html because the input is unstable");o--,r=i,i=n.innerHTML,n=zn.getInertBodyElement(r)}while(r!==i);let a=new oi().sanitizeChildren(Wa(n)||n);return Lr(a)}finally{if(n){let r=Wa(n)||n;for(;r.firstChild;)r.removeChild(r.firstChild)}}}function Wa(e){return"content"in e&&Vh(e)?e.content:null}function Vh(e){return e.nodeType===Node.ELEMENT_NODE&&e.nodeName==="TEMPLATE"}var us=function(e){return e[e.NONE=0]="NONE",e[e.HTML=1]="HTML",e[e.STYLE=2]="STYLE",e[e.SCRIPT=3]="SCRIPT",e[e.URL=4]="URL",e[e.RESOURCE_URL=5]="RESOURCE_URL",e}(us||{});function Bh(e){let t=Fc();return t?t.sanitize(us.URL,e)||"":Mc(e,"URL")?cn(e):xc(xr(e))}function $h(e){let t=Fc();if(t)return Ha(t.sanitize(us.RESOURCE_URL,e)||"");if(Mc(e,"ResourceURL"))return Ha(cn(e));throw new _(904,!1)}function Hh(e,t){return t==="src"&&(e==="embed"||e==="frame"||e==="iframe"||e==="media"||e==="script")||t==="href"&&(e==="base"||e==="link")?$h:Bh}function K_(e,t,n){return Hh(t,n)(e)}function Fc(){let e=E();return e&&e[ae].sanitizer}var Uh=/^>|^->|<!--|-->|--!>|<!-$/g,Gh=/(<|>)/g,zh="\u200B$1\u200B";function Wh(e){return e.replace(Uh,t=>t.replace(Gh,zh))}function Rc(e){return e instanceof Function?e():e}function qh(e){return(e??S(Le)).get(ss)==="browser"}var dr=function(e){return e[e.Important=1]="Important",e[e.DashCase=2]="DashCase",e}(dr||{}),Yh;function cs(e,t){return Yh(e,t)}function bt(e,t,n,r,o){if(r!=null){let i,s=!1;Ce(r)?i=r:Ye(r)&&(s=!0,r=r[Ee]);let a=he(r);e===0&&n!==null?o==null?Vc(t,n,a):pr(t,n,a,o||null,!0):e===1&&n!==null?pr(t,n,a,o||null,!0):e===2?lg(t,a,s):e===3&&t.destroyNode(a),i!=null&&fg(t,e,i,n,o)}}function Qh(e,t){return e.createText(t)}function Zh(e,t,n){e.setValue(t,n)}function Kh(e,t){return e.createComment(Wh(t))}function Pc(e,t,n){return e.createElement(t,n)}function Jh(e,t){kc(e,t),t[Ee]=null,t[Q]=null}function Xh(e,t,n,r,o,i){r[Ee]=o,r[Q]=t,Vr(e,r,n,1,o,i)}function kc(e,t){t[ae].changeDetectionScheduler?.notify(1),Vr(e,t,t[F],2,null,null)}function eg(e){let t=e[en];if(!t)return Mo(e[v],e);for(;t;){let n=null;if(Ye(t))n=t[en];else{let r=t[W];r&&(n=r)}if(!n){for(;t&&!t[se]&&t!==e;)Ye(t)&&Mo(t[v],t),t=t[j];t===null&&(t=e),Ye(t)&&Mo(t[v],t),n=t&&t[se]}t=n}}function tg(e,t,n,r){let o=W+r,i=n.length;r>0&&(n[o-1][se]=t),r<i-W?(t[se]=n[o],wu(n,W+r,t)):(n.push(t),t[se]=null),t[j]=n;let s=t[an];s!==null&&n!==s&&ng(s,t);let a=t[Ie];a!==null&&a.insertView(e),Ho(t),t[m]|=128}function ng(e,t){let n=e[Ot],o=t[j][j][ue];t[ue]!==o&&(e[m]|=Qi.HasTransplantedViews),n===null?e[Ot]=[t]:n.push(t)}function Lc(e,t){let n=e[Ot],r=n.indexOf(t);n.splice(r,1)}function fr(e,t){if(e.length<=W)return;let n=W+t,r=e[n];if(r){let o=r[an];o!==null&&o!==e&&Lc(o,r),t>0&&(e[n-1][se]=r[se]);let i=or(e,W+t);Jh(r[v],r);let s=i[Ie];s!==null&&s.detachView(i[v]),r[j]=null,r[se]=null,r[m]&=-129}return r}function ls(e,t){if(!(t[m]&256)){let n=t[F];n.destroyNode&&Vr(e,t,n,3,null,null),eg(t)}}function Mo(e,t){if(t[m]&256)return;let n=M(null);try{t[m]&=-129,t[m]|=256,t[Ke]&&Kr(t[Ke]),og(e,t),rg(e,t),t[v].type===1&&t[F].destroy();let r=t[an];if(r!==null&&Ce(t[j])){r!==t[j]&&Lc(r,t);let o=t[Ie];o!==null&&o.detachView(e)}ph(t)}finally{M(n)}}function rg(e,t){let n=e.cleanup,r=t[Xt];if(n!==null)for(let i=0;i<n.length-1;i+=2)if(typeof n[i]=="string"){let s=n[i+3];s>=0?r[s]():r[-s].unsubscribe(),i+=2}else{let s=r[n[i+1]];n[i].call(s)}r!==null&&(t[Xt]=null);let o=t[Te];if(o!==null){t[Te]=null;for(let i=0;i<o.length;i++){let s=o[i];s()}}}function og(e,t){let n;if(e!=null&&(n=e.destroyHooks)!=null)for(let r=0;r<n.length;r+=2){let o=t[n[r]];if(!(o instanceof et)){let i=n[r+1];if(Array.isArray(i))for(let s=0;s<i.length;s+=2){let a=o[i[s]],u=i[s+1];fe(4,a,u);try{u.call(a)}finally{fe(5,a,u)}}else{fe(4,o,i);try{i.call(o)}finally{fe(5,o,i)}}}}}function jc(e,t,n){return ig(e,t.parent,n)}function ig(e,t,n){let r=t;for(;r!==null&&r.type&40;)t=r,r=t.parent;if(r===null)return n[Ee];{let{componentOffset:o}=r;if(o>-1){let{encapsulation:i}=e.data[r.directiveStart+o];if(i===Qt.None||i===Qt.Emulated)return null}return X(r,n)}}function pr(e,t,n,r,o){e.insertBefore(t,n,r,o)}function Vc(e,t,n){e.appendChild(t,n)}function qa(e,t,n,r,o){r!==null?pr(e,t,n,r,o):Vc(e,t,n)}function sg(e,t,n,r){e.removeChild(t,n,r)}function ds(e,t){return e.parentNode(t)}function ag(e,t){return e.nextSibling(t)}function Bc(e,t,n){return cg(e,t,n)}function ug(e,t,n){return e.type&40?X(e,n):null}var cg=ug,Ya;function jr(e,t,n,r){let o=jc(e,r,t),i=t[F],s=r.parent||t[Q],a=Bc(s,r,t);if(o!=null)if(Array.isArray(n))for(let u=0;u<n.length;u++)qa(i,o,n[u],a,!1);else qa(i,o,n,a,!1);Ya!==void 0&&Ya(i,r,t,n,o)}function er(e,t){if(t!==null){let n=t.type;if(n&3)return X(t,e);if(n&4)return ii(-1,e[t.index]);if(n&8){let r=t.child;if(r!==null)return er(e,r);{let o=e[t.index];return Ce(o)?ii(-1,o):he(o)}}else{if(n&32)return cs(t,e)()||he(e[t.index]);{let r=$c(e,t);if(r!==null){if(Array.isArray(r))return r[0];let o=nn(e[ue]);return er(o,r)}else return er(e,t.next)}}}return null}function $c(e,t){if(t!==null){let r=e[ue][Q],o=t.projection;return r.projection[o]}return null}function ii(e,t){let n=W+e+1;if(n<t.length){let r=t[n],o=r[v].firstChild;if(o!==null)return er(r,o)}return t[Je]}function lg(e,t,n){let r=ds(e,t);r&&sg(e,r,t,n)}function fs(e,t,n,r,o,i,s){for(;n!=null;){let a=r[n.index],u=n.type;if(s&&t===0&&(a&&Re(he(a),r),n.flags|=2),(n.flags&32)!==32)if(u&8)fs(e,t,n.child,r,o,i,!1),bt(t,e,o,a,i);else if(u&32){let c=cs(n,r),l;for(;l=c();)bt(t,e,o,l,i);bt(t,e,o,a,i)}else u&16?Hc(e,t,r,n,o,i):bt(t,e,o,a,i);n=s?n.projectionNext:n.next}}function Vr(e,t,n,r,o,i){fs(n,r,e.firstChild,t,o,i,!1)}function dg(e,t,n){let r=t[F],o=jc(e,n,t),i=n.parent||t[Q],s=Bc(i,n,t);Hc(r,0,t,n,o,s)}function Hc(e,t,n,r,o,i){let s=n[ue],u=s[Q].projection[r.projection];if(Array.isArray(u))for(let c=0;c<u.length;c++){let l=u[c];bt(t,e,o,l,i)}else{let c=u,l=s[j];Ic(r)&&(c.flags|=128),fs(e,t,c,l,o,i,!0)}}function fg(e,t,n,r,o){let i=n[Je],s=he(n);i!==s&&bt(t,e,r,i,o);for(let a=W;a<n.length;a++){let u=n[a];Vr(u[v],u,e,t,r,i)}}function pg(e,t,n,r,o){if(t)o?e.addClass(n,r):e.removeClass(n,r);else{let i=r.indexOf("-")===-1?void 0:dr.DashCase;o==null?e.removeStyle(n,r,i):(typeof o=="string"&&o.endsWith("!important")&&(o=o.slice(0,-10),i|=dr.Important),e.setStyle(n,r,o,i))}}function hg(e,t,n){e.setAttribute(t,"style",n)}function Uc(e,t,n){n===""?e.removeAttribute(t,"class"):e.setAttribute(t,"class",n)}function Gc(e,t,n){let{mergedAttrs:r,classes:o,styles:i}=n;r!==null&&Lo(e,t,r),o!==null&&Uc(e,t,o),i!==null&&hg(e,t,i)}var ge={};function J_(e=1){zc(P(),E(),st()+e,!1)}function zc(e,t,n,r){if(!r)if((t[m]&3)===3){let i=e.preOrderCheckHooks;i!==null&&Kn(t,i,n)}else{let i=e.preOrderHooks;i!==null&&Jn(t,i,0,n)}Xe(n)}function _e(e,t=b.Default){let n=E();if(n===null)return R(e,t);let r=V();return gc(r,n,$(e),t)}function X_(){let e="invalid";throw new Error(e)}function Wc(e,t,n,r,o,i){let s=M(null);try{let a=null;o&Ze.SignalBased&&(a=t[r][gn]),a!==null&&a.transformFn!==void 0&&(i=a.transformFn(i)),o&Ze.HasDecoratorInputTransform&&(i=e.inputTransforms[r].call(t,i)),e.setInput!==null?e.setInput(t,a,i,n,r):Hu(t,a,r,i)}finally{M(s)}}function gg(e,t){let n=e.hostBindingOpCodes;if(n!==null)try{for(let r=0;r<n.length;r++){let o=n[r];if(o<0)Xe(~o);else{let i=o,s=n[++r],a=n[++r];jp(s,i);let u=t[i];a(2,u)}}}finally{Xe(-1)}}function Br(e,t,n,r,o,i,s,a,u,c,l){let d=t.blueprint.slice();return d[Ee]=o,d[m]=r|4|128|8|64,(c!==null||e&&e[m]&2048)&&(d[m]|=2048),Qu(d),d[j]=d[kt]=e,d[J]=n,d[ae]=s||e&&e[ae],d[F]=a||e&&e[F],d[At]=u||e&&e[At]||null,d[Q]=i,d[Tr]=dh(),d[Jt]=l,d[Bu]=c,d[ue]=t.type==2?e[ue]:d,d}function Vt(e,t,n,r,o){let i=e.data[t];if(i===null)i=mg(e,t,n,r,o),Lp()&&(i.flags|=32);else if(i.type&64){i.type=n,i.value=r,i.attrs=o;let s=Fp();i.injectorIndex=s===null?-1:s.injectorIndex}return it(i,!0),i}function mg(e,t,n,r,o){let i=Xu(),s=es(),a=s?i:i&&i.parent,u=e.data[t]=Eg(e,a,n,t,r,o);return e.firstChild===null&&(e.firstChild=u),i!==null&&(s?i.child==null&&u.parent!==null&&(i.child=u):i.next===null&&(i.next=u,u.prev=i)),u}function qc(e,t,n,r){if(n===0)return-1;let o=t.length;for(let i=0;i<n;i++)t.push(r),e.blueprint.push(r),e.data.push(null);return o}function Yc(e,t,n,r,o){let i=st(),s=r&2;try{Xe(-1),s&&t.length>Y&&zc(e,t,Y,!1),fe(s?2:0,o),n(r,o)}finally{Xe(i),fe(s?3:1,o)}}function ps(e,t,n){if(Zi(t)){let r=M(null);try{let o=t.directiveStart,i=t.directiveEnd;for(let s=o;s<i;s++){let a=e.data[s];if(a.contentQueries){let u=n[s];a.contentQueries(1,u,s)}}}finally{M(r)}}}function hs(e,t,n){Ku()&&(Sg(e,t,n,X(n,t)),(n.flags&64)===64&&Kc(e,t,n))}function gs(e,t,n=X){let r=t.localNames;if(r!==null){let o=t.index+1;for(let i=0;i<r.length;i+=2){let s=r[i+1],a=s===-1?n(t,e):e[s];e[o++]=a}}}function Qc(e){let t=e.tView;return t===null||t.incompleteFirstPass?e.tView=ms(1,null,e.template,e.decls,e.vars,e.directiveDefs,e.pipeDefs,e.viewQuery,e.schemas,e.consts,e.id):t}function ms(e,t,n,r,o,i,s,a,u,c,l){let d=Y+r,f=d+o,p=yg(d,f),h=typeof c=="function"?c():c;return p[v]={type:e,blueprint:p,template:n,queries:null,viewQuery:a,declTNode:t,data:p.slice().fill(null,d),bindingStartIndex:d,expandoStartIndex:f,hostBindingOpCodes:null,firstCreatePass:!0,firstUpdatePass:!0,staticViewQueries:!1,staticContentQueries:!1,preOrderHooks:null,preOrderCheckHooks:null,contentHooks:null,contentCheckHooks:null,viewHooks:null,viewCheckHooks:null,destroyHooks:null,cleanup:null,contentQueries:null,components:null,directiveRegistry:typeof i=="function"?i():i,pipeRegistry:typeof s=="function"?s():s,firstChild:null,schemas:u,consts:h,incompleteFirstPass:!1,ssrId:l}}function yg(e,t){let n=[];for(let r=0;r<t;r++)n.push(r<e?null:ge);return n}function Dg(e,t,n,r){let i=r.get(Ih,_c)||n===Qt.ShadowDom,s=e.selectRootElement(t,i);return vg(s),s}function vg(e){Ig(e)}var Ig=()=>null;function wg(e,t,n,r){let o=el(t);o.push(n),e.firstCreatePass&&tl(e).push(r,o.length-1)}function Eg(e,t,n,r,o,i){let s=t?t.injectorIndex:-1,a=0;return Ju()&&(a|=128),{type:n,index:r,insertBeforeIndex:null,injectorIndex:s,directiveStart:-1,directiveEnd:-1,directiveStylingLast:-1,componentOffset:-1,propertyBindings:null,flags:a,providerIndexes:0,value:o,attrs:i,mergedAttrs:null,localNames:null,initialInputs:void 0,inputs:null,outputs:null,tView:null,next:null,prev:null,projectionNext:null,child:null,parent:t,projection:null,styles:null,stylesWithoutHost:null,residualStyles:void 0,classes:null,classesWithoutHost:null,residualClasses:void 0,classBindings:0,styleBindings:0}}function Qa(e,t,n,r,o){for(let i in t){if(!t.hasOwnProperty(i))continue;let s=t[i];if(s===void 0)continue;r??={};let a,u=Ze.None;Array.isArray(s)?(a=s[0],u=s[1]):a=s;let c=i;if(o!==null){if(!o.hasOwnProperty(i))continue;c=o[i]}e===0?Za(r,n,c,a,u):Za(r,n,c,a)}return r}function Za(e,t,n,r,o){let i;e.hasOwnProperty(n)?(i=e[n]).push(t,r):i=e[n]=[t,r],o!==void 0&&i.push(o)}function Cg(e,t,n){let r=t.directiveStart,o=t.directiveEnd,i=e.data,s=t.attrs,a=[],u=null,c=null;for(let l=r;l<o;l++){let d=i[l],f=n?n.get(d):null,p=f?f.inputs:null,h=f?f.outputs:null;u=Qa(0,d.inputs,l,u,p),c=Qa(1,d.outputs,l,c,h);let w=u!==null&&s!==null&&!Gi(t)?Vg(u,l,s):null;a.push(w)}u!==null&&(u.hasOwnProperty("class")&&(t.flags|=8),u.hasOwnProperty("style")&&(t.flags|=16)),t.initialInputs=a,t.inputs=u,t.outputs=c}function bg(e){return e==="class"?"className":e==="for"?"htmlFor":e==="formaction"?"formAction":e==="innerHtml"?"innerHTML":e==="readonly"?"readOnly":e==="tabindex"?"tabIndex":e}function ys(e,t,n,r,o,i,s,a){let u=X(t,n),c=t.inputs,l;!a&&c!=null&&(l=c[r])?(vs(e,n,l,r,o),Nr(t)&&_g(n,t.index)):t.type&3?(r=bg(r),o=s!=null?s(o,t.value||"",r):o,i.setProperty(u,r,o)):t.type&12}function _g(e,t){let n=ke(t,e);n[m]&16||(n[m]|=64)}function Ds(e,t,n,r){if(Ku()){let o=r===null?null:{"":-1},i=Ng(e,n),s,a;i===null?s=a=null:[s,a]=i,s!==null&&Zc(e,t,n,s,o,a),o&&Ag(n,r,o)}n.mergedAttrs=Zt(n.mergedAttrs,n.attrs)}function Zc(e,t,n,r,o,i){for(let c=0;c<r.length;c++)zo(lr(n,t),e,r[c].type);Fg(n,e.data.length,r.length);for(let c=0;c<r.length;c++){let l=r[c];l.providersResolver&&l.providersResolver(l)}let s=!1,a=!1,u=qc(e,t,r.length,null);for(let c=0;c<r.length;c++){let l=r[c];n.mergedAttrs=Zt(n.mergedAttrs,l.hostAttrs),Rg(e,n,t,u,l),Og(u,l,o),l.contentQueries!==null&&(n.flags|=4),(l.hostBindings!==null||l.hostAttrs!==null||l.hostVars!==0)&&(n.flags|=64);let d=l.type.prototype;!s&&(d.ngOnChanges||d.ngOnInit||d.ngDoCheck)&&((e.preOrderHooks??=[]).push(n.index),s=!0),!a&&(d.ngOnChanges||d.ngDoCheck)&&((e.preOrderCheckHooks??=[]).push(n.index),a=!0),u++}Cg(e,n,i)}function Mg(e,t,n,r,o){let i=o.hostBindings;if(i){let s=e.hostBindingOpCodes;s===null&&(s=e.hostBindingOpCodes=[]);let a=~t.index;xg(s)!=a&&s.push(a),s.push(n,r,i)}}function xg(e){let t=e.length;for(;t>0;){let n=e[--t];if(typeof n=="number"&&n<0)return n}return 0}function Sg(e,t,n,r){let o=n.directiveStart,i=n.directiveEnd;Nr(n)&&Pg(t,n,e.data[o+n.componentOffset]),e.firstCreatePass||lr(n,t),Re(r,t);let s=n.initialInputs;for(let a=o;a<i;a++){let u=e.data[a],c=tt(t,e,a,n);if(Re(c,t),s!==null&&jg(t,a-o,c,u,n,s),Oe(u)){let l=ke(n.index,t);l[J]=tt(t,e,a,n)}}}function Kc(e,t,n){let r=n.directiveStart,o=n.directiveEnd,i=n.index,s=Vp();try{Xe(i);for(let a=r;a<o;a++){let u=e.data[a],c=t[a];Uo(a),(u.hostBindings!==null||u.hostVars!==0||u.hostAttrs!==null)&&Tg(u,c)}}finally{Xe(-1),Uo(s)}}function Tg(e,t){e.hostBindings!==null&&e.hostBindings(1,t)}function Ng(e,t){let n=e.directiveRegistry,r=null,o=null;if(n)for(let i=0;i<n.length;i++){let s=n[i];if(xu(t,s.selectors,!1))if(r||(r=[]),Oe(s))if(s.findHostDirectiveDefs!==null){let a=[];o=o||new Map,s.findHostDirectiveDefs(s,a,o),r.unshift(...a,s);let u=a.length;si(e,t,u)}else r.unshift(s),si(e,t,0);else o=o||new Map,s.findHostDirectiveDefs?.(s,r,o),r.push(s)}return r===null?null:[r,o]}function si(e,t,n){t.componentOffset=n,(e.components??=[]).push(t.index)}function Ag(e,t,n){if(t){let r=e.localNames=[];for(let o=0;o<t.length;o+=2){let i=n[t[o+1]];if(i==null)throw new _(-301,!1);r.push(t[o],i)}}}function Og(e,t,n){if(n){if(t.exportAs)for(let r=0;r<t.exportAs.length;r++)n[t.exportAs[r]]=e;Oe(t)&&(n[""]=e)}}function Fg(e,t,n){e.flags|=1,e.directiveStart=t,e.directiveEnd=t+n,e.providerIndexes=t}function Rg(e,t,n,r,o){e.data[r]=o;let i=o.factory||(o.factory=St(o.type,!0)),s=new et(i,Oe(o),_e);e.blueprint[r]=s,n[r]=s,Mg(e,t,r,qc(e,n,o.hostVars,ge),o)}function Pg(e,t,n){let r=X(t,e),o=Qc(n),i=e[ae].rendererFactory,s=16;n.signals?s=4096:n.onPush&&(s=64);let a=$r(e,Br(e,o,null,s,r,t,null,i.createRenderer(r,n),null,null,null));e[t.index]=a}function kg(e,t,n,r,o,i){let s=X(e,t);Lg(t[F],s,i,e.value,n,r,o)}function Lg(e,t,n,r,o,i,s){if(i==null)e.removeAttribute(t,o,n);else{let a=s==null?xr(i):s(i,r||"",o);e.setAttribute(t,o,a,n)}}function jg(e,t,n,r,o,i){let s=i[t];if(s!==null)for(let a=0;a<s.length;){let u=s[a++],c=s[a++],l=s[a++],d=s[a++];Wc(r,n,u,c,l,d)}}function Vg(e,t,n){let r=null,o=0;for(;o<n.length;){let i=n[o];if(i===0){o+=4;continue}else if(i===5){o+=2;continue}if(typeof i=="number")break;if(e.hasOwnProperty(i)){r===null&&(r=[]);let s=e[i];for(let a=0;a<s.length;a+=3)if(s[a]===t){r.push(i,s[a+1],s[a+2],n[o+1]);break}}o+=2}return r}function Jc(e,t,n,r){return[e,!0,0,t,null,r,null,n,null,null]}function Xc(e,t){let n=e.contentQueries;if(n!==null){let r=M(null);try{for(let o=0;o<n.length;o+=2){let i=n[o],s=n[o+1];if(s!==-1){let a=e.data[s];ns(i),a.contentQueries(2,t[s],s)}}}finally{M(r)}}}function $r(e,t){return e[en]?e[Ra][se]=t:e[en]=t,e[Ra]=t,t}function ai(e,t,n){ns(0);let r=M(null);try{t(e,n)}finally{M(r)}}function el(e){return e[Xt]||(e[Xt]=[])}function tl(e){return e.cleanup||(e.cleanup=[])}function nl(e,t){let n=e[At],r=n?n.get(Fe,null):null;r&&r.handleError(t)}function vs(e,t,n,r,o){for(let i=0;i<n.length;){let s=n[i++],a=n[i++],u=n[i++],c=t[s],l=e.data[s];Wc(l,c,r,a,u,o)}}function Bg(e,t,n){let r=Yu(t,e);Zh(e[F],r,n)}function $g(e,t){let n=ke(t,e),r=n[v];Hg(r,n);let o=n[Ee];o!==null&&n[Jt]===null&&(n[Jt]=as(o,n[At])),Is(r,n,n[J])}function Hg(e,t){for(let n=t.length;n<e.blueprint.length;n++)t.push(e.blueprint[n])}function Is(e,t,n){rs(t);try{let r=e.viewQuery;r!==null&&ai(1,r,n);let o=e.template;o!==null&&Yc(e,t,o,1,n),e.firstCreatePass&&(e.firstCreatePass=!1),t[Ie]?.finishViewCreation(e),e.staticContentQueries&&Xc(e,t),e.staticViewQueries&&ai(2,e.viewQuery,n);let i=e.components;i!==null&&Ug(t,i)}catch(r){throw e.firstCreatePass&&(e.incompleteFirstPass=!0,e.firstCreatePass=!1),r}finally{t[m]&=-5,os()}}function Ug(e,t){for(let n=0;n<t.length;n++)$g(e,t[n])}function rl(e,t,n,r){let o=M(null);try{let i=t.tView,a=e[m]&4096?4096:16,u=Br(e,i,n,a,null,t,null,null,r?.injector??null,r?.embeddedViewInjector??null,r?.dehydratedView??null),c=e[t.index];u[an]=c;let l=e[Ie];return l!==null&&(u[Ie]=l.createEmbeddedView(i)),Is(i,u,n),u}finally{M(o)}}function Gg(e,t){let n=W+t;if(n<e.length)return e[n]}function ui(e,t){return!t||t.firstChild===null||Ic(e)}function ol(e,t,n,r=!0){let o=t[v];if(tg(o,t,e,n),r){let s=ii(n,e),a=t[F],u=ds(a,e[Je]);u!==null&&Xh(o,e[Q],a,t,u,s)}let i=t[Jt];i!==null&&i.firstChild!==null&&(i.firstChild=null)}function zg(e,t){let n=fr(e,t);return n!==void 0&&ls(n[v],n),n}function hr(e,t,n,r,o=!1){for(;n!==null;){let i=t[n.index];i!==null&&r.push(he(i)),Ce(i)&&Wg(i,r);let s=n.type;if(s&8)hr(e,t,n.child,r);else if(s&32){let a=cs(n,t),u;for(;u=a();)r.push(u)}else if(s&16){let a=$c(t,n);if(Array.isArray(a))r.push(...a);else{let u=nn(t[ue]);hr(u[v],u,a,r,!0)}}n=o?n.projectionNext:n.next}return r}function Wg(e,t){for(let n=W;n<e.length;n++){let r=e[n],o=r[v].firstChild;o!==null&&hr(r[v],r,o,t)}e[Je]!==e[Ee]&&t.push(e[Je])}var il=[];function qg(e){return e[Ke]??Yg(e)}function Yg(e){let t=il.pop()??Object.create(Zg);return t.lView=e,t}function Qg(e){e.lView[Ke]!==e&&(e.lView=null,il.push(e))}var Zg=lt(xe({},Yr),{consumerIsAlwaysLive:!0,consumerMarkedDirty:e=>{tn(e.lView)},consumerOnSignalRead(){this.lView[Ke]=this}}),sl=100;function al(e,t=!0,n=0){let r=e[ae],o=r.rendererFactory,i=!1;i||o.begin?.();try{Kg(e,n)}catch(s){throw t&&nl(e,s),s}finally{i||(o.end?.(),r.inlineEffectRunner?.flush())}}function Kg(e,t){ci(e,t);let n=0;for(;Xi(e);){if(n===sl)throw new _(103,!1);n++,ci(e,1)}}function Jg(e,t,n,r){let o=t[m];if((o&256)===256)return;let i=!1;!i&&t[ae].inlineEffectRunner?.flush(),rs(t);let s=null,a=null;!i&&Xg(e)&&(a=qg(t),s=Qr(a));try{Qu(t),kp(e.bindingStartIndex),n!==null&&Yc(e,t,n,2,r);let u=(o&3)===3;if(!i)if(u){let d=e.preOrderCheckHooks;d!==null&&Kn(t,d,null)}else{let d=e.preOrderHooks;d!==null&&Jn(t,d,0,null),Eo(t,0)}if(em(t),ul(t,0),e.contentQueries!==null&&Xc(e,t),!i)if(u){let d=e.contentCheckHooks;d!==null&&Kn(t,d)}else{let d=e.contentHooks;d!==null&&Jn(t,d,1),Eo(t,1)}gg(e,t);let c=e.components;c!==null&&ll(t,c,0);let l=e.viewQuery;if(l!==null&&ai(2,l,r),!i)if(u){let d=e.viewCheckHooks;d!==null&&Kn(t,d)}else{let d=e.viewHooks;d!==null&&Jn(t,d,2),Eo(t,2)}if(e.firstUpdatePass===!0&&(e.firstUpdatePass=!1),t[Zn]){for(let d of t[Zn])d();t[Zn]=null}i||(t[m]&=-73)}catch(u){throw tn(t),u}finally{a!==null&&(Zr(a,s),Qg(a)),os()}}function Xg(e){return e.type!==2}function ul(e,t){for(let n=Ec(e);n!==null;n=Cc(n))for(let r=W;r<n.length;r++){let o=n[r];cl(o,t)}}function em(e){for(let t=Ec(e);t!==null;t=Cc(t)){if(!(t[m]&Qi.HasTransplantedViews))continue;let n=t[Ot];for(let r=0;r<n.length;r++){let o=n[r],i=o[j];_p(o)}}}function tm(e,t,n){let r=ke(t,e);cl(r,n)}function cl(e,t){Ji(e)&&ci(e,t)}function ci(e,t){let r=e[v],o=e[m],i=e[Ke],s=!!(t===0&&o&16);if(s||=!!(o&64&&t===0),s||=!!(o&1024),s||=!!(i?.dirty&&mn(i)),i&&(i.dirty=!1),e[m]&=-9217,s)Jg(r,e,r.template,e[J]);else if(o&8192){ul(e,1);let a=r.components;a!==null&&ll(e,a,1)}}function ll(e,t,n){for(let r=0;r<t.length;r++)tm(e,t[r],n)}function ws(e){for(e[ae].changeDetectionScheduler?.notify();e;){e[m]|=64;let t=nn(e);if(gp(e)&&!t)return e;e=t}return null}var nt=class{get rootNodes(){let t=this._lView,n=t[v];return hr(n,t,n.firstChild,[])}constructor(t,n,r=!0){this._lView=t,this._cdRefInjectingView=n,this.notifyErrorHandler=r,this._appRef=null,this._attachedToViewContainer=!1}get context(){return this._lView[J]}set context(t){this._lView[J]=t}get destroyed(){return(this._lView[m]&256)===256}destroy(){if(this._appRef)this._appRef.detachView(this);else if(this._attachedToViewContainer){let t=this._lView[j];if(Ce(t)){let n=t[ar],r=n?n.indexOf(this):-1;r>-1&&(fr(t,r),or(n,r))}this._attachedToViewContainer=!1}ls(this._lView[v],this._lView)}onDestroy(t){Zu(this._lView,t)}markForCheck(){ws(this._cdRefInjectingView||this._lView)}detach(){this._lView[m]&=-129}reattach(){Ho(this._lView),this._lView[m]|=128}detectChanges(){this._lView[m]|=1024,al(this._lView,this.notifyErrorHandler)}checkNoChanges(){}attachToViewContainerRef(){if(this._appRef)throw new _(902,!1);this._attachedToViewContainer=!0}detachFromAppRef(){this._appRef=null,kc(this._lView[v],this._lView)}attachToAppRef(t){if(this._attachedToViewContainer)throw new _(902,!1);this._appRef=t,Ho(this._lView)}},rt=(()=>{let t=class t{};t.__NG_ELEMENT_ID__=om;let e=t;return e})(),nm=rt,rm=class extends nm{constructor(t,n,r){super(),this._declarationLView=t,this._declarationTContainer=n,this.elementRef=r}get ssrId(){return this._declarationTContainer.tView?.ssrId||null}createEmbeddedView(t,n){return this.createEmbeddedViewImpl(t,n)}createEmbeddedViewImpl(t,n,r){let o=rl(this._declarationLView,this._declarationTContainer,t,{embeddedViewInjector:n,dehydratedView:r});return new nt(o)}};function om(){return Hr(V(),E())}function Hr(e,t){return e.type&4?new rm(t,e,Lt(e,t)):null}var tM=new RegExp(`^(\\d+)*(${Dh}|${yh})*(.*)`);var im=()=>null;function li(e,t){return im(e,t)}var gr=class{},di=class{},mr=class{};function sm(e){let t=Error(`No component factory found for ${H(e)}.`);return t[am]=e,t}var am="ngComponent";var fi=class{resolveComponentFactory(t){throw sm(t)}},Ur=(()=>{let t=class t{};t.NULL=new fi;let e=t;return e})(),pi=class{},dl=(()=>{let t=class t{constructor(){this.destroyNode=null}};t.__NG_ELEMENT_ID__=()=>um();let e=t;return e})();function um(){let e=E(),t=V(),n=ke(t.index,e);return(Ye(n)?n:e)[F]}var cm=(()=>{let t=class t{};t.\u0275prov=O({token:t,providedIn:"root",factory:()=>null});let e=t;return e})(),xo={};var Ka=new Set;function dn(e){Ka.has(e)||(Ka.add(e),performance?.mark?.("mark_feature_usage",{detail:{feature:e}}))}function Ja(...e){}function lm(){let e=typeof ve.requestAnimationFrame=="function",t=ve[e?"requestAnimationFrame":"setTimeout"],n=ve[e?"cancelAnimationFrame":"clearTimeout"];if(typeof Zone<"u"&&t&&n){let r=t[Zone.__symbol__("OriginalDelegate")];r&&(t=r);let o=n[Zone.__symbol__("OriginalDelegate")];o&&(n=o)}return{nativeRequestAnimationFrame:t,nativeCancelAnimationFrame:n}}var q=class e{constructor({enableLongStackTrace:t=!1,shouldCoalesceEventChangeDetection:n=!1,shouldCoalesceRunChangeDetection:r=!1}){if(this.hasPendingMacrotasks=!1,this.hasPendingMicrotasks=!1,this.isStable=!0,this.onUnstable=new ie(!1),this.onMicrotaskEmpty=new ie(!1),this.onStable=new ie(!1),this.onError=new ie(!1),typeof Zone>"u")throw new _(908,!1);Zone.assertZonePatched();let o=this;o._nesting=0,o._outer=o._inner=Zone.current,Zone.TaskTrackingZoneSpec&&(o._inner=o._inner.fork(new Zone.TaskTrackingZoneSpec)),t&&Zone.longStackTraceZoneSpec&&(o._inner=o._inner.fork(Zone.longStackTraceZoneSpec)),o.shouldCoalesceEventChangeDetection=!r&&n,o.shouldCoalesceRunChangeDetection=r,o.lastRequestAnimationFrameId=-1,o.nativeRequestAnimationFrame=lm().nativeRequestAnimationFrame,pm(o)}static isInAngularZone(){return typeof Zone<"u"&&Zone.current.get("isAngularZone")===!0}static assertInAngularZone(){if(!e.isInAngularZone())throw new _(909,!1)}static assertNotInAngularZone(){if(e.isInAngularZone())throw new _(909,!1)}run(t,n,r){return this._inner.run(t,n,r)}runTask(t,n,r,o){let i=this._inner,s=i.scheduleEventTask("NgZoneEvent: "+o,t,dm,Ja,Ja);try{return i.runTask(s,n,r)}finally{i.cancelTask(s)}}runGuarded(t,n,r){return this._inner.runGuarded(t,n,r)}runOutsideAngular(t){return this._outer.run(t)}},dm={};function Es(e){if(e._nesting==0&&!e.hasPendingMicrotasks&&!e.isStable)try{e._nesting++,e.onMicrotaskEmpty.emit(null)}finally{if(e._nesting--,!e.hasPendingMicrotasks)try{e.runOutsideAngular(()=>e.onStable.emit(null))}finally{e.isStable=!0}}}function fm(e){e.isCheckStableRunning||e.lastRequestAnimationFrameId!==-1||(e.lastRequestAnimationFrameId=e.nativeRequestAnimationFrame.call(ve,()=>{e.fakeTopEventTask||(e.fakeTopEventTask=Zone.root.scheduleEventTask("fakeTopEventTask",()=>{e.lastRequestAnimationFrameId=-1,hi(e),e.isCheckStableRunning=!0,Es(e),e.isCheckStableRunning=!1},void 0,()=>{},()=>{})),e.fakeTopEventTask.invoke()}),hi(e))}function pm(e){let t=()=>{fm(e)};e._inner=e._inner.fork({name:"angular",properties:{isAngularZone:!0},onInvokeTask:(n,r,o,i,s,a)=>{if(hm(a))return n.invokeTask(o,i,s,a);try{return Xa(e),n.invokeTask(o,i,s,a)}finally{(e.shouldCoalesceEventChangeDetection&&i.type==="eventTask"||e.shouldCoalesceRunChangeDetection)&&t(),eu(e)}},onInvoke:(n,r,o,i,s,a,u)=>{try{return Xa(e),n.invoke(o,i,s,a,u)}finally{e.shouldCoalesceRunChangeDetection&&t(),eu(e)}},onHasTask:(n,r,o,i)=>{n.hasTask(o,i),r===o&&(i.change=="microTask"?(e._hasPendingMicrotasks=i.microTask,hi(e),Es(e)):i.change=="macroTask"&&(e.hasPendingMacrotasks=i.macroTask))},onHandleError:(n,r,o,i)=>(n.handleError(o,i),e.runOutsideAngular(()=>e.onError.emit(i)),!1)})}function hi(e){e._hasPendingMicrotasks||(e.shouldCoalesceEventChangeDetection||e.shouldCoalesceRunChangeDetection)&&e.lastRequestAnimationFrameId!==-1?e.hasPendingMicrotasks=!0:e.hasPendingMicrotasks=!1}function Xa(e){e._nesting++,e.isStable&&(e.isStable=!1,e.onUnstable.emit(null))}function eu(e){e._nesting--,Es(e)}var gi=class{constructor(){this.hasPendingMicrotasks=!1,this.hasPendingMacrotasks=!1,this.isStable=!0,this.onUnstable=new ie,this.onMicrotaskEmpty=new ie,this.onStable=new ie,this.onError=new ie}run(t,n,r){return t.apply(n,r)}runGuarded(t,n,r){return t.apply(n,r)}runOutsideAngular(t){return t()}runTask(t,n,r,o){return t.apply(n,r)}};function hm(e){return!Array.isArray(e)||e.length!==1?!1:e[0].data?.__ignore_ng_zone__===!0}function gm(e="zone.js",t){return e==="noop"?new gi:e==="zone.js"?new q(t):e}var _t=function(e){return e[e.EarlyRead=0]="EarlyRead",e[e.Write=1]="Write",e[e.MixedReadWrite=2]="MixedReadWrite",e[e.Read=3]="Read",e}(_t||{}),mm={destroy(){}};function ym(e,t){!t&&Vu(ym);let n=t?.injector??S(Le);if(!qh(n))return mm;dn("NgAfterNextRender");let r=n.get(Cs),o=r.handler??=new yi,i=t?.phase??_t.MixedReadWrite,s=()=>{o.unregister(u),a()},a=n.get(kr).onDestroy(s),u=fp(n,()=>new mi(i,()=>{s(),e()}));return o.register(u),{destroy:s}}var mi=class{constructor(t,n){this.phase=t,this.callbackFn=n,this.zone=S(q),this.errorHandler=S(Fe,{optional:!0}),S(gr,{optional:!0})?.notify(1)}invoke(){try{this.zone.runOutsideAngular(this.callbackFn)}catch(t){this.errorHandler?.handleError(t)}}},yi=class{constructor(){this.executingCallbacks=!1,this.buckets={[_t.EarlyRead]:new Set,[_t.Write]:new Set,[_t.MixedReadWrite]:new Set,[_t.Read]:new Set},this.deferredCallbacks=new Set}register(t){(this.executingCallbacks?this.deferredCallbacks:this.buckets[t.phase]).add(t)}unregister(t){this.buckets[t.phase].delete(t),this.deferredCallbacks.delete(t)}execute(){this.executingCallbacks=!0;for(let t of Object.values(this.buckets))for(let n of t)n.invoke();this.executingCallbacks=!1;for(let t of this.deferredCallbacks)this.buckets[t.phase].add(t);this.deferredCallbacks.clear()}destroy(){for(let t of Object.values(this.buckets))t.clear();this.deferredCallbacks.clear()}},Cs=(()=>{let t=class t{constructor(){this.handler=null,this.internalCallbacks=[]}execute(){this.executeInternalCallbacks(),this.handler?.execute()}executeInternalCallbacks(){let r=[...this.internalCallbacks];this.internalCallbacks.length=0;for(let o of r)o()}ngOnDestroy(){this.handler?.destroy(),this.handler=null,this.internalCallbacks.length=0}};t.\u0275prov=O({token:t,providedIn:"root",factory:()=>new t});let e=t;return e})();function yr(e,t,n){let r=n?e.styles:null,o=n?e.classes:null,i=0;if(t!==null)for(let s=0;s<t.length;s++){let a=t[s];if(typeof a=="number")i=a;else if(i==1)o=Fo(o,a);else if(i==2){let u=a,c=t[++s];r=Fo(r,u+": "+c+";")}}n?e.styles=r:e.stylesWithoutHost=r,n?e.classes=o:e.classesWithoutHost=o}var Dr=class extends Ur{constructor(t){super(),this.ngModule=t}resolveComponentFactory(t){let n=Ne(t);return new Rt(n,this.ngModule)}};function tu(e){let t=[];for(let n in e){if(!e.hasOwnProperty(n))continue;let r=e[n];r!==void 0&&t.push({propName:Array.isArray(r)?r[0]:r,templateName:n})}return t}function Dm(e){let t=e.toLowerCase();return t==="svg"?qu:t==="math"?vp:null}var Di=class{constructor(t,n){this.injector=t,this.parentInjector=n}get(t,n,r){r=Sr(r);let o=this.injector.get(t,xo,r);return o!==xo||n===xo?o:this.parentInjector.get(t,n,r)}},Rt=class extends mr{get inputs(){let t=this.componentDef,n=t.inputTransforms,r=tu(t.inputs);if(n!==null)for(let o of r)n.hasOwnProperty(o.propName)&&(o.transform=n[o.propName]);return r}get outputs(){return tu(this.componentDef.outputs)}constructor(t,n){super(),this.componentDef=t,this.ngModule=n,this.componentType=t.type,this.selector=Qf(t.selectors),this.ngContentSelectors=t.ngContentSelectors?t.ngContentSelectors:[],this.isBoundToModule=!!n}create(t,n,r,o){let i=M(null);try{o=o||this.ngModule;let s=o instanceof Ae?o:o?.injector;s&&this.componentDef.getStandaloneInjector!==null&&(s=this.componentDef.getStandaloneInjector(s)||s);let a=s?new Di(t,s):t,u=a.get(pi,null);if(u===null)throw new _(407,!1);let c=a.get(cm,null),l=a.get(Cs,null),d=a.get(gr,null),f={rendererFactory:u,sanitizer:c,inlineEffectRunner:null,afterRenderEventManager:l,changeDetectionScheduler:d},p=u.createRenderer(null,this.componentDef),h=this.componentDef.selectors[0][0]||"div",w=r?Dg(p,r,this.componentDef.encapsulation,a):Pc(p,h,Dm(h)),k=512;this.componentDef.signals?k|=4096:this.componentDef.onPush||(k|=16);let N=null;w!==null&&(N=as(w,a,!0));let Z=ms(0,null,null,1,0,null,null,null,null,null,null),U=Br(null,Z,null,k,null,null,f,p,a,null,N);rs(U);let me,ut;try{let ee=this.componentDef,ct,zr=null;ee.findHostDirectiveDefs?(ct=[],zr=new Map,ee.findHostDirectiveDefs(ee,ct,zr),ct.push(ee)):ct=[ee];let Kl=vm(U,w),Jl=Im(Kl,w,ee,ct,U,f,p);ut=Ki(Z,Y),w&&Cm(p,ee,w,r),n!==void 0&&bm(ut,this.ngContentSelectors,n),me=Em(Jl,ee,ct,zr,U,[_m]),Is(Z,U,null)}finally{os()}return new vi(this.componentType,me,Lt(ut,U),U,ut)}finally{M(i)}}},vi=class extends di{constructor(t,n,r,o,i){super(),this.location=r,this._rootLView=o,this._tNode=i,this.previousInputValues=null,this.instance=n,this.hostView=this.changeDetectorRef=new nt(o,void 0,!1),this.componentType=t}setInput(t,n){let r=this._tNode.inputs,o;if(r!==null&&(o=r[t])){if(this.previousInputValues??=new Map,this.previousInputValues.has(t)&&Object.is(this.previousInputValues.get(t),n))return;let i=this._rootLView;vs(i[v],i,o,t,n),this.previousInputValues.set(t,n);let s=ke(this._tNode.index,i);ws(s)}}get injector(){return new Qe(this._tNode,this._rootLView)}destroy(){this.hostView.destroy()}onDestroy(t){this.hostView.onDestroy(t)}};function vm(e,t){let n=e[v],r=Y;return e[r]=t,Vt(n,r,2,"#host",null)}function Im(e,t,n,r,o,i,s){let a=o[v];wm(r,e,t,s);let u=null;t!==null&&(u=as(t,o[At]));let c=i.rendererFactory.createRenderer(t,n),l=16;n.signals?l=4096:n.onPush&&(l=64);let d=Br(o,Qc(n),null,l,o[e.index],e,i,c,null,null,u);return a.firstCreatePass&&si(a,e,r.length-1),$r(o,d),o[e.index]=d}function wm(e,t,n,r){for(let o of e)t.mergedAttrs=Zt(t.mergedAttrs,o.hostAttrs);t.mergedAttrs!==null&&(yr(t,t.mergedAttrs,!0),n!==null&&Gc(r,n,t))}function Em(e,t,n,r,o,i){let s=V(),a=o[v],u=X(s,o);Zc(a,o,s,n,null,r);for(let l=0;l<n.length;l++){let d=s.directiveStart+l,f=tt(o,a,d,s);Re(f,o)}Kc(a,o,s),u&&Re(u,o);let c=tt(o,a,s.directiveStart+s.componentOffset,s);if(e[J]=o[J]=c,i!==null)for(let l of i)l(c,t);return ps(a,s,o),c}function Cm(e,t,n,r){if(r)Lo(e,n,["ng-version","17.3.9"]);else{let{attrs:o,classes:i}=Zf(t.selectors[0]);o&&Lo(e,n,o),i&&i.length>0&&Uc(e,n,i.join(" "))}}function bm(e,t,n){let r=e.projection=[];for(let o=0;o<t.length;o++){let i=n[o];r.push(i!=null?Array.from(i):null)}}function _m(){let e=V();Pr(E()[v],e)}var Bt=(()=>{let t=class t{};t.__NG_ELEMENT_ID__=Mm;let e=t;return e})();function Mm(){let e=V();return pl(e,E())}var xm=Bt,fl=class extends xm{constructor(t,n,r){super(),this._lContainer=t,this._hostTNode=n,this._hostLView=r}get element(){return Lt(this._hostTNode,this._hostLView)}get injector(){return new Qe(this._hostTNode,this._hostLView)}get parentInjector(){let t=is(this._hostTNode,this._hostLView);if(cc(t)){let n=cr(t,this._hostLView),r=ur(t),o=n[v].data[r+8];return new Qe(o,n)}else return new Qe(null,this._hostLView)}clear(){for(;this.length>0;)this.remove(this.length-1)}get(t){let n=nu(this._lContainer);return n!==null&&n[t]||null}get length(){return this._lContainer.length-W}createEmbeddedView(t,n,r){let o,i;typeof r=="number"?o=r:r!=null&&(o=r.index,i=r.injector);let s=li(this._lContainer,t.ssrId),a=t.createEmbeddedViewImpl(n||{},i,s);return this.insertImpl(a,o,ui(this._hostTNode,s)),a}createComponent(t,n,r,o,i){let s=t&&!hp(t),a;if(s)a=n;else{let h=n||{};a=h.index,r=h.injector,o=h.projectableNodes,i=h.environmentInjector||h.ngModuleRef}let u=s?t:new Rt(Ne(t)),c=r||this.parentInjector;if(!i&&u.ngModule==null){let w=(s?c:this.parentInjector).get(Ae,null);w&&(i=w)}let l=Ne(u.componentType??{}),d=li(this._lContainer,l?.id??null),f=d?.firstChild??null,p=u.create(c,o,f,i);return this.insertImpl(p.hostView,a,ui(this._hostTNode,d)),p}insert(t,n){return this.insertImpl(t,n,!0)}insertImpl(t,n,r){let o=t._lView;if(bp(o)){let a=this.indexOf(t);if(a!==-1)this.detach(a);else{let u=o[j],c=new fl(u,u[Q],u[j]);c.detach(c.indexOf(t))}}let i=this._adjustIndex(n),s=this._lContainer;return ol(s,o,i,r),t.attachToViewContainerRef(),wu(So(s),i,t),t}move(t,n){return this.insert(t,n)}indexOf(t){let n=nu(this._lContainer);return n!==null?n.indexOf(t):-1}remove(t){let n=this._adjustIndex(t,-1),r=fr(this._lContainer,n);r&&(or(So(this._lContainer),n),ls(r[v],r))}detach(t){let n=this._adjustIndex(t,-1),r=fr(this._lContainer,n);return r&&or(So(this._lContainer),n)!=null?new nt(r):null}_adjustIndex(t,n=0){return t??this.length+n}};function nu(e){return e[ar]}function So(e){return e[ar]||(e[ar]=[])}function pl(e,t){let n,r=t[e.index];return Ce(r)?n=r:(n=Jc(r,t,null,e),t[e.index]=n,$r(t,n)),Tm(n,t,e,r),new fl(n,e,t)}function Sm(e,t){let n=e[F],r=n.createComment(""),o=X(t,e),i=ds(n,o);return pr(n,i,r,ag(n,o),!1),r}var Tm=Om,Nm=()=>!1;function Am(e,t,n){return Nm(e,t,n)}function Om(e,t,n,r){if(e[Je])return;let o;n.type&8?o=he(r):o=Sm(t,n),e[Je]=o}var Ii=class e{constructor(t){this.queryList=t,this.matches=null}clone(){return new e(this.queryList)}setDirty(){this.queryList.setDirty()}},wi=class e{constructor(t=[]){this.queries=t}createEmbeddedView(t){let n=t.queries;if(n!==null){let r=t.contentQueries!==null?t.contentQueries[0]:n.length,o=[];for(let i=0;i<r;i++){let s=n.getByIndex(i),a=this.queries[s.indexInDeclarationView];o.push(a.clone())}return new e(o)}return null}insertView(t){this.dirtyQueriesWithMatches(t)}detachView(t){this.dirtyQueriesWithMatches(t)}finishViewCreation(t){this.dirtyQueriesWithMatches(t)}dirtyQueriesWithMatches(t){for(let n=0;n<this.queries.length;n++)bs(t,n).matches!==null&&this.queries[n].setDirty()}},vr=class{constructor(t,n,r=null){this.flags=n,this.read=r,typeof t=="string"?this.predicate=Bm(t):this.predicate=t}},Ei=class e{constructor(t=[]){this.queries=t}elementStart(t,n){for(let r=0;r<this.queries.length;r++)this.queries[r].elementStart(t,n)}elementEnd(t){for(let n=0;n<this.queries.length;n++)this.queries[n].elementEnd(t)}embeddedTView(t){let n=null;for(let r=0;r<this.length;r++){let o=n!==null?n.length:0,i=this.getByIndex(r).embeddedTView(t,o);i&&(i.indexInDeclarationView=r,n!==null?n.push(i):n=[i])}return n!==null?new e(n):null}template(t,n){for(let r=0;r<this.queries.length;r++)this.queries[r].template(t,n)}getByIndex(t){return this.queries[t]}get length(){return this.queries.length}track(t){this.queries.push(t)}},Ci=class e{constructor(t,n=-1){this.metadata=t,this.matches=null,this.indexInDeclarationView=-1,this.crossesNgTemplate=!1,this._appliesToNextNode=!0,this._declarationNodeIndex=n}elementStart(t,n){this.isApplyingToNode(n)&&this.matchTNode(t,n)}elementEnd(t){this._declarationNodeIndex===t.index&&(this._appliesToNextNode=!1)}template(t,n){this.elementStart(t,n)}embeddedTView(t,n){return this.isApplyingToNode(t)?(this.crossesNgTemplate=!0,this.addMatch(-t.index,n),new e(this.metadata)):null}isApplyingToNode(t){if(this._appliesToNextNode&&(this.metadata.flags&1)!==1){let n=this._declarationNodeIndex,r=t.parent;for(;r!==null&&r.type&8&&r.index!==n;)r=r.parent;return n===(r!==null?r.index:-1)}return this._appliesToNextNode}matchTNode(t,n){let r=this.metadata.predicate;if(Array.isArray(r))for(let o=0;o<r.length;o++){let i=r[o];this.matchTNodeWithReadOption(t,n,Fm(n,i)),this.matchTNodeWithReadOption(t,n,Xn(n,t,i,!1,!1))}else r===rt?n.type&4&&this.matchTNodeWithReadOption(t,n,-1):this.matchTNodeWithReadOption(t,n,Xn(n,t,r,!1,!1))}matchTNodeWithReadOption(t,n,r){if(r!==null){let o=this.metadata.read;if(o!==null)if(o===jt||o===Bt||o===rt&&n.type&4)this.addMatch(n.index,-2);else{let i=Xn(n,t,o,!1,!1);i!==null&&this.addMatch(n.index,i)}else this.addMatch(n.index,r)}}addMatch(t,n){this.matches===null?this.matches=[t,n]:this.matches.push(t,n)}};function Fm(e,t){let n=e.localNames;if(n!==null){for(let r=0;r<n.length;r+=2)if(n[r]===t)return n[r+1]}return null}function Rm(e,t){return e.type&11?Lt(e,t):e.type&4?Hr(e,t):null}function Pm(e,t,n,r){return n===-1?Rm(t,e):n===-2?km(e,t,r):tt(e,e[v],n,t)}function km(e,t,n){if(n===jt)return Lt(t,e);if(n===rt)return Hr(t,e);if(n===Bt)return pl(t,e)}function hl(e,t,n,r){let o=t[Ie].queries[r];if(o.matches===null){let i=e.data,s=n.matches,a=[];for(let u=0;s!==null&&u<s.length;u+=2){let c=s[u];if(c<0)a.push(null);else{let l=i[c];a.push(Pm(t,l,s[u+1],n.metadata.read))}}o.matches=a}return o.matches}function bi(e,t,n,r){let o=e.queries.getByIndex(n),i=o.matches;if(i!==null){let s=hl(e,t,o,n);for(let a=0;a<i.length;a+=2){let u=i[a];if(u>0)r.push(s[a/2]);else{let c=i[a+1],l=t[-u];for(let d=W;d<l.length;d++){let f=l[d];f[an]===f[j]&&bi(f[v],f,c,r)}if(l[Ot]!==null){let d=l[Ot];for(let f=0;f<d.length;f++){let p=d[f];bi(p[v],p,c,r)}}}}}return r}function Lm(e,t){return e[Ie].queries[t].queryList}function gl(e,t,n){let r=new Qo((n&4)===4);return wg(e,t,r,r.destroy),(t[Ie]??=new wi).queries.push(new Ii(r))-1}function jm(e,t,n){let r=P();return r.firstCreatePass&&(ml(r,new vr(e,t,n),-1),(t&2)===2&&(r.staticViewQueries=!0)),gl(r,E(),t)}function Vm(e,t,n,r){let o=P();if(o.firstCreatePass){let i=V();ml(o,new vr(t,n,r),i.index),$m(o,e),(n&2)===2&&(o.staticContentQueries=!0)}return gl(o,E(),n)}function Bm(e){return e.split(",").map(t=>t.trim())}function ml(e,t,n){e.queries===null&&(e.queries=new Ei),e.queries.track(new Ci(t,n))}function $m(e,t){let n=e.contentQueries||(e.contentQueries=[]),r=n.length?n[n.length-1]:-1;t!==r&&n.push(e.queries.length-1,t)}function bs(e,t){return e.queries.getByIndex(t)}function Hm(e,t){let n=e[v],r=bs(n,t);return r.crossesNgTemplate?bi(n,e,t,[]):hl(n,e,r,t)}function Um(e){return typeof e=="function"&&e[gn]!==void 0}function yl(e){return Um(e)&&typeof e.set=="function"}function Gm(e){let t=[],n=new Map;function r(o){let i=n.get(o);if(!i){let s=e(o);n.set(o,i=s.then(Ym))}return i}return Ir.forEach((o,i)=>{let s=[];o.templateUrl&&s.push(r(o.templateUrl).then(c=>{o.template=c}));let a=typeof o.styles=="string"?[o.styles]:o.styles||[];if(o.styles=a,o.styleUrl&&o.styleUrls?.length)throw new Error("@Component cannot define both `styleUrl` and `styleUrls`. Use `styleUrl` if the component has one stylesheet, or `styleUrls` if it has multiple");if(o.styleUrls?.length){let c=o.styles.length,l=o.styleUrls;o.styleUrls.forEach((d,f)=>{a.push(""),s.push(r(d).then(p=>{a[c+f]=p,l.splice(l.indexOf(d),1),l.length==0&&(o.styleUrls=void 0)}))})}else o.styleUrl&&s.push(r(o.styleUrl).then(c=>{a.push(c),o.styleUrl=void 0}));let u=Promise.all(s).then(()=>Qm(i));t.push(u)}),Wm(),Promise.all(t).then(()=>{})}var Ir=new Map,zm=new Set;function Wm(){let e=Ir;return Ir=new Map,e}function qm(){return Ir.size===0}function Ym(e){return typeof e=="string"?e:e.text()}function Qm(e){zm.delete(e)}function Zm(e){return Object.getPrototypeOf(e.prototype).constructor}function Km(e){let t=Zm(e.type),n=!0,r=[e];for(;t;){let o;if(Oe(e))o=t.\u0275cmp||t.\u0275dir;else{if(t.\u0275cmp)throw new _(903,!1);o=t.\u0275dir}if(o){if(n){r.push(o);let s=e;s.inputs=Wn(e.inputs),s.inputTransforms=Wn(e.inputTransforms),s.declaredInputs=Wn(e.declaredInputs),s.outputs=Wn(e.outputs);let a=o.hostBindings;a&&ny(e,a);let u=o.viewQuery,c=o.contentQueries;if(u&&ey(e,u),c&&ty(e,c),Jm(e,o),ff(e.outputs,o.outputs),Oe(o)&&o.data.animation){let l=e.data;l.animation=(l.animation||[]).concat(o.data.animation)}}let i=o.features;if(i)for(let s=0;s<i.length;s++){let a=i[s];a&&a.ngInherit&&a(e),a===Km&&(n=!1)}}t=Object.getPrototypeOf(t)}Xm(r)}function Jm(e,t){for(let n in t.inputs){if(!t.inputs.hasOwnProperty(n)||e.inputs.hasOwnProperty(n))continue;let r=t.inputs[n];if(r!==void 0&&(e.inputs[n]=r,e.declaredInputs[n]=t.declaredInputs[n],t.inputTransforms!==null)){let o=Array.isArray(r)?r[0]:r;if(!t.inputTransforms.hasOwnProperty(o))continue;e.inputTransforms??={},e.inputTransforms[o]=t.inputTransforms[o]}}}function Xm(e){let t=0,n=null;for(let r=e.length-1;r>=0;r--){let o=e[r];o.hostVars=t+=o.hostVars,o.hostAttrs=Zt(o.hostAttrs,n=Zt(n,o.hostAttrs))}}function Wn(e){return e===Tt?{}:e===z?[]:e}function ey(e,t){let n=e.viewQuery;n?e.viewQuery=(r,o)=>{t(r,o),n(r,o)}:e.viewQuery=t}function ty(e,t){let n=e.contentQueries;n?e.contentQueries=(r,o,i)=>{t(r,o,i),n(r,o,i)}:e.contentQueries=t}function ny(e,t){let n=e.hostBindings;n?e.hostBindings=(r,o)=>{t(r,o),n(r,o)}:e.hostBindings=t}function ry(e){let t=e.inputConfig,n={};for(let r in t)if(t.hasOwnProperty(r)){let o=t[r];Array.isArray(o)&&o[3]&&(n[r]=o[3])}e.inputTransforms=n}var Pe=class{},_i=class{};var wr=class extends Pe{constructor(t,n,r){super(),this._parent=n,this._bootstrapComponents=[],this.destroyCbs=[],this.componentFactoryResolver=new Dr(this);let o=Nu(t);this._bootstrapComponents=Rc(o.bootstrap),this._r3Injector=Dc(t,n,[{provide:Pe,useValue:this},{provide:Ur,useValue:this.componentFactoryResolver},...r],H(t),new Set(["environment"])),this._r3Injector.resolveInjectorInitializers(),this.instance=this._r3Injector.get(t)}get injector(){return this._r3Injector}destroy(){let t=this._r3Injector;!t.destroyed&&t.destroy(),this.destroyCbs.forEach(n=>n()),this.destroyCbs=null}onDestroy(t){this.destroyCbs.push(t)}},Er=class extends _i{constructor(t){super(),this.moduleType=t}create(t){return new wr(this.moduleType,t,[])}};function oy(e,t,n){return new wr(e,t,n)}var Mi=class extends Pe{constructor(t){super(),this.componentFactoryResolver=new Dr(this),this.instance=null;let n=new Kt([...t.providers,{provide:Pe,useValue:this},{provide:Ur,useValue:this.componentFactoryResolver}],t.parent||Yi(),t.debugName,new Set(["environment"]));this.injector=n,t.runEnvironmentInitializers&&n.resolveInjectorInitializers()}destroy(){this.injector.destroy()}onDestroy(t){this.injector.onDestroy(t)}};function iy(e,t,n=null){return new Mi({providers:e,parent:t,debugName:n,runEnvironmentInitializers:!0}).injector}var _s=(()=>{let t=class t{constructor(){this.taskId=0,this.pendingTasks=new Set,this.hasPendingTasks=new $t(!1)}get _hasPendingTasks(){return this.hasPendingTasks.value}add(){this._hasPendingTasks||this.hasPendingTasks.next(!0);let r=this.taskId++;return this.pendingTasks.add(r),r}remove(r){this.pendingTasks.delete(r),this.pendingTasks.size===0&&this._hasPendingTasks&&this.hasPendingTasks.next(!1)}ngOnDestroy(){this.pendingTasks.clear(),this._hasPendingTasks&&this.hasPendingTasks.next(!1)}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"root"});let e=t;return e})();function Dl(e){return ay(e)?Array.isArray(e)||!(e instanceof Map)&&Symbol.iterator in e:!1}function sy(e,t){if(Array.isArray(e))for(let n=0;n<e.length;n++)t(e[n]);else{let n=e[Symbol.iterator](),r;for(;!(r=n.next()).done;)t(r.value)}}function ay(e){return e!==null&&(typeof e=="function"||typeof e=="object")}function uy(e,t,n){return e[t]=n}function je(e,t,n){let r=e[t];return Object.is(r,n)?!1:(e[t]=n,!0)}function cy(e){return(e.flags&32)===32}function ly(e,t,n,r,o,i,s,a,u){let c=t.consts,l=Vt(t,e,4,s||null,Ft(c,a));Ds(t,n,l,Ft(c,u)),Pr(t,l);let d=l.tView=ms(2,l,r,o,i,t.directiveRegistry,t.pipeRegistry,null,t.schemas,c,null);return t.queries!==null&&(t.queries.template(t,l),d.queries=t.queries.embeddedTView(l)),l}function dy(e,t,n,r,o,i,s,a){let u=E(),c=P(),l=e+Y,d=c.firstCreatePass?ly(l,c,u,t,n,r,o,i,s):c.data[l];it(d,!1);let f=fy(c,u,d,e);Fr()&&jr(c,u,f,d),Re(f,u);let p=Jc(f,u,f,d);return u[l]=p,$r(u,p),Am(p,d,u),Ar(d)&&hs(c,u,d),s!=null&&gs(u,d,a),dy}var fy=py;function py(e,t,n,r){return Rr(!0),t[F].createComment("")}function hy(e,t,n,r){let o=E(),i=un();if(je(o,i,t)){let s=P(),a=Or();kg(a,o,e,t,n,r)}return hy}function vl(e,t,n,r){return je(e,un(),n)?t+xr(n)+r:ge}function qn(e,t){return e<<17|t<<2}function ot(e){return e>>17&32767}function gy(e){return(e&2)==2}function my(e,t){return e&131071|t<<17}function xi(e){return e|2}function Pt(e){return(e&131068)>>2}function To(e,t){return e&-131069|t<<2}function yy(e){return(e&1)===1}function Si(e){return e|1}function Dy(e,t,n,r,o,i){let s=i?t.classBindings:t.styleBindings,a=ot(s),u=Pt(s);e[r]=n;let c=!1,l;if(Array.isArray(n)){let d=n;l=d[1],(l===null||sn(d,l)>0)&&(c=!0)}else l=n;if(o)if(u!==0){let f=ot(e[a+1]);e[r+1]=qn(f,a),f!==0&&(e[f+1]=To(e[f+1],r)),e[a+1]=my(e[a+1],r)}else e[r+1]=qn(a,0),a!==0&&(e[a+1]=To(e[a+1],r)),a=r;else e[r+1]=qn(u,0),a===0?a=r:e[u+1]=To(e[u+1],r),u=r;c&&(e[r+1]=xi(e[r+1])),ru(e,l,r,!0),ru(e,l,r,!1),vy(t,l,e,r,i),s=qn(a,u),i?t.classBindings=s:t.styleBindings=s}function vy(e,t,n,r,o){let i=o?e.residualClasses:e.residualStyles;i!=null&&typeof t=="string"&&sn(i,t)>=0&&(n[r+1]=Si(n[r+1]))}function ru(e,t,n,r){let o=e[n+1],i=t===null,s=r?ot(o):Pt(o),a=!1;for(;s!==0&&(a===!1||i);){let u=e[s],c=e[s+1];Iy(u,t)&&(a=!0,e[s+1]=r?Si(c):xi(c)),s=r?ot(c):Pt(c)}a&&(e[n+1]=r?xi(o):Si(o))}function Iy(e,t){return e===null||t==null||(Array.isArray(e)?e[1]:e)===t?!0:Array.isArray(e)&&typeof t=="string"?sn(e,t)>=0:!1}var oe={textEnd:0,key:0,keyEnd:0,value:0,valueEnd:0};function wy(e){return e.substring(oe.key,oe.keyEnd)}function Ey(e){return Cy(e),Il(e,wl(e,0,oe.textEnd))}function Il(e,t){let n=oe.textEnd;return n===t?-1:(t=oe.keyEnd=by(e,oe.key=t,n),wl(e,t,n))}function Cy(e){oe.key=0,oe.keyEnd=0,oe.value=0,oe.valueEnd=0,oe.textEnd=e.length}function wl(e,t,n){for(;t<n&&e.charCodeAt(t)<=32;)t++;return t}function by(e,t,n){for(;t<n&&e.charCodeAt(t)>32;)t++;return t}function _y(e,t,n){let r=E(),o=un();if(je(r,o,t)){let i=P(),s=Or();ys(i,s,r,e,t,r[F],n,!1)}return _y}function Ti(e,t,n,r,o){let i=t.inputs,s=o?"class":"style";vs(e,n,i[s],s,r)}function My(e,t){return Sy(e,t,null,!0),My}function rM(e){Ty(Py,xy,e,!0)}function xy(e,t){for(let n=Ey(t);n>=0;n=Il(t,n))Ui(e,wy(t),!0)}function Sy(e,t,n,r){let o=E(),i=P(),s=ec(2);if(i.firstUpdatePass&&Cl(i,e,s,r),t!==ge&&je(o,s,t)){let a=i.data[st()];bl(i,a,o,o[F],e,o[s+1]=Ly(t,n),r,s)}}function Ty(e,t,n,r){let o=P(),i=ec(2);o.firstUpdatePass&&Cl(o,null,i,r);let s=E();if(n!==ge&&je(s,i,n)){let a=o.data[st()];if(_l(a,r)&&!El(o,i)){let u=r?a.classesWithoutHost:a.stylesWithoutHost;u!==null&&(n=Fo(u,n||"")),Ti(o,a,s,n,r)}else ky(o,a,s,s[F],s[i+1],s[i+1]=Ry(e,t,n),r,i)}}function El(e,t){return t>=e.expandoStartIndex}function Cl(e,t,n,r){let o=e.data;if(o[n+1]===null){let i=o[st()],s=El(e,n);_l(i,r)&&t===null&&!s&&(t=!1),t=Ny(o,i,t,r),Dy(o,i,t,n,s,r)}}function Ny(e,t,n,r){let o=Bp(e),i=r?t.residualClasses:t.residualStyles;if(o===null)(r?t.classBindings:t.styleBindings)===0&&(n=No(null,e,t,n,r),n=rn(n,t.attrs,r),i=null);else{let s=t.directiveStylingLast;if(s===-1||e[s]!==o)if(n=No(o,e,t,n,r),i===null){let u=Ay(e,t,r);u!==void 0&&Array.isArray(u)&&(u=No(null,e,t,u[1],r),u=rn(u,t.attrs,r),Oy(e,t,r,u))}else i=Fy(e,t,r)}return i!==void 0&&(r?t.residualClasses=i:t.residualStyles=i),n}function Ay(e,t,n){let r=n?t.classBindings:t.styleBindings;if(Pt(r)!==0)return e[ot(r)]}function Oy(e,t,n,r){let o=n?t.classBindings:t.styleBindings;e[ot(o)]=r}function Fy(e,t,n){let r,o=t.directiveEnd;for(let i=1+t.directiveStylingLast;i<o;i++){let s=e[i].hostAttrs;r=rn(r,s,n)}return rn(r,t.attrs,n)}function No(e,t,n,r,o){let i=null,s=n.directiveEnd,a=n.directiveStylingLast;for(a===-1?a=n.directiveStart:a++;a<s&&(i=t[a],r=rn(r,i.hostAttrs,o),i!==e);)a++;return e!==null&&(n.directiveStylingLast=a),r}function rn(e,t,n){let r=n?1:2,o=-1;if(t!==null)for(let i=0;i<t.length;i++){let s=t[i];typeof s=="number"?o=s:o===r&&(Array.isArray(e)||(e=e===void 0?[]:["",e]),Ui(e,s,n?!0:t[++i]))}return e===void 0?null:e}function Ry(e,t,n){if(n==null||n==="")return z;let r=[],o=cn(n);if(Array.isArray(o))for(let i=0;i<o.length;i++)e(r,o[i],!0);else if(typeof o=="object")for(let i in o)o.hasOwnProperty(i)&&e(r,i,o[i]);else typeof o=="string"&&t(r,o);return r}function Py(e,t,n){let r=String(t);r!==""&&!r.includes(" ")&&Ui(e,r,n)}function ky(e,t,n,r,o,i,s,a){o===ge&&(o=z);let u=0,c=0,l=0<o.length?o[0]:null,d=0<i.length?i[0]:null;for(;l!==null||d!==null;){let f=u<o.length?o[u+1]:void 0,p=c<i.length?i[c+1]:void 0,h=null,w;l===d?(u+=2,c+=2,f!==p&&(h=d,w=p)):d===null||l!==null&&l<d?(u+=2,h=l):(c+=2,h=d,w=p),h!==null&&bl(e,t,n,r,h,w,s,a),l=u<o.length?o[u]:null,d=c<i.length?i[c]:null}}function bl(e,t,n,r,o,i,s,a){if(!(t.type&3))return;let u=e.data,c=u[a+1],l=yy(c)?ou(u,t,n,o,Pt(c),s):void 0;if(!Cr(l)){Cr(i)||gy(c)&&(i=ou(u,null,n,o,a,s));let d=Yu(st(),n);pg(r,s,d,o,i)}}function ou(e,t,n,r,o,i){let s=t===null,a;for(;o>0;){let u=e[o],c=Array.isArray(u),l=c?u[1]:u,d=l===null,f=n[o+1];f===ge&&(f=d?z:void 0);let p=d?Io(f,r):l===r?f:void 0;if(c&&!Cr(p)&&(p=Io(u,r)),Cr(p)&&(a=p,s))return a;let h=e[o+1];o=s?ot(h):Pt(h)}if(t!==null){let u=i?t.residualClasses:t.residualStyles;u!=null&&(a=Io(u,r))}return a}function Cr(e){return e!==void 0}function Ly(e,t){return e==null||e===""||(typeof t=="string"?e=e+t:typeof e=="object"&&(e=H(cn(e)))),e}function _l(e,t){return(e.flags&(t?8:16))!==0}function oM(e,t,n){dn("NgControlFlow");let r=E(),o=un(),i=jy(r,Y+e),s=0;if(je(r,o,t)){let a=M(null);try{if(zg(i,s),t!==-1){let u=Vy(r[v],Y+t),c=li(i,u.tView.ssrId),l=rl(r,u,n,{dehydratedView:c});ol(i,l,s,ui(u,c))}}finally{M(a)}}else{let a=Gg(i,s);a!==void 0&&(a[J]=n)}}function jy(e,t){return e[t]}function Vy(e,t){return Ki(e,t)}function By(e,t,n,r,o,i){let s=t.consts,a=Ft(s,o),u=Vt(t,e,2,r,a);return Ds(t,n,u,Ft(s,i)),u.attrs!==null&&yr(u,u.attrs,!1),u.mergedAttrs!==null&&yr(u,u.mergedAttrs,!0),t.queries!==null&&t.queries.elementStart(t,u),u}function Ml(e,t,n,r){let o=E(),i=P(),s=Y+e,a=o[F],u=i.firstCreatePass?By(s,i,o,t,n,r):i.data[s],c=Hy(i,o,u,a,t,e);o[s]=c;let l=Ar(u);return it(u,!0),Gc(a,c,u),!cy(u)&&Fr()&&jr(i,o,c,u),Sp()===0&&Re(c,o),Tp(),l&&(hs(i,o,u),ps(i,u,o)),r!==null&&gs(o,u),Ml}function xl(){let e=V();es()?ts():(e=e.parent,it(e,!1));let t=e;Ap(t)&&Op(),Np();let n=P();return n.firstCreatePass&&(Pr(n,e),Zi(e)&&n.queries.elementEnd(e)),t.classesWithoutHost!=null&&qp(t)&&Ti(n,t,E(),t.classesWithoutHost,!0),t.stylesWithoutHost!=null&&Yp(t)&&Ti(n,t,E(),t.stylesWithoutHost,!1),xl}function $y(e,t,n,r){return Ml(e,t,n,r),xl(),$y}var Hy=(e,t,n,r,o,i)=>(Rr(!0),Pc(r,o,Up()));function Uy(e,t,n,r,o){let i=t.consts,s=Ft(i,r),a=Vt(t,e,8,"ng-container",s);s!==null&&yr(a,s,!0);let u=Ft(i,o);return Ds(t,n,a,u),t.queries!==null&&t.queries.elementStart(t,a),a}function Sl(e,t,n){let r=E(),o=P(),i=e+Y,s=o.firstCreatePass?Uy(i,o,r,t,n):o.data[i];it(s,!0);let a=zy(o,r,s,e);return r[i]=a,Fr()&&jr(o,r,a,s),Re(a,r),Ar(s)&&(hs(o,r,s),ps(o,s,r)),n!=null&&gs(r,s),Sl}function Tl(){let e=V(),t=P();return es()?ts():(e=e.parent,it(e,!1)),t.firstCreatePass&&(Pr(t,e),Zi(e)&&t.queries.elementEnd(e)),Tl}function Gy(e,t,n){return Sl(e,t,n),Tl(),Gy}var zy=(e,t,n,r)=>(Rr(!0),Kh(t[F],""));function iM(){return E()}var br="en-US";var Wy=br;function qy(e){typeof e=="string"&&(Wy=e.toLowerCase().replace(/_/g,"-"))}function Yy(e,t,n,r){let o=E(),i=P(),s=V();return Nl(i,o,o[F],s,e,t,r),Yy}function Qy(e,t,n,r){let o=e.cleanup;if(o!=null)for(let i=0;i<o.length-1;i+=2){let s=o[i];if(s===n&&o[i+1]===r){let a=t[Xt],u=o[i+2];return a.length>u?a[u]:null}typeof s=="string"&&(i+=2)}return null}function Nl(e,t,n,r,o,i,s){let a=Ar(r),c=e.firstCreatePass&&tl(e),l=t[J],d=el(t),f=!0;if(r.type&3||s){let w=X(r,t),k=s?s(w):w,N=d.length,Z=s?me=>s(he(me[r.index])):r.index,U=null;if(!s&&a&&(U=Qy(e,t,o,r.index)),U!==null){let me=U.__ngLastListenerFn__||U;me.__ngNextListenerFn__=i,U.__ngLastListenerFn__=i,f=!1}else{i=su(r,t,l,i,!1);let me=n.listen(k,o,i);d.push(i,me),c&&c.push(o,Z,N,N+1)}}else i=su(r,t,l,i,!1);let p=r.outputs,h;if(f&&p!==null&&(h=p[o])){let w=h.length;if(w)for(let k=0;k<w;k+=2){let N=h[k],Z=h[k+1],ut=t[N][Z].subscribe(i),ee=d.length;d.push(i,ut),c&&c.push(o,r.index,ee,-(ee+1))}}}function iu(e,t,n,r){let o=M(null);try{return fe(6,t,n),n(r)!==!1}catch(i){return nl(e,i),!1}finally{fe(7,t,n),M(o)}}function su(e,t,n,r,o){return function i(s){if(s===Function)return r;let a=e.componentOffset>-1?ke(e.index,t):t;ws(a);let u=iu(t,n,r,s),c=i.__ngNextListenerFn__;for(;c;)u=iu(t,n,c,s)&&u,c=c.__ngNextListenerFn__;return o&&u===!1&&s.preventDefault(),u}}function sM(e=1){return Hp(e)}function Zy(e,t){let n=null,r=Gf(e);for(let o=0;o<t.length;o++){let i=t[o];if(i==="*"){n=o;continue}if(r===null?xu(e,i,!0):qf(r,i))return o}return n}function aM(e){let t=E()[ue][Q];if(!t.projection){let n=e?e.length:1,r=t.projection=Pf(n,null),o=r.slice(),i=t.child;for(;i!==null;){let s=e?Zy(i,e):0;s!==null&&(o[s]?o[s].projectionNext=i:r[s]=i,o[s]=i),i=i.next}}}function uM(e,t=0,n){let r=E(),o=P(),i=Vt(o,Y+e,16,null,n||null);i.projection===null&&(i.projection=t),ts(),(!r[Jt]||Ju())&&(i.flags&32)!==32&&dg(o,r,i)}function Ky(e,t,n){return Al(e,"",t,"",n),Ky}function Al(e,t,n,r,o){let i=E(),s=vl(i,t,n,r);if(s!==ge){let a=P(),u=Or();ys(a,u,i,e,s,i[F],o,!1)}return Al}function cM(e,t,n,r){Vm(e,t,n,r)}function lM(e,t,n){jm(e,t,n)}function dM(e){let t=E(),n=P(),r=tc();ns(r+1);let o=bs(n,r);if(e.dirty&&Cp(t)===((o.metadata.flags&2)===2)){if(o.matches===null)e.reset([]);else{let i=Hm(t,r);e.reset(i,uh),e.notifyOnChanges()}return!0}return!1}function fM(){return Lm(E(),tc())}function pM(e){let t=Rp();return Ep(t,Y+e)}function hM(e,t=""){let n=E(),r=P(),o=e+Y,i=r.firstCreatePass?Vt(r,o,1,t,null):r.data[o],s=Jy(r,n,i,t,e);n[o]=s,Fr()&&jr(r,n,s,i),it(i,!1)}var Jy=(e,t,n,r,o)=>(Rr(!0),Qh(t[F],r));function Xy(e){return Ol("",e,""),Xy}function Ol(e,t,n){let r=E(),o=vl(r,e,t,n);return o!==ge&&Bg(r,st(),o),Ol}function eD(e,t,n){yl(t)&&(t=t());let r=E(),o=un();if(je(r,o,t)){let i=P(),s=Or();ys(i,s,r,e,t,r[F],n,!1)}return eD}function gM(e,t){let n=yl(e);return n&&e.set(t),n}function tD(e,t){let n=E(),r=P(),o=V();return Nl(r,n,n[F],o,e,t),tD}function nD(e,t,n){let r=P();if(r.firstCreatePass){let o=Oe(e);Ni(n,r.data,r.blueprint,o,!0),Ni(t,r.data,r.blueprint,o,!1)}}function Ni(e,t,n,r,o){if(e=$(e),Array.isArray(e))for(let i=0;i<e.length;i++)Ni(e[i],t,n,r,o);else{let i=P(),s=E(),a=V(),u=Nt(e)?e:$(e.provide),c=Lu(e),l=a.providerIndexes&1048575,d=a.directiveStart,f=a.providerIndexes>>20;if(Nt(e)||!e.multi){let p=new et(c,o,_e),h=Oo(u,t,o?l:l+f,d);h===-1?(zo(lr(a,s),i,u),Ao(i,e,t.length),t.push(u),a.directiveStart++,a.directiveEnd++,o&&(a.providerIndexes+=1048576),n.push(p),s.push(p)):(n[h]=p,s[h]=p)}else{let p=Oo(u,t,l+f,d),h=Oo(u,t,l,l+f),w=p>=0&&n[p],k=h>=0&&n[h];if(o&&!k||!o&&!w){zo(lr(a,s),i,u);let N=iD(o?oD:rD,n.length,o,r,c);!o&&k&&(n[h].providerFactory=N),Ao(i,e,t.length,0),t.push(u),a.directiveStart++,a.directiveEnd++,o&&(a.providerIndexes+=1048576),n.push(N),s.push(N)}else{let N=Fl(n[o?h:p],c,!o&&r);Ao(i,e,p>-1?p:h,N)}!o&&r&&k&&n[h].componentProviders++}}}function Ao(e,t,n,r){let o=Nt(t),i=ip(t);if(o||i){let u=(i?$(t.useClass):t).prototype.ngOnDestroy;if(u){let c=e.destroyHooks||(e.destroyHooks=[]);if(!o&&t.multi){let l=c.indexOf(n);l===-1?c.push(n,[r,u]):c[l+1].push(r,u)}else c.push(n,u)}}}function Fl(e,t,n){return n&&e.componentProviders++,e.multi.push(t)-1}function Oo(e,t,n,r){for(let o=n;o<r;o++)if(t[o]===e)return o;return-1}function rD(e,t,n,r){return Ai(this.multi,[])}function oD(e,t,n,r){let o=this.multi,i;if(this.providerFactory){let s=this.providerFactory.componentProviders,a=tt(n,n[v],this.providerFactory.index,r);i=a.slice(0,s),Ai(o,i);for(let u=s;u<a.length;u++)i.push(a[u])}else i=[],Ai(o,i);return i}function Ai(e,t){for(let n=0;n<e.length;n++){let r=e[n];t.push(r())}return t}function iD(e,t,n,r,o){let i=new et(e,n,_e);return i.multi=[],i.index=t,i.componentProviders=0,Fl(i,o,r&&!n),i}function mM(e,t=[]){return n=>{n.providersResolver=(r,o)=>nD(r,o?o(e):e,t)}}var sD=(()=>{let t=class t{constructor(r){this._injector=r,this.cachedInjectors=new Map}getOrCreateStandaloneInjector(r){if(!r.standalone)return null;if(!this.cachedInjectors.has(r)){let o=Fu(!1,r.type),i=o.length>0?iy([o],this._injector,`Standalone[${r.type.name}]`):null;this.cachedInjectors.set(r,i)}return this.cachedInjectors.get(r)}ngOnDestroy(){try{for(let r of this.cachedInjectors.values())r!==null&&r.destroy()}finally{this.cachedInjectors.clear()}}};t.\u0275prov=O({token:t,providedIn:"environment",factory:()=>new t(R(Ae))});let e=t;return e})();function yM(e){dn("NgStandalone"),e.getStandaloneInjector=t=>t.get(sD).getOrCreateStandaloneInjector(e)}function DM(e,t,n,r){return uD(E(),Pp(),e,t,n,r)}function aD(e,t){let n=e[t];return n===ge?void 0:n}function uD(e,t,n,r,o,i){let s=t+n;return je(e,s,o)?uy(e,s+1,i?r.call(i,o):r(o)):aD(e,s+1)}function vM(e,t){return Hr(e,t)}var Yn=null;function cD(e){Yn!==null&&(e.defaultEncapsulation!==Yn.defaultEncapsulation||e.preserveWhitespaces!==Yn.preserveWhitespaces)||(Yn=e)}var IM=(()=>{let t=class t{log(r){console.log(r)}warn(r){console.warn(r)}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"platform"});let e=t;return e})();var lD=new T(""),dD=new T(""),wM=(()=>{let t=class t{constructor(r,o,i){this._ngZone=r,this.registry=o,this._pendingCount=0,this._isZoneStable=!0,this._callbacks=[],this.taskTrackingZone=null,Ms||(pD(i),i.addToWindow(o)),this._watchAngularEvents(),r.run(()=>{this.taskTrackingZone=typeof Zone>"u"?null:Zone.current.get("TaskTrackingZone")})}_watchAngularEvents(){this._ngZone.onUnstable.subscribe({next:()=>{this._isZoneStable=!1}}),this._ngZone.runOutsideAngular(()=>{this._ngZone.onStable.subscribe({next:()=>{q.assertNotInAngularZone(),queueMicrotask(()=>{this._isZoneStable=!0,this._runCallbacksIfReady()})}})})}increasePendingRequestCount(){return this._pendingCount+=1,this._pendingCount}decreasePendingRequestCount(){if(this._pendingCount-=1,this._pendingCount<0)throw new Error("pending async requests below zero");return this._runCallbacksIfReady(),this._pendingCount}isStable(){return this._isZoneStable&&this._pendingCount===0&&!this._ngZone.hasPendingMacrotasks}_runCallbacksIfReady(){if(this.isStable())queueMicrotask(()=>{for(;this._callbacks.length!==0;){let r=this._callbacks.pop();clearTimeout(r.timeoutId),r.doneCb()}});else{let r=this.getPendingTasks();this._callbacks=this._callbacks.filter(o=>o.updateCb&&o.updateCb(r)?(clearTimeout(o.timeoutId),!1):!0)}}getPendingTasks(){return this.taskTrackingZone?this.taskTrackingZone.macroTasks.map(r=>({source:r.source,creationLocation:r.creationLocation,data:r.data})):[]}addCallback(r,o,i){let s=-1;o&&o>0&&(s=setTimeout(()=>{this._callbacks=this._callbacks.filter(a=>a.timeoutId!==s),r()},o)),this._callbacks.push({doneCb:r,timeoutId:s,updateCb:i})}whenStable(r,o,i){if(i&&!this.taskTrackingZone)throw new Error('Task tracking zone is required when passing an update callback to whenStable(). Is "zone.js/plugins/task-tracking" loaded?');this.addCallback(r,o,i),this._runCallbacksIfReady()}getPendingRequestCount(){return this._pendingCount}registerApplication(r){this.registry.registerApplication(r,this)}unregisterApplication(r){this.registry.unregisterApplication(r)}findProviders(r,o,i){return[]}};t.\u0275fac=function(o){return new(o||t)(R(q),R(fD),R(dD))},t.\u0275prov=O({token:t,factory:t.\u0275fac});let e=t;return e})(),fD=(()=>{let t=class t{constructor(){this._applications=new Map}registerApplication(r,o){this._applications.set(r,o)}unregisterApplication(r){this._applications.delete(r)}unregisterAllApplications(){this._applications.clear()}getTestability(r){return this._applications.get(r)||null}getAllTestabilities(){return Array.from(this._applications.values())}getAllRootElements(){return Array.from(this._applications.keys())}findTestabilityInTree(r,o=!0){return Ms?.findTestabilityInTree(this,r,o)??null}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"platform"});let e=t;return e})();function pD(e){Ms=e}var Ms;function xs(e){return!!e&&typeof e.then=="function"}function Rl(e){return!!e&&typeof e.subscribe=="function"}var hD=new T(""),Pl=(()=>{let t=class t{constructor(){this.initialized=!1,this.done=!1,this.donePromise=new Promise((r,o)=>{this.resolve=r,this.reject=o}),this.appInits=S(hD,{optional:!0})??[]}runInitializers(){if(this.initialized)return;let r=[];for(let i of this.appInits){let s=i();if(xs(s))r.push(s);else if(Rl(s)){let a=new Promise((u,c)=>{s.subscribe({complete:u,error:c})});r.push(a)}}let o=()=>{this.done=!0,this.resolve()};Promise.all(r).then(()=>{o()}).catch(i=>{this.reject(i)}),r.length===0&&o(),this.initialized=!0}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"root"});let e=t;return e})(),gD=new T("");function mD(){zs(()=>{throw new _(600,!1)})}function yD(e){return e.isBoundToModule}function DD(e,t,n){try{let r=n();return xs(r)?r.catch(o=>{throw t.runOutsideAngular(()=>e.handleError(o)),o}):r}catch(r){throw t.runOutsideAngular(()=>e.handleError(r)),r}}function kl(e,t){return Array.isArray(t)?t.reduce(kl,e):xe(xe({},e),t)}var Ss=(()=>{let t=class t{constructor(){this._bootstrapListeners=[],this._runningTick=!1,this._destroyed=!1,this._destroyListeners=[],this._views=[],this.internalErrorHandler=S(vc),this.afterRenderEffectManager=S(Cs),this.externalTestViews=new Set,this.beforeRender=new ce,this.afterTick=new ce,this.componentTypes=[],this.components=[],this.isStable=S(_s).hasPendingTasks.pipe(De(r=>!r)),this._injector=S(Ae)}get destroyed(){return this._destroyed}get injector(){return this._injector}bootstrap(r,o){let i=r instanceof mr;if(!this._injector.get(Pl).done){let p=!i&&Xf(r),h=!1;throw new _(405,h)}let a;i?a=r:a=this._injector.get(Ur).resolveComponentFactory(r),this.componentTypes.push(a.componentType);let u=yD(a)?void 0:this._injector.get(Pe),c=o||a.selector,l=a.create(Le.NULL,[],c,u),d=l.location.nativeElement,f=l.injector.get(lD,null);return f?.registerApplication(d),l.onDestroy(()=>{this.detachView(l.hostView),tr(this.components,l),f?.unregisterApplication(d)}),this._loadComponent(l),l}tick(){this._tick(!0)}_tick(r){if(this._runningTick)throw new _(101,!1);let o=M(null);try{this._runningTick=!0,this.detectChangesInAttachedViews(r)}catch(i){this.internalErrorHandler(i)}finally{this.afterTick.next(),this._runningTick=!1,M(o)}}detectChangesInAttachedViews(r){let o=0,i=this.afterRenderEffectManager;for(;;){if(o===sl)throw new _(103,!1);if(r){let s=o===0;this.beforeRender.next(s);for(let{_lView:a,notifyErrorHandler:u}of this._views)vD(a,s,u)}if(o++,i.executeInternalCallbacks(),![...this.externalTestViews.keys(),...this._views].some(({_lView:s})=>Oi(s))&&(i.execute(),![...this.externalTestViews.keys(),...this._views].some(({_lView:s})=>Oi(s))))break}}attachView(r){let o=r;this._views.push(o),o.attachToAppRef(this)}detachView(r){let o=r;tr(this._views,o),o.detachFromAppRef()}_loadComponent(r){this.attachView(r.hostView),this.tick(),this.components.push(r);let o=this._injector.get(gD,[]);[...this._bootstrapListeners,...o].forEach(i=>i(r))}ngOnDestroy(){if(!this._destroyed)try{this._destroyListeners.forEach(r=>r()),this._views.slice().forEach(r=>r.destroy())}finally{this._destroyed=!0,this._views=[],this._bootstrapListeners=[],this._destroyListeners=[]}}onDestroy(r){return this._destroyListeners.push(r),()=>tr(this._destroyListeners,r)}destroy(){if(this._destroyed)throw new _(406,!1);let r=this._injector;r.destroy&&!r.destroyed&&r.destroy()}get viewCount(){return this._views.length}warnIfDestroyed(){}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"root"});let e=t;return e})();function tr(e,t){let n=e.indexOf(t);n>-1&&e.splice(n,1)}function vD(e,t,n){!t&&!Oi(e)||ID(e,n,t)}function Oi(e){return Xi(e)}function ID(e,t,n){let r;n?(r=0,e[m]|=1024):e[m]&64?r=0:r=1,al(e,t,r)}var Fi=class{constructor(t,n){this.ngModuleFactory=t,this.componentFactories=n}},EM=(()=>{let t=class t{compileModuleSync(r){return new Er(r)}compileModuleAsync(r){return Promise.resolve(this.compileModuleSync(r))}compileModuleAndAllComponentsSync(r){let o=this.compileModuleSync(r),i=Nu(r),s=Rc(i.declarations).reduce((a,u)=>{let c=Ne(u);return c&&a.push(new Rt(c)),a},[]);return new Fi(o,s)}compileModuleAndAllComponentsAsync(r){return Promise.resolve(this.compileModuleAndAllComponentsSync(r))}clearCache(){}clearCacheFor(r){}getModuleId(r){}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"root"});let e=t;return e})(),wD=new T("");function ED(e,t,n){let r=new Er(n);return Promise.resolve(r)}function au(e){for(let t=e.length-1;t>=0;t--)if(e[t]!==void 0)return e[t]}var CD=(()=>{let t=class t{constructor(){this.zone=S(q),this.applicationRef=S(Ss)}initialize(){this._onMicrotaskEmptySubscription||(this._onMicrotaskEmptySubscription=this.zone.onMicrotaskEmpty.subscribe({next:()=>{this.zone.run(()=>{this.applicationRef.tick()})}}))}ngOnDestroy(){this._onMicrotaskEmptySubscription?.unsubscribe()}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"root"});let e=t;return e})();function bD(e){return[{provide:q,useFactory:e},{provide:ir,multi:!0,useFactory:()=>{let t=S(CD,{optional:!0});return()=>t.initialize()}},{provide:ir,multi:!0,useFactory:()=>{let t=S(xD);return()=>{t.initialize()}}},{provide:vc,useFactory:_D}]}function _D(){let e=S(q),t=S(Fe);return n=>e.runOutsideAngular(()=>t.handleError(n))}function MD(e){return{enableLongStackTrace:!1,shouldCoalesceEventChangeDetection:e?.eventCoalescing??!1,shouldCoalesceRunChangeDetection:e?.runCoalescing??!1}}var xD=(()=>{let t=class t{constructor(){this.subscription=new L,this.initialized=!1,this.zone=S(q),this.pendingTasks=S(_s)}initialize(){if(this.initialized)return;this.initialized=!0;let r=null;!this.zone.isStable&&!this.zone.hasPendingMacrotasks&&!this.zone.hasPendingMicrotasks&&(r=this.pendingTasks.add()),this.zone.runOutsideAngular(()=>{this.subscription.add(this.zone.onStable.subscribe(()=>{q.assertNotInAngularZone(),queueMicrotask(()=>{r!==null&&!this.zone.hasPendingMacrotasks&&!this.zone.hasPendingMicrotasks&&(this.pendingTasks.remove(r),r=null)})}))}),this.subscription.add(this.zone.onUnstable.subscribe(()=>{q.assertInAngularZone(),r??=this.pendingTasks.add()}))}ngOnDestroy(){this.subscription.unsubscribe()}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"root"});let e=t;return e})();function SD(){return typeof $localize<"u"&&$localize.locale||br}var Ts=new T("",{providedIn:"root",factory:()=>S(Ts,b.Optional|b.SkipSelf)||SD()});var Ll=new T(""),jl=(()=>{let t=class t{constructor(r){this._injector=r,this._modules=[],this._destroyListeners=[],this._destroyed=!1}bootstrapModuleFactory(r,o){let i=gm(o?.ngZone,MD({eventCoalescing:o?.ngZoneEventCoalescing,runCoalescing:o?.ngZoneRunCoalescing}));return i.run(()=>{let s=oy(r.moduleType,this.injector,bD(()=>i)),a=s.injector.get(Fe,null);return i.runOutsideAngular(()=>{let u=i.onError.subscribe({next:c=>{a.handleError(c)}});s.onDestroy(()=>{tr(this._modules,s),u.unsubscribe()})}),DD(a,i,()=>{let u=s.injector.get(Pl);return u.runInitializers(),u.donePromise.then(()=>{let c=s.injector.get(Ts,br);return qy(c||br),this._moduleDoBootstrap(s),s})})})}bootstrapModule(r,o=[]){let i=kl({},o);return ED(this.injector,i,r).then(s=>this.bootstrapModuleFactory(s,i))}_moduleDoBootstrap(r){let o=r.injector.get(Ss);if(r._bootstrapComponents.length>0)r._bootstrapComponents.forEach(i=>o.bootstrap(i));else if(r.instance.ngDoBootstrap)r.instance.ngDoBootstrap(o);else throw new _(-403,!1);this._modules.push(r)}onDestroy(r){this._destroyListeners.push(r)}get injector(){return this._injector}destroy(){if(this._destroyed)throw new _(404,!1);this._modules.slice().forEach(o=>o.destroy()),this._destroyListeners.forEach(o=>o());let r=this._injector.get(Ll,null);r&&(r.forEach(o=>o()),r.clear()),this._destroyed=!0}get destroyed(){return this._destroyed}};t.\u0275fac=function(o){return new(o||t)(R(Le))},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"platform"});let e=t;return e})(),qt=null,Vl=new T("");function TD(e){if(qt&&!qt.get(Vl,!1))throw new _(400,!1);mD(),qt=e;let t=e.get(jl);return FD(e),t}function ND(e,t,n=[]){let r=`Platform: ${t}`,o=new T(r);return(i=[])=>{let s=Bl();if(!s||s.injector.get(Vl,!1)){let a=[...n,...i,{provide:o,useValue:!0}];e?e(a):TD(AD(a,r))}return OD(o)}}function AD(e=[],t){return Le.create({name:t,providers:[{provide:ku,useValue:"platform"},{provide:Ll,useValue:new Set([()=>qt=null])},...e]})}function OD(e){let t=Bl();if(!t)throw new _(401,!1);return t}function Bl(){return qt?.get(jl)??null}function FD(e){e.get(mh,null)?.forEach(n=>n())}var Ns=(()=>{let t=class t{};t.__NG_ELEMENT_ID__=RD;let e=t;return e})();function RD(e){return PD(V(),E(),(e&16)===16)}function PD(e,t,n){if(Nr(e)&&!n){let r=ke(e.index,t);return new nt(r,r)}else if(e.type&47){let r=t[ue];return new nt(r,t)}return null}var Ri=class{constructor(){}supports(t){return Dl(t)}create(t){return new Pi(t)}},kD=(e,t)=>t,Pi=class{constructor(t){this.length=0,this._linkedRecords=null,this._unlinkedRecords=null,this._previousItHead=null,this._itHead=null,this._itTail=null,this._additionsHead=null,this._additionsTail=null,this._movesHead=null,this._movesTail=null,this._removalsHead=null,this._removalsTail=null,this._identityChangesHead=null,this._identityChangesTail=null,this._trackByFn=t||kD}forEachItem(t){let n;for(n=this._itHead;n!==null;n=n._next)t(n)}forEachOperation(t){let n=this._itHead,r=this._removalsHead,o=0,i=null;for(;n||r;){let s=!r||n&&n.currentIndex<uu(r,o,i)?n:r,a=uu(s,o,i),u=s.currentIndex;if(s===r)o--,r=r._nextRemoved;else if(n=n._next,s.previousIndex==null)o++;else{i||(i=[]);let c=a-o,l=u-o;if(c!=l){for(let f=0;f<c;f++){let p=f<i.length?i[f]:i[f]=0,h=p+f;l<=h&&h<c&&(i[f]=p+1)}let d=s.previousIndex;i[d]=l-c}}a!==u&&t(s,a,u)}}forEachPreviousItem(t){let n;for(n=this._previousItHead;n!==null;n=n._nextPrevious)t(n)}forEachAddedItem(t){let n;for(n=this._additionsHead;n!==null;n=n._nextAdded)t(n)}forEachMovedItem(t){let n;for(n=this._movesHead;n!==null;n=n._nextMoved)t(n)}forEachRemovedItem(t){let n;for(n=this._removalsHead;n!==null;n=n._nextRemoved)t(n)}forEachIdentityChange(t){let n;for(n=this._identityChangesHead;n!==null;n=n._nextIdentityChange)t(n)}diff(t){if(t==null&&(t=[]),!Dl(t))throw new _(900,!1);return this.check(t)?this:null}onDestroy(){}check(t){this._reset();let n=this._itHead,r=!1,o,i,s;if(Array.isArray(t)){this.length=t.length;for(let a=0;a<this.length;a++)i=t[a],s=this._trackByFn(a,i),n===null||!Object.is(n.trackById,s)?(n=this._mismatch(n,i,s,a),r=!0):(r&&(n=this._verifyReinsertion(n,i,s,a)),Object.is(n.item,i)||this._addIdentityChange(n,i)),n=n._next}else o=0,sy(t,a=>{s=this._trackByFn(o,a),n===null||!Object.is(n.trackById,s)?(n=this._mismatch(n,a,s,o),r=!0):(r&&(n=this._verifyReinsertion(n,a,s,o)),Object.is(n.item,a)||this._addIdentityChange(n,a)),n=n._next,o++}),this.length=o;return this._truncate(n),this.collection=t,this.isDirty}get isDirty(){return this._additionsHead!==null||this._movesHead!==null||this._removalsHead!==null||this._identityChangesHead!==null}_reset(){if(this.isDirty){let t;for(t=this._previousItHead=this._itHead;t!==null;t=t._next)t._nextPrevious=t._next;for(t=this._additionsHead;t!==null;t=t._nextAdded)t.previousIndex=t.currentIndex;for(this._additionsHead=this._additionsTail=null,t=this._movesHead;t!==null;t=t._nextMoved)t.previousIndex=t.currentIndex;this._movesHead=this._movesTail=null,this._removalsHead=this._removalsTail=null,this._identityChangesHead=this._identityChangesTail=null}}_mismatch(t,n,r,o){let i;return t===null?i=this._itTail:(i=t._prev,this._remove(t)),t=this._unlinkedRecords===null?null:this._unlinkedRecords.get(r,null),t!==null?(Object.is(t.item,n)||this._addIdentityChange(t,n),this._reinsertAfter(t,i,o)):(t=this._linkedRecords===null?null:this._linkedRecords.get(r,o),t!==null?(Object.is(t.item,n)||this._addIdentityChange(t,n),this._moveAfter(t,i,o)):t=this._addAfter(new ki(n,r),i,o)),t}_verifyReinsertion(t,n,r,o){let i=this._unlinkedRecords===null?null:this._unlinkedRecords.get(r,null);return i!==null?t=this._reinsertAfter(i,t._prev,o):t.currentIndex!=o&&(t.currentIndex=o,this._addToMoves(t,o)),t}_truncate(t){for(;t!==null;){let n=t._next;this._addToRemovals(this._unlink(t)),t=n}this._unlinkedRecords!==null&&this._unlinkedRecords.clear(),this._additionsTail!==null&&(this._additionsTail._nextAdded=null),this._movesTail!==null&&(this._movesTail._nextMoved=null),this._itTail!==null&&(this._itTail._next=null),this._removalsTail!==null&&(this._removalsTail._nextRemoved=null),this._identityChangesTail!==null&&(this._identityChangesTail._nextIdentityChange=null)}_reinsertAfter(t,n,r){this._unlinkedRecords!==null&&this._unlinkedRecords.remove(t);let o=t._prevRemoved,i=t._nextRemoved;return o===null?this._removalsHead=i:o._nextRemoved=i,i===null?this._removalsTail=o:i._prevRemoved=o,this._insertAfter(t,n,r),this._addToMoves(t,r),t}_moveAfter(t,n,r){return this._unlink(t),this._insertAfter(t,n,r),this._addToMoves(t,r),t}_addAfter(t,n,r){return this._insertAfter(t,n,r),this._additionsTail===null?this._additionsTail=this._additionsHead=t:this._additionsTail=this._additionsTail._nextAdded=t,t}_insertAfter(t,n,r){let o=n===null?this._itHead:n._next;return t._next=o,t._prev=n,o===null?this._itTail=t:o._prev=t,n===null?this._itHead=t:n._next=t,this._linkedRecords===null&&(this._linkedRecords=new _r),this._linkedRecords.put(t),t.currentIndex=r,t}_remove(t){return this._addToRemovals(this._unlink(t))}_unlink(t){this._linkedRecords!==null&&this._linkedRecords.remove(t);let n=t._prev,r=t._next;return n===null?this._itHead=r:n._next=r,r===null?this._itTail=n:r._prev=n,t}_addToMoves(t,n){return t.previousIndex===n||(this._movesTail===null?this._movesTail=this._movesHead=t:this._movesTail=this._movesTail._nextMoved=t),t}_addToRemovals(t){return this._unlinkedRecords===null&&(this._unlinkedRecords=new _r),this._unlinkedRecords.put(t),t.currentIndex=null,t._nextRemoved=null,this._removalsTail===null?(this._removalsTail=this._removalsHead=t,t._prevRemoved=null):(t._prevRemoved=this._removalsTail,this._removalsTail=this._removalsTail._nextRemoved=t),t}_addIdentityChange(t,n){return t.item=n,this._identityChangesTail===null?this._identityChangesTail=this._identityChangesHead=t:this._identityChangesTail=this._identityChangesTail._nextIdentityChange=t,t}},ki=class{constructor(t,n){this.item=t,this.trackById=n,this.currentIndex=null,this.previousIndex=null,this._nextPrevious=null,this._prev=null,this._next=null,this._prevDup=null,this._nextDup=null,this._prevRemoved=null,this._nextRemoved=null,this._nextAdded=null,this._nextMoved=null,this._nextIdentityChange=null}},Li=class{constructor(){this._head=null,this._tail=null}add(t){this._head===null?(this._head=this._tail=t,t._nextDup=null,t._prevDup=null):(this._tail._nextDup=t,t._prevDup=this._tail,t._nextDup=null,this._tail=t)}get(t,n){let r;for(r=this._head;r!==null;r=r._nextDup)if((n===null||n<=r.currentIndex)&&Object.is(r.trackById,t))return r;return null}remove(t){let n=t._prevDup,r=t._nextDup;return n===null?this._head=r:n._nextDup=r,r===null?this._tail=n:r._prevDup=n,this._head===null}},_r=class{constructor(){this.map=new Map}put(t){let n=t.trackById,r=this.map.get(n);r||(r=new Li,this.map.set(n,r)),r.add(t)}get(t,n){let r=t,o=this.map.get(r);return o?o.get(t,n):null}remove(t){let n=t.trackById;return this.map.get(n).remove(t)&&this.map.delete(n),t}get isEmpty(){return this.map.size===0}clear(){this.map.clear()}};function uu(e,t,n){let r=e.previousIndex;if(r===null)return r;let o=0;return n&&r<n.length&&(o=n[r]),r+t+o}function cu(){return new As([new Ri])}var As=(()=>{let t=class t{constructor(r){this.factories=r}static create(r,o){if(o!=null){let i=o.factories.slice();r=r.concat(i)}return new t(r)}static extend(r){return{provide:t,useFactory:o=>t.create(r,o||cu()),deps:[[t,new Of,new Af]]}}find(r){let o=this.factories.find(i=>i.supports(r));if(o!=null)return o;throw new _(901,!1)}};t.\u0275prov=O({token:t,providedIn:"root",factory:cu});let e=t;return e})();var CM=ND(null,"core",[]),bM=(()=>{let t=class t{constructor(r){}};t.\u0275fac=function(o){return new(o||t)(R(Ss))},t.\u0275mod=zi({type:t}),t.\u0275inj=Bi({});let e=t;return e})();function LD(e){return typeof e=="boolean"?e:e!=null&&e!=="false"}function jD(e,t=NaN){return!isNaN(parseFloat(e))&&!isNaN(Number(e))?Number(e):t}var VD=new T("",{providedIn:"root",factory:()=>S(BD)}),BD=(()=>{let t=class t{};t.\u0275prov=O({token:t,providedIn:"root",factory:()=>new ji});let e=t;return e})(),ji=class{constructor(){this.queuedEffectCount=0,this.queues=new Map,this.pendingTasks=S(_s),this.taskId=null}scheduleEffect(t){if(this.enqueue(t),this.taskId===null){let n=this.taskId=this.pendingTasks.add();queueMicrotask(()=>{this.flush(),this.pendingTasks.remove(n),this.taskId=null})}}enqueue(t){let n=t.creationZone;this.queues.has(n)||this.queues.set(n,new Set);let r=this.queues.get(n);r.has(t)||(this.queuedEffectCount++,r.add(t))}flush(){for(;this.queuedEffectCount>0;)for(let[t,n]of this.queues)t===null?this.flushQueue(n):t.run(()=>this.flushQueue(n))}flushQueue(t){for(let n of t)t.delete(n),this.queuedEffectCount--,n.run()}},Vi=class{constructor(t,n,r,o,i,s){this.scheduler=t,this.effectFn=n,this.creationZone=r,this.injector=i,this.watcher=Ws(a=>this.runEffect(a),()=>this.schedule(),s),this.unregisterOnDestroy=o?.onDestroy(()=>this.destroy())}runEffect(t){try{this.effectFn(t)}catch(n){this.injector.get(Fe,null,{optional:!0})?.handleError(n)}}run(){this.watcher.run()}schedule(){this.scheduler.scheduleEffect(this)}destroy(){this.watcher.destroy(),this.unregisterOnDestroy?.()}};function $D(e,t){dn("NgSignals"),!t?.injector&&Vu($D);let n=t?.injector??S(Le),r=t?.manualCleanup!==!0?n.get(kr):null,o=new Vi(n.get(VD),e,typeof Zone>"u"?null:Zone.current,r,n,t?.allowSignalWrites??!1),i=n.get(Ns,null,{optional:!0});return!i||!(i._lView[m]&8)?o.watcher.notify():(i._lView[Zn]??=[]).push(o.watcher.notify),o}function _M(e){let t=Ne(e);if(!t)return null;let n=new Rt(t);return{get selector(){return n.selector},get type(){return n.componentType},get inputs(){return n.inputs},get outputs(){return n.outputs},get ngContentSelectors(){return n.ngContentSelectors},get isStandalone(){return t.standalone},get isSignal(){return t.signals}}}var ql=null;function Os(){return ql}function KM(e){ql??=e}var $l=class{};var Ls=new T(""),js=(()=>{let t=class t{historyGo(r){throw new Error("")}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:()=>S(UD),providedIn:"platform"});let e=t;return e})(),JM=new T(""),UD=(()=>{let t=class t extends js{constructor(){super(),this._doc=S(Ls),this._location=window.location,this._history=window.history}getBaseHrefFromDOM(){return Os().getBaseHref(this._doc)}onPopState(r){let o=Os().getGlobalEventTarget(this._doc,"window");return o.addEventListener("popstate",r,!1),()=>o.removeEventListener("popstate",r)}onHashChange(r){let o=Os().getGlobalEventTarget(this._doc,"window");return o.addEventListener("hashchange",r,!1),()=>o.removeEventListener("hashchange",r)}get href(){return this._location.href}get protocol(){return this._location.protocol}get hostname(){return this._location.hostname}get port(){return this._location.port}get pathname(){return this._location.pathname}get search(){return this._location.search}get hash(){return this._location.hash}set pathname(r){this._location.pathname=r}pushState(r,o,i){this._history.pushState(r,o,i)}replaceState(r,o,i){this._history.replaceState(r,o,i)}forward(){this._history.forward()}back(){this._history.back()}historyGo(r=0){this._history.go(r)}getState(){return this._history.state}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:()=>new t,providedIn:"platform"});let e=t;return e})();function Vs(e,t){if(e.length==0)return t;if(t.length==0)return e;let n=0;return e.endsWith("/")&&n++,t.startsWith("/")&&n++,n==2?e+t.substring(1):n==1?e+t:e+"/"+t}function Hl(e){let t=e.match(/#|\?|$/),n=t&&t.index||e.length,r=n-(e[n-1]==="/"?1:0);return e.slice(0,r)+e.slice(n)}function Me(e){return e&&e[0]!=="?"?"?"+e:e}var Gr=(()=>{let t=class t{historyGo(r){throw new Error("")}};t.\u0275fac=function(o){return new(o||t)},t.\u0275prov=O({token:t,factory:()=>S(GD),providedIn:"root"});let e=t;return e})(),Yl=new T(""),GD=(()=>{let t=class t extends Gr{constructor(r,o){super(),this._platformLocation=r,this._removeListenerFns=[],this._baseHref=o??this._platformLocation.getBaseHrefFromDOM()??S(Ls).location?.origin??""}ngOnDestroy(){for(;this._removeListenerFns.length;)this._removeListenerFns.pop()()}onPopState(r){this._removeListenerFns.push(this._platformLocation.onPopState(r),this._platformLocation.onHashChange(r))}getBaseHref(){return this._baseHref}prepareExternalUrl(r){return Vs(this._baseHref,r)}path(r=!1){let o=this._platformLocation.pathname+Me(this._platformLocation.search),i=this._platformLocation.hash;return i&&r?`${o}${i}`:o}pushState(r,o,i,s){let a=this.prepareExternalUrl(i+Me(s));this._platformLocation.pushState(r,o,a)}replaceState(r,o,i,s){let a=this.prepareExternalUrl(i+Me(s));this._platformLocation.replaceState(r,o,a)}forward(){this._platformLocation.forward()}back(){this._platformLocation.back()}getState(){return this._platformLocation.getState()}historyGo(r=0){this._platformLocation.historyGo?.(r)}};t.\u0275fac=function(o){return new(o||t)(R(js),R(Yl,8))},t.\u0275prov=O({token:t,factory:t.\u0275fac,providedIn:"root"});let e=t;return e})(),XM=(()=>{let t=class t extends Gr{constructor(r,o){super(),this._platformLocation=r,this._baseHref="",this._removeListenerFns=[],o!=null&&(this._baseHref=o)}ngOnDestroy(){for(;this._removeListenerFns.length;)this._removeListenerFns.pop()()}onPopState(r){this._removeListenerFns.push(this._platformLocation.onPopState(r),this._platformLocation.onHashChange(r))}getBaseHref(){return this._baseHref}path(r=!1){let o=this._platformLocation.hash??"#";return o.length>0?o.substring(1):o}prepareExternalUrl(r){let o=Vs(this._baseHref,r);return o.length>0?"#"+o:o}pushState(r,o,i,s){let a=this.prepareExternalUrl(i+Me(s));a.length==0&&(a=this._platformLocation.pathname),this._platformLocation.pushState(r,o,a)}replaceState(r,o,i,s){let a=this.prepareExternalUrl(i+Me(s));a.length==0&&(a=this._platformLocation.pathname),this._platformLocation.replaceState(r,o,a)}forward(){this._platformLocation.forward()}back(){this._platformLocation.back()}getState(){return this._platformLocation.getState()}historyGo(r=0){this._platformLocation.historyGo?.(r)}};t.\u0275fac=function(o){return new(o||t)(R(js),R(Yl,8))},t.\u0275prov=O({token:t,factory:t.\u0275fac});let e=t;return e})(),zD=(()=>{let t=class t{constructor(r){this._subject=new ie,this._urlChangeListeners=[],this._urlChangeSubscription=null,this._locationStrategy=r;let o=this._locationStrategy.getBaseHref();this._basePath=YD(Hl(Ul(o))),this._locationStrategy.onPopState(i=>{this._subject.emit({url:this.path(!0),pop:!0,state:i.state,type:i.type})})}ngOnDestroy(){this._urlChangeSubscription?.unsubscribe(),this._urlChangeListeners=[]}path(r=!1){return this.normalize(this._locationStrategy.path(r))}getState(){return this._locationStrategy.getState()}isCurrentPathEqualTo(r,o=""){return this.path()==this.normalize(r+Me(o))}normalize(r){return t.stripTrailingSlash(qD(this._basePath,Ul(r)))}prepareExternalUrl(r){return r&&r[0]!=="/"&&(r="/"+r),this._locationStrategy.prepareExternalUrl(r)}go(r,o="",i=null){this._locationStrategy.pushState(i,"",r,o),this._notifyUrlChangeListeners(this.prepareExternalUrl(r+Me(o)),i)}replaceState(r,o="",i=null){this._locationStrategy.replaceState(i,"",r,o),this._notifyUrlChangeListeners(this.prepareExternalUrl(r+Me(o)),i)}forward(){this._locationStrategy.forward()}back(){this._locationStrategy.back()}historyGo(r=0){this._locationStrategy.historyGo?.(r)}onUrlChange(r){return this._urlChangeListeners.push(r),this._urlChangeSubscription??=this.subscribe(o=>{this._notifyUrlChangeListeners(o.url,o.state)}),()=>{let o=this._urlChangeListeners.indexOf(r);this._urlChangeListeners.splice(o,1),this._urlChangeListeners.length===0&&(this._urlChangeSubscription?.unsubscribe(),this._urlChangeSubscription=null)}}_notifyUrlChangeListeners(r="",o){this._urlChangeListeners.forEach(i=>i(r,o))}subscribe(r,o,i){return this._subject.subscribe({next:r,error:o,complete:i})}};t.normalizeQueryParams=Me,t.joinWithSlash=Vs,t.stripTrailingSlash=Hl,t.\u0275fac=function(o){return new(o||t)(R(Gr))},t.\u0275prov=O({token:t,factory:()=>WD(),providedIn:"root"});let e=t;return e})();function WD(){return new zD(R(Gr))}function qD(e,t){if(!e||!t.startsWith(e))return t;let n=t.substring(e.length);return n===""||["/",";","?","#"].includes(n[0])?n:t}function Ul(e){return e.replace(/\/index.html$/,"")}function YD(e){if(new RegExp("^(https?:)?//").test(e)){let[,n]=e.split(/\/\/[^\/]+/);return n}return e}function ex(e,t){t=encodeURIComponent(t);for(let n of e.split(";")){let r=n.indexOf("="),[o,i]=r==-1?[n,""]:[n.slice(0,r),n.slice(r+1)];if(o.trim()===t)return decodeURIComponent(i)}return null}var Fs=class{constructor(t,n,r,o){this.$implicit=t,this.ngForOf=n,this.index=r,this.count=o}get first(){return this.index===0}get last(){return this.index===this.count-1}get even(){return this.index%2===0}get odd(){return!this.even}},tx=(()=>{let t=class t{set ngForOf(r){this._ngForOf=r,this._ngForOfDirty=!0}set ngForTrackBy(r){this._trackByFn=r}get ngForTrackBy(){return this._trackByFn}constructor(r,o,i){this._viewContainer=r,this._template=o,this._differs=i,this._ngForOf=null,this._ngForOfDirty=!0,this._differ=null}set ngForTemplate(r){r&&(this._template=r)}ngDoCheck(){if(this._ngForOfDirty){this._ngForOfDirty=!1;let r=this._ngForOf;if(!this._differ&&r)if(0)try{}catch{}else this._differ=this._differs.find(r).create(this.ngForTrackBy)}if(this._differ){let r=this._differ.diff(this._ngForOf);r&&this._applyChanges(r)}}_applyChanges(r){let o=this._viewContainer;r.forEachOperation((i,s,a)=>{if(i.previousIndex==null)o.createEmbeddedView(this._template,new Fs(i.item,this._ngForOf,-1,-1),a===null?void 0:a);else if(a==null)o.remove(s===null?void 0:s);else if(s!==null){let u=o.get(s);o.move(u,a),Gl(u,i)}});for(let i=0,s=o.length;i<s;i++){let u=o.get(i).context;u.index=i,u.count=s,u.ngForOf=this._ngForOf}r.forEachIdentityChange(i=>{let s=o.get(i.currentIndex);Gl(s,i)})}static ngTemplateContextGuard(r,o){return!0}};t.\u0275fac=function(o){return new(o||t)(_e(Bt),_e(rt),_e(As))},t.\u0275dir=Wi({type:t,selectors:[["","ngFor","","ngForOf",""]],inputs:{ngForOf:"ngForOf",ngForTrackBy:"ngForTrackBy",ngForTemplate:"ngForTemplate"},standalone:!0});let e=t;return e})();function Gl(e,t){e.context.$implicit=t.item}var nx=(()=>{let t=class t{constructor(r,o){this._viewContainer=r,this._context=new Rs,this._thenTemplateRef=null,this._elseTemplateRef=null,this._thenViewRef=null,this._elseViewRef=null,this._thenTemplateRef=o}set ngIf(r){this._context.$implicit=this._context.ngIf=r,this._updateView()}set ngIfThen(r){zl("ngIfThen",r),this._thenTemplateRef=r,this._thenViewRef=null,this._updateView()}set ngIfElse(r){zl("ngIfElse",r),this._elseTemplateRef=r,this._elseViewRef=null,this._updateView()}_updateView(){this._context.$implicit?this._thenViewRef||(this._viewContainer.clear(),this._elseViewRef=null,this._thenTemplateRef&&(this._thenViewRef=this._viewContainer.createEmbeddedView(this._thenTemplateRef,this._context))):this._elseViewRef||(this._viewContainer.clear(),this._thenViewRef=null,this._elseTemplateRef&&(this._elseViewRef=this._viewContainer.createEmbeddedView(this._elseTemplateRef,this._context)))}static ngTemplateContextGuard(r,o){return!0}};t.\u0275fac=function(o){return new(o||t)(_e(Bt),_e(rt))},t.\u0275dir=Wi({type:t,selectors:[["","ngIf",""]],inputs:{ngIf:"ngIf",ngIfThen:"ngIfThen",ngIfElse:"ngIfElse"},standalone:!0});let e=t;return e})(),Rs=class{constructor(){this.$implicit=null,this.ngIf=null}};function zl(e,t){if(!!!(!t||t.createEmbeddedView))throw new Error(`${e} must be a TemplateRef, but received '${H(t)}'.`)}var rx=(()=>{let t=class t{};t.\u0275fac=function(o){return new(o||t)},t.\u0275mod=zi({type:t}),t.\u0275inj=Bi({});let e=t;return e})(),QD="browser",ZD="server";function KD(e){return e===QD}function ox(e){return e===ZD}var ix=(()=>{let t=class t{};t.\u0275prov=O({token:t,providedIn:"root",factory:()=>KD(S(ss))?new Ps(S(Ls),window):new ks});let e=t;return e})(),Ps=class{constructor(t,n){this.document=t,this.window=n,this.offset=()=>[0,0]}setOffset(t){Array.isArray(t)?this.offset=()=>t:this.offset=t}getScrollPosition(){return[this.window.scrollX,this.window.scrollY]}scrollToPosition(t){this.window.scrollTo(t[0],t[1])}scrollToAnchor(t){let n=JD(this.document,t);n&&(this.scrollToElement(n),n.focus())}setHistoryScrollRestoration(t){this.window.history.scrollRestoration=t}scrollToElement(t){let n=t.getBoundingClientRect(),r=n.left+this.window.pageXOffset,o=n.top+this.window.pageYOffset,i=this.offset();this.window.scrollTo(r-i[0],o-i[1])}};function JD(e,t){let n=e.getElementById(t)||e.getElementsByName(t)[0];if(n)return n;if(typeof e.createTreeWalker=="function"&&e.body&&typeof e.body.attachShadow=="function"){let r=e.createTreeWalker(e.body,NodeFilter.SHOW_ELEMENT),o=r.currentNode;for(;o;){let i=o.shadowRoot;if(i){let s=i.getElementById(t)||i.querySelector(`[name="${t}"]`);if(s)return s}o=r.nextNode()}}return null}var ks=class{setOffset(t){}getScrollPosition(){return[0,0]}scrollToPosition(t){}scrollToAnchor(t){}setHistoryScrollRestoration(t){}},Wl=class{};var at=function(e){return e[e.State=0]="State",e[e.Transition=1]="Transition",e[e.Sequence=2]="Sequence",e[e.Group=3]="Group",e[e.Animate=4]="Animate",e[e.Keyframes=5]="Keyframes",e[e.Style=6]="Style",e[e.Trigger=7]="Trigger",e[e.Reference=8]="Reference",e[e.AnimateChild=9]="AnimateChild",e[e.AnimateRef=10]="AnimateRef",e[e.Query=11]="Query",e[e.Stagger=12]="Stagger",e}(at||{}),ux="*";function cx(e,t){return{type:at.Trigger,name:e,definitions:t,options:{}}}function lx(e,t=null){return{type:at.Animate,styles:t,timings:e}}function dx(e,t=null){return{type:at.Sequence,steps:e,options:t}}function fx(e){return{type:at.Style,styles:e,offset:null}}function px(e,t,n){return{type:at.State,name:e,styles:t,options:n}}function hx(e,t,n=null){return{type:at.Transition,expr:e,animation:t,options:n}}var Ql=class{constructor(t=0,n=0){this._onDoneFns=[],this._onStartFns=[],this._onDestroyFns=[],this._originalOnDoneFns=[],this._originalOnStartFns=[],this._started=!1,this._destroyed=!1,this._finished=!1,this._position=0,this.parentPlayer=null,this.totalTime=t+n}_onFinish(){this._finished||(this._finished=!0,this._onDoneFns.forEach(t=>t()),this._onDoneFns=[])}onStart(t){this._originalOnStartFns.push(t),this._onStartFns.push(t)}onDone(t){this._originalOnDoneFns.push(t),this._onDoneFns.push(t)}onDestroy(t){this._onDestroyFns.push(t)}hasStarted(){return this._started}init(){}play(){this.hasStarted()||(this._onStart(),this.triggerMicrotask()),this._started=!0}triggerMicrotask(){queueMicrotask(()=>this._onFinish())}_onStart(){this._onStartFns.forEach(t=>t()),this._onStartFns=[]}pause(){}restart(){}finish(){this._onFinish()}destroy(){this._destroyed||(this._destroyed=!0,this.hasStarted()||this._onStart(),this.finish(),this._onDestroyFns.forEach(t=>t()),this._onDestroyFns=[])}reset(){this._started=!1,this._finished=!1,this._onStartFns=this._originalOnStartFns,this._onDoneFns=this._originalOnDoneFns}setPosition(t){this._position=this.totalTime?t*this.totalTime:1}getPosition(){return this.totalTime?this._position/this.totalTime:1}triggerCallback(t){let n=t=="start"?this._onStartFns:this._onDoneFns;n.forEach(r=>r()),n.length=0}},Zl=class{constructor(t){this._onDoneFns=[],this._onStartFns=[],this._finished=!1,this._started=!1,this._destroyed=!1,this._onDestroyFns=[],this.parentPlayer=null,this.totalTime=0,this.players=t;let n=0,r=0,o=0,i=this.players.length;i==0?queueMicrotask(()=>this._onFinish()):this.players.forEach(s=>{s.onDone(()=>{++n==i&&this._onFinish()}),s.onDestroy(()=>{++r==i&&this._onDestroy()}),s.onStart(()=>{++o==i&&this._onStart()})}),this.totalTime=this.players.reduce((s,a)=>Math.max(s,a.totalTime),0)}_onFinish(){this._finished||(this._finished=!0,this._onDoneFns.forEach(t=>t()),this._onDoneFns=[])}init(){this.players.forEach(t=>t.init())}onStart(t){this._onStartFns.push(t)}_onStart(){this.hasStarted()||(this._started=!0,this._onStartFns.forEach(t=>t()),this._onStartFns=[])}onDone(t){this._onDoneFns.push(t)}onDestroy(t){this._onDestroyFns.push(t)}hasStarted(){return this._started}play(){this.parentPlayer||this.init(),this._onStart(),this.players.forEach(t=>t.play())}pause(){this.players.forEach(t=>t.pause())}restart(){this.players.forEach(t=>t.restart())}finish(){this._onFinish(),this.players.forEach(t=>t.finish())}destroy(){this._onDestroy()}_onDestroy(){this._destroyed||(this._destroyed=!0,this._onFinish(),this.players.forEach(t=>t.destroy()),this._onDestroyFns.forEach(t=>t()),this._onDestroyFns=[])}reset(){this.players.forEach(t=>t.reset()),this._destroyed=!1,this._finished=!1,this._started=!1}setPosition(t){let n=t*this.totalTime;this.players.forEach(r=>{let o=r.totalTime?Math.min(1,n/r.totalTime):1;r.setPosition(o)})}getPosition(){let t=this.players.reduce((n,r)=>n===null||r.totalTime>n.totalTime?r:n,null);return t!=null?t.getPosition():0}beforeDestroy(){this.players.forEach(t=>{t.beforeDestroy&&t.beforeDestroy()})}triggerCallback(t){let n=t=="start"?this._onStartFns:this._onDoneFns;n.forEach(r=>r()),n.length=0}},gx="!";export{xe as a,lt as b,XD as c,nd as d,L as e,pd as f,C as g,uo as h,co as i,ce as j,$t as k,vd as l,Ge as m,de as n,xd as o,Sd as p,Td as q,We as r,De as s,Ld as t,ne as u,Gt as v,It as w,Vd as x,Bd as y,go as z,qd as A,qe as B,Yd as C,wa as D,Qd as E,Zd as F,zt as G,wt as H,mo as I,Kd as J,Jd as K,tf as L,ba as M,Do as N,nf as O,rf as P,of as Q,sf as R,af as S,uf as T,cf as U,lf as V,_ as W,ve as X,pu as Y,O as Z,Bi as _,R_ as $,T as aa,b as ba,R as ca,S as da,Af as ea,Of as fa,Qt as ga,Ze as ha,P_ as ia,zi as ja,Wi as ka,k_ as la,ku as ma,Ae as na,fp as oa,Uu as pa,L_ as qa,j_ as ra,V_ as sa,B_ as ta,oh as ua,Le as va,Fe as wa,jt as xa,ie as ya,Qo as za,$_ as Aa,H_ as Ba,mh as Ca,ss as Da,U_ as Ea,G_ as Fa,cn as Ga,Mc as Ha,z_ as Ia,W_ as Ja,q_ as Ka,Y_ as La,Q_ as Ma,xc as Na,Z_ as Oa,us as Pa,Bh as Qa,K_ as Ra,dr as Sa,J_ as Ta,_e as Ua,X_ as Va,rt as Wa,gr as Xa,Ur as Ya,pi as Za,dl as _a,dn as $a,q as ab,ym as bb,Bt as cb,Um as db,Km as eb,ry as fb,_i as gb,iy as hb,_s as ib,dy as jb,hy as kb,_y as lb,My as mb,rM as nb,oM as ob,Ml as pb,xl as qb,$y as rb,Sl as sb,Tl as tb,Gy as ub,iM as vb,Yy as wb,sM as xb,aM as yb,uM as zb,Ky as Ab,cM as Bb,lM as Cb,dM as Db,fM as Eb,pM as Fb,hM as Gb,Xy as Hb,Ol as Ib,eD as Jb,gM as Kb,tD as Lb,mM as Mb,yM as Nb,DM as Ob,vM as Pb,IM as Qb,lD as Rb,dD as Sb,wM as Tb,fD as Ub,xs as Vb,hD as Wb,gD as Xb,Ss as Yb,EM as Zb,ND as _b,Ns as $b,As as ac,CM as bc,bM as cc,LD as dc,jD as ec,$D as fc,_M as gc,Os as hc,KM as ic,$l as jc,Ls as kc,JM as lc,Gr as mc,GD as nc,XM as oc,zD as pc,ex as qc,tx as rc,nx as sc,rx as tc,QD as uc,KD as vc,ox as wc,ix as xc,Wl as yc,at as zc,ux as Ac,cx as Bc,lx as Cc,dx as Dc,fx as Ec,px as Fc,hx as Gc,Ql as Hc,Zl as Ic,gx as Jc};
+var Xl = Object.defineProperty,
+    ed = Object.defineProperties;
+var td = Object.getOwnPropertyDescriptors;
+var fn = Object.getOwnPropertySymbols;
+var $s = Object.prototype.hasOwnProperty,
+    Hs = Object.prototype.propertyIsEnumerable;
+var Bs = (e, t, n) =>
+        t in e
+            ? Xl(e, t, {
+                  enumerable: !0,
+                  configurable: !0,
+                  writable: !0,
+                  value: n,
+              })
+            : (e[t] = n),
+    xe = (e, t) => {
+        for (var n in (t ||= {})) $s.call(t, n) && Bs(e, n, t[n]);
+        if (fn) for (var n of fn(t)) Hs.call(t, n) && Bs(e, n, t[n]);
+        return e;
+    },
+    lt = (e, t) => ed(e, td(t));
+var XD = (e, t) => {
+    var n = {};
+    for (var r in e) $s.call(e, r) && t.indexOf(r) < 0 && (n[r] = e[r]);
+    if (e != null && fn)
+        for (var r of fn(e)) t.indexOf(r) < 0 && Hs.call(e, r) && (n[r] = e[r]);
+    return n;
+};
+var nd = (e, t, n) =>
+    new Promise((r, o) => {
+        var i = (u) => {
+                try {
+                    a(n.next(u));
+                } catch (c) {
+                    o(c);
+                }
+            },
+            s = (u) => {
+                try {
+                    a(n.throw(u));
+                } catch (c) {
+                    o(c);
+                }
+            },
+            a = (u) =>
+                u.done ? r(u.value) : Promise.resolve(u.value).then(i, s);
+        a((n = n.apply(e, t)).next());
+    });
+var Us = null,
+    pn = !1,
+    Wr = 1,
+    gn = Symbol("SIGNAL");
+function M(e) {
+    let t = Us;
+    return (Us = e), t;
+}
+function rd() {
+    return pn;
+}
+var Yr = {
+    version: 0,
+    lastCleanEpoch: 0,
+    dirty: !1,
+    producerNode: void 0,
+    producerLastReadVersion: void 0,
+    producerIndexOfThis: void 0,
+    nextProducerIndex: 0,
+    liveConsumerNode: void 0,
+    liveConsumerIndexOfThis: void 0,
+    consumerAllowSignalWrites: !1,
+    consumerIsAlwaysLive: !1,
+    producerMustRecompute: () => !1,
+    producerRecomputeValue: () => {},
+    consumerMarkedDirty: () => {},
+    consumerOnSignalRead: () => {},
+};
+function od(e) {
+    if (!(Xr(e) && !e.dirty) && !(!e.dirty && e.lastCleanEpoch === Wr)) {
+        if (!e.producerMustRecompute(e) && !mn(e)) {
+            (e.dirty = !1), (e.lastCleanEpoch = Wr);
+            return;
+        }
+        e.producerRecomputeValue(e), (e.dirty = !1), (e.lastCleanEpoch = Wr);
+    }
+}
+function id(e) {
+    if (e.liveConsumerNode === void 0) return;
+    let t = pn;
+    pn = !0;
+    try {
+        for (let n of e.liveConsumerNode) n.dirty || Gs(n);
+    } finally {
+        pn = t;
+    }
+}
+function Gs(e) {
+    (e.dirty = !0), id(e), e.consumerMarkedDirty?.(e);
+}
+function Qr(e) {
+    return e && (e.nextProducerIndex = 0), M(e);
+}
+function Zr(e, t) {
+    if (
+        (M(t),
+        !(
+            !e ||
+            e.producerNode === void 0 ||
+            e.producerIndexOfThis === void 0 ||
+            e.producerLastReadVersion === void 0
+        ))
+    ) {
+        if (Xr(e))
+            for (let n = e.nextProducerIndex; n < e.producerNode.length; n++)
+                Jr(e.producerNode[n], e.producerIndexOfThis[n]);
+        for (; e.producerNode.length > e.nextProducerIndex; )
+            e.producerNode.pop(),
+                e.producerLastReadVersion.pop(),
+                e.producerIndexOfThis.pop();
+    }
+}
+function mn(e) {
+    hn(e);
+    for (let t = 0; t < e.producerNode.length; t++) {
+        let n = e.producerNode[t],
+            r = e.producerLastReadVersion[t];
+        if (r !== n.version || (od(n), r !== n.version)) return !0;
+    }
+    return !1;
+}
+function Kr(e) {
+    if ((hn(e), Xr(e)))
+        for (let t = 0; t < e.producerNode.length; t++)
+            Jr(e.producerNode[t], e.producerIndexOfThis[t]);
+    (e.producerNode.length =
+        e.producerLastReadVersion.length =
+        e.producerIndexOfThis.length =
+            0),
+        e.liveConsumerNode &&
+            (e.liveConsumerNode.length = e.liveConsumerIndexOfThis.length = 0);
+}
+function Jr(e, t) {
+    if ((sd(e), hn(e), e.liveConsumerNode.length === 1))
+        for (let r = 0; r < e.producerNode.length; r++)
+            Jr(e.producerNode[r], e.producerIndexOfThis[r]);
+    let n = e.liveConsumerNode.length - 1;
+    if (
+        ((e.liveConsumerNode[t] = e.liveConsumerNode[n]),
+        (e.liveConsumerIndexOfThis[t] = e.liveConsumerIndexOfThis[n]),
+        e.liveConsumerNode.length--,
+        e.liveConsumerIndexOfThis.length--,
+        t < e.liveConsumerNode.length)
+    ) {
+        let r = e.liveConsumerIndexOfThis[t],
+            o = e.liveConsumerNode[t];
+        hn(o), (o.producerIndexOfThis[r] = t);
+    }
+}
+function Xr(e) {
+    return e.consumerIsAlwaysLive || (e?.liveConsumerNode?.length ?? 0) > 0;
+}
+function hn(e) {
+    (e.producerNode ??= []),
+        (e.producerIndexOfThis ??= []),
+        (e.producerLastReadVersion ??= []);
+}
+function sd(e) {
+    (e.liveConsumerNode ??= []), (e.liveConsumerIndexOfThis ??= []);
+}
+function ad() {
+    throw new Error();
+}
+var ud = ad;
+function zs(e) {
+    ud = e;
+}
+function Ws(e, t, n) {
+    let r = Object.create(cd);
+    n && (r.consumerAllowSignalWrites = !0), (r.fn = e), (r.schedule = t);
+    let o = (u) => {
+        r.cleanupFn = u;
+    };
+    function i(u) {
+        return u.fn === null && u.schedule === null;
+    }
+    function s(u) {
+        i(u) ||
+            (Kr(u),
+            u.cleanupFn(),
+            (u.fn = null),
+            (u.schedule = null),
+            (u.cleanupFn = qr));
+    }
+    let a = () => {
+        if (r.fn === null) return;
+        if (rd())
+            throw new Error(
+                "Schedulers cannot synchronously execute watches while scheduling."
+            );
+        if (((r.dirty = !1), r.hasRun && !mn(r))) return;
+        r.hasRun = !0;
+        let u = Qr(r);
+        try {
+            r.cleanupFn(), (r.cleanupFn = qr), r.fn(o);
+        } finally {
+            Zr(r, u);
+        }
+    };
+    return (
+        (r.ref = {
+            notify: () => Gs(r),
+            run: a,
+            cleanup: () => r.cleanupFn(),
+            destroy: () => s(r),
+            [gn]: r,
+        }),
+        r.ref
+    );
+}
+var qr = () => {},
+    cd = lt(xe({}, Yr), {
+        consumerIsAlwaysLive: !0,
+        consumerAllowSignalWrites: !1,
+        consumerMarkedDirty: (e) => {
+            e.schedule !== null && e.schedule(e.ref);
+        },
+        hasRun: !1,
+        cleanupFn: qr,
+    });
+function g(e) {
+    return typeof e == "function";
+}
+function dt(e) {
+    let n = e((r) => {
+        Error.call(r), (r.stack = new Error().stack);
+    });
+    return (
+        (n.prototype = Object.create(Error.prototype)),
+        (n.prototype.constructor = n),
+        n
+    );
+}
+var yn = dt(
+    (e) =>
+        function (n) {
+            e(this),
+                (this.message = n
+                    ? `${n.length} errors occurred during unsubscription:
+${n.map((r, o) => `${o + 1}) ${r.toString()}`).join(`
+  `)}`
+                    : ""),
+                (this.name = "UnsubscriptionError"),
+                (this.errors = n);
+        }
+);
+function Ve(e, t) {
+    if (e) {
+        let n = e.indexOf(t);
+        0 <= n && e.splice(n, 1);
+    }
+}
+var L = class e {
+    constructor(t) {
+        (this.initialTeardown = t),
+            (this.closed = !1),
+            (this._parentage = null),
+            (this._finalizers = null);
+    }
+    unsubscribe() {
+        let t;
+        if (!this.closed) {
+            this.closed = !0;
+            let { _parentage: n } = this;
+            if (n)
+                if (((this._parentage = null), Array.isArray(n)))
+                    for (let i of n) i.remove(this);
+                else n.remove(this);
+            let { initialTeardown: r } = this;
+            if (g(r))
+                try {
+                    r();
+                } catch (i) {
+                    t = i instanceof yn ? i.errors : [i];
+                }
+            let { _finalizers: o } = this;
+            if (o) {
+                this._finalizers = null;
+                for (let i of o)
+                    try {
+                        qs(i);
+                    } catch (s) {
+                        (t = t ?? []),
+                            s instanceof yn
+                                ? (t = [...t, ...s.errors])
+                                : t.push(s);
+                    }
+            }
+            if (t) throw new yn(t);
+        }
+    }
+    add(t) {
+        var n;
+        if (t && t !== this)
+            if (this.closed) qs(t);
+            else {
+                if (t instanceof e) {
+                    if (t.closed || t._hasParent(this)) return;
+                    t._addParent(this);
+                }
+                (this._finalizers =
+                    (n = this._finalizers) !== null && n !== void 0
+                        ? n
+                        : []).push(t);
+            }
+    }
+    _hasParent(t) {
+        let { _parentage: n } = this;
+        return n === t || (Array.isArray(n) && n.includes(t));
+    }
+    _addParent(t) {
+        let { _parentage: n } = this;
+        this._parentage = Array.isArray(n) ? (n.push(t), n) : n ? [n, t] : t;
+    }
+    _removeParent(t) {
+        let { _parentage: n } = this;
+        n === t ? (this._parentage = null) : Array.isArray(n) && Ve(n, t);
+    }
+    remove(t) {
+        let { _finalizers: n } = this;
+        n && Ve(n, t), t instanceof e && t._removeParent(this);
+    }
+};
+L.EMPTY = (() => {
+    let e = new L();
+    return (e.closed = !0), e;
+})();
+var eo = L.EMPTY;
+function Dn(e) {
+    return (
+        e instanceof L ||
+        (e && "closed" in e && g(e.remove) && g(e.add) && g(e.unsubscribe))
+    );
+}
+function qs(e) {
+    g(e) ? e() : e.unsubscribe();
+}
+var te = {
+    onUnhandledError: null,
+    onStoppedNotification: null,
+    Promise: void 0,
+    useDeprecatedSynchronousErrorHandling: !1,
+    useDeprecatedNextContext: !1,
+};
+var ft = {
+    setTimeout(e, t, ...n) {
+        let { delegate: r } = ft;
+        return r?.setTimeout
+            ? r.setTimeout(e, t, ...n)
+            : setTimeout(e, t, ...n);
+    },
+    clearTimeout(e) {
+        let { delegate: t } = ft;
+        return (t?.clearTimeout || clearTimeout)(e);
+    },
+    delegate: void 0,
+};
+function vn(e) {
+    ft.setTimeout(() => {
+        let { onUnhandledError: t } = te;
+        if (t) t(e);
+        else throw e;
+    });
+}
+function Be() {}
+var Ys = to("C", void 0, void 0);
+function Qs(e) {
+    return to("E", void 0, e);
+}
+function Zs(e) {
+    return to("N", e, void 0);
+}
+function to(e, t, n) {
+    return { kind: e, value: t, error: n };
+}
+var $e = null;
+function pt(e) {
+    if (te.useDeprecatedSynchronousErrorHandling) {
+        let t = !$e;
+        if ((t && ($e = { errorThrown: !1, error: null }), e(), t)) {
+            let { errorThrown: n, error: r } = $e;
+            if ((($e = null), n)) throw r;
+        }
+    } else e();
+}
+function Ks(e) {
+    te.useDeprecatedSynchronousErrorHandling &&
+        $e &&
+        (($e.errorThrown = !0), ($e.error = e));
+}
+var He = class extends L {
+        constructor(t) {
+            super(),
+                (this.isStopped = !1),
+                t
+                    ? ((this.destination = t), Dn(t) && t.add(this))
+                    : (this.destination = fd);
+        }
+        static create(t, n, r) {
+            return new ye(t, n, r);
+        }
+        next(t) {
+            this.isStopped ? ro(Zs(t), this) : this._next(t);
+        }
+        error(t) {
+            this.isStopped
+                ? ro(Qs(t), this)
+                : ((this.isStopped = !0), this._error(t));
+        }
+        complete() {
+            this.isStopped
+                ? ro(Ys, this)
+                : ((this.isStopped = !0), this._complete());
+        }
+        unsubscribe() {
+            this.closed ||
+                ((this.isStopped = !0),
+                super.unsubscribe(),
+                (this.destination = null));
+        }
+        _next(t) {
+            this.destination.next(t);
+        }
+        _error(t) {
+            try {
+                this.destination.error(t);
+            } finally {
+                this.unsubscribe();
+            }
+        }
+        _complete() {
+            try {
+                this.destination.complete();
+            } finally {
+                this.unsubscribe();
+            }
+        }
+    },
+    ld = Function.prototype.bind;
+function no(e, t) {
+    return ld.call(e, t);
+}
+var oo = class {
+        constructor(t) {
+            this.partialObserver = t;
+        }
+        next(t) {
+            let { partialObserver: n } = this;
+            if (n.next)
+                try {
+                    n.next(t);
+                } catch (r) {
+                    In(r);
+                }
+        }
+        error(t) {
+            let { partialObserver: n } = this;
+            if (n.error)
+                try {
+                    n.error(t);
+                } catch (r) {
+                    In(r);
+                }
+            else In(t);
+        }
+        complete() {
+            let { partialObserver: t } = this;
+            if (t.complete)
+                try {
+                    t.complete();
+                } catch (n) {
+                    In(n);
+                }
+        }
+    },
+    ye = class extends He {
+        constructor(t, n, r) {
+            super();
+            let o;
+            if (g(t) || !t)
+                o = {
+                    next: t ?? void 0,
+                    error: n ?? void 0,
+                    complete: r ?? void 0,
+                };
+            else {
+                let i;
+                this && te.useDeprecatedNextContext
+                    ? ((i = Object.create(t)),
+                      (i.unsubscribe = () => this.unsubscribe()),
+                      (o = {
+                          next: t.next && no(t.next, i),
+                          error: t.error && no(t.error, i),
+                          complete: t.complete && no(t.complete, i),
+                      }))
+                    : (o = t);
+            }
+            this.destination = new oo(o);
+        }
+    };
+function In(e) {
+    te.useDeprecatedSynchronousErrorHandling ? Ks(e) : vn(e);
+}
+function dd(e) {
+    throw e;
+}
+function ro(e, t) {
+    let { onStoppedNotification: n } = te;
+    n && ft.setTimeout(() => n(e, t));
+}
+var fd = { closed: !0, next: Be, error: dd, complete: Be };
+var ht = (typeof Symbol == "function" && Symbol.observable) || "@@observable";
+function B(e) {
+    return e;
+}
+function pd(...e) {
+    return io(e);
+}
+function io(e) {
+    return e.length === 0
+        ? B
+        : e.length === 1
+          ? e[0]
+          : function (n) {
+                return e.reduce((r, o) => o(r), n);
+            };
+}
+var C = (() => {
+    class e {
+        constructor(n) {
+            n && (this._subscribe = n);
+        }
+        lift(n) {
+            let r = new e();
+            return (r.source = this), (r.operator = n), r;
+        }
+        subscribe(n, r, o) {
+            let i = gd(n) ? n : new ye(n, r, o);
+            return (
+                pt(() => {
+                    let { operator: s, source: a } = this;
+                    i.add(
+                        s
+                            ? s.call(i, a)
+                            : a
+                              ? this._subscribe(i)
+                              : this._trySubscribe(i)
+                    );
+                }),
+                i
+            );
+        }
+        _trySubscribe(n) {
+            try {
+                return this._subscribe(n);
+            } catch (r) {
+                n.error(r);
+            }
+        }
+        forEach(n, r) {
+            return (
+                (r = Js(r)),
+                new r((o, i) => {
+                    let s = new ye({
+                        next: (a) => {
+                            try {
+                                n(a);
+                            } catch (u) {
+                                i(u), s.unsubscribe();
+                            }
+                        },
+                        error: i,
+                        complete: o,
+                    });
+                    this.subscribe(s);
+                })
+            );
+        }
+        _subscribe(n) {
+            var r;
+            return (r = this.source) === null || r === void 0
+                ? void 0
+                : r.subscribe(n);
+        }
+        [ht]() {
+            return this;
+        }
+        pipe(...n) {
+            return io(n)(this);
+        }
+        toPromise(n) {
+            return (
+                (n = Js(n)),
+                new n((r, o) => {
+                    let i;
+                    this.subscribe(
+                        (s) => (i = s),
+                        (s) => o(s),
+                        () => r(i)
+                    );
+                })
+            );
+        }
+    }
+    return (e.create = (t) => new e(t)), e;
+})();
+function Js(e) {
+    var t;
+    return (t = e ?? te.Promise) !== null && t !== void 0 ? t : Promise;
+}
+function hd(e) {
+    return e && g(e.next) && g(e.error) && g(e.complete);
+}
+function gd(e) {
+    return (e && e instanceof He) || (hd(e) && Dn(e));
+}
+function so(e) {
+    return g(e?.lift);
+}
+function D(e) {
+    return (t) => {
+        if (so(t))
+            return t.lift(function (n) {
+                try {
+                    return e(n, this);
+                } catch (r) {
+                    this.error(r);
+                }
+            });
+        throw new TypeError("Unable to lift unknown Observable type");
+    };
+}
+function y(e, t, n, r, o) {
+    return new ao(e, t, n, r, o);
+}
+var ao = class extends He {
+    constructor(t, n, r, o, i, s) {
+        super(t),
+            (this.onFinalize = i),
+            (this.shouldUnsubscribe = s),
+            (this._next = n
+                ? function (a) {
+                      try {
+                          n(a);
+                      } catch (u) {
+                          t.error(u);
+                      }
+                  }
+                : super._next),
+            (this._error = o
+                ? function (a) {
+                      try {
+                          o(a);
+                      } catch (u) {
+                          t.error(u);
+                      } finally {
+                          this.unsubscribe();
+                      }
+                  }
+                : super._error),
+            (this._complete = r
+                ? function () {
+                      try {
+                          r();
+                      } catch (a) {
+                          t.error(a);
+                      } finally {
+                          this.unsubscribe();
+                      }
+                  }
+                : super._complete);
+    }
+    unsubscribe() {
+        var t;
+        if (!this.shouldUnsubscribe || this.shouldUnsubscribe()) {
+            let { closed: n } = this;
+            super.unsubscribe(),
+                !n &&
+                    ((t = this.onFinalize) === null ||
+                        t === void 0 ||
+                        t.call(this));
+        }
+    }
+};
+function uo() {
+    return D((e, t) => {
+        let n = null;
+        e._refCount++;
+        let r = y(t, void 0, void 0, void 0, () => {
+            if (!e || e._refCount <= 0 || 0 < --e._refCount) {
+                n = null;
+                return;
+            }
+            let o = e._connection,
+                i = n;
+            (n = null),
+                o && (!i || o === i) && o.unsubscribe(),
+                t.unsubscribe();
+        });
+        e.subscribe(r), r.closed || (n = e.connect());
+    });
+}
+var co = class extends C {
+    constructor(t, n) {
+        super(),
+            (this.source = t),
+            (this.subjectFactory = n),
+            (this._subject = null),
+            (this._refCount = 0),
+            (this._connection = null),
+            so(t) && (this.lift = t.lift);
+    }
+    _subscribe(t) {
+        return this.getSubject().subscribe(t);
+    }
+    getSubject() {
+        let t = this._subject;
+        return (
+            (!t || t.isStopped) && (this._subject = this.subjectFactory()),
+            this._subject
+        );
+    }
+    _teardown() {
+        this._refCount = 0;
+        let { _connection: t } = this;
+        (this._subject = this._connection = null), t?.unsubscribe();
+    }
+    connect() {
+        let t = this._connection;
+        if (!t) {
+            t = this._connection = new L();
+            let n = this.getSubject();
+            t.add(
+                this.source.subscribe(
+                    y(
+                        n,
+                        void 0,
+                        () => {
+                            this._teardown(), n.complete();
+                        },
+                        (r) => {
+                            this._teardown(), n.error(r);
+                        },
+                        () => this._teardown()
+                    )
+                )
+            ),
+                t.closed && ((this._connection = null), (t = L.EMPTY));
+        }
+        return t;
+    }
+    refCount() {
+        return uo()(this);
+    }
+};
+var Xs = dt(
+    (e) =>
+        function () {
+            e(this),
+                (this.name = "ObjectUnsubscribedError"),
+                (this.message = "object unsubscribed");
+        }
+);
+var ce = (() => {
+        class e extends C {
+            constructor() {
+                super(),
+                    (this.closed = !1),
+                    (this.currentObservers = null),
+                    (this.observers = []),
+                    (this.isStopped = !1),
+                    (this.hasError = !1),
+                    (this.thrownError = null);
+            }
+            lift(n) {
+                let r = new wn(this, this);
+                return (r.operator = n), r;
+            }
+            _throwIfClosed() {
+                if (this.closed) throw new Xs();
+            }
+            next(n) {
+                pt(() => {
+                    if ((this._throwIfClosed(), !this.isStopped)) {
+                        this.currentObservers ||
+                            (this.currentObservers = Array.from(
+                                this.observers
+                            ));
+                        for (let r of this.currentObservers) r.next(n);
+                    }
+                });
+            }
+            error(n) {
+                pt(() => {
+                    if ((this._throwIfClosed(), !this.isStopped)) {
+                        (this.hasError = this.isStopped = !0),
+                            (this.thrownError = n);
+                        let { observers: r } = this;
+                        for (; r.length; ) r.shift().error(n);
+                    }
+                });
+            }
+            complete() {
+                pt(() => {
+                    if ((this._throwIfClosed(), !this.isStopped)) {
+                        this.isStopped = !0;
+                        let { observers: n } = this;
+                        for (; n.length; ) n.shift().complete();
+                    }
+                });
+            }
+            unsubscribe() {
+                (this.isStopped = this.closed = !0),
+                    (this.observers = this.currentObservers = null);
+            }
+            get observed() {
+                var n;
+                return (
+                    ((n = this.observers) === null || n === void 0
+                        ? void 0
+                        : n.length) > 0
+                );
+            }
+            _trySubscribe(n) {
+                return this._throwIfClosed(), super._trySubscribe(n);
+            }
+            _subscribe(n) {
+                return (
+                    this._throwIfClosed(),
+                    this._checkFinalizedStatuses(n),
+                    this._innerSubscribe(n)
+                );
+            }
+            _innerSubscribe(n) {
+                let { hasError: r, isStopped: o, observers: i } = this;
+                return r || o
+                    ? eo
+                    : ((this.currentObservers = null),
+                      i.push(n),
+                      new L(() => {
+                          (this.currentObservers = null), Ve(i, n);
+                      }));
+            }
+            _checkFinalizedStatuses(n) {
+                let { hasError: r, thrownError: o, isStopped: i } = this;
+                r ? n.error(o) : i && n.complete();
+            }
+            asObservable() {
+                let n = new C();
+                return (n.source = this), n;
+            }
+        }
+        return (e.create = (t, n) => new wn(t, n)), e;
+    })(),
+    wn = class extends ce {
+        constructor(t, n) {
+            super(), (this.destination = t), (this.source = n);
+        }
+        next(t) {
+            var n, r;
+            (r =
+                (n = this.destination) === null || n === void 0
+                    ? void 0
+                    : n.next) === null ||
+                r === void 0 ||
+                r.call(n, t);
+        }
+        error(t) {
+            var n, r;
+            (r =
+                (n = this.destination) === null || n === void 0
+                    ? void 0
+                    : n.error) === null ||
+                r === void 0 ||
+                r.call(n, t);
+        }
+        complete() {
+            var t, n;
+            (n =
+                (t = this.destination) === null || t === void 0
+                    ? void 0
+                    : t.complete) === null ||
+                n === void 0 ||
+                n.call(t);
+        }
+        _subscribe(t) {
+            var n, r;
+            return (r =
+                (n = this.source) === null || n === void 0
+                    ? void 0
+                    : n.subscribe(t)) !== null && r !== void 0
+                ? r
+                : eo;
+        }
+    };
+var $t = class extends ce {
+    constructor(t) {
+        super(), (this._value = t);
+    }
+    get value() {
+        return this.getValue();
+    }
+    _subscribe(t) {
+        let n = super._subscribe(t);
+        return !n.closed && t.next(this._value), n;
+    }
+    getValue() {
+        let { hasError: t, thrownError: n, _value: r } = this;
+        if (t) throw n;
+        return this._throwIfClosed(), r;
+    }
+    next(t) {
+        super.next((this._value = t));
+    }
+};
+var lo = {
+    now() {
+        return (lo.delegate || Date).now();
+    },
+    delegate: void 0,
+};
+var En = class extends L {
+    constructor(t, n) {
+        super();
+    }
+    schedule(t, n = 0) {
+        return this;
+    }
+};
+var Ht = {
+    setInterval(e, t, ...n) {
+        let { delegate: r } = Ht;
+        return r?.setInterval
+            ? r.setInterval(e, t, ...n)
+            : setInterval(e, t, ...n);
+    },
+    clearInterval(e) {
+        let { delegate: t } = Ht;
+        return (t?.clearInterval || clearInterval)(e);
+    },
+    delegate: void 0,
+};
+var gt = class extends En {
+    constructor(t, n) {
+        super(t, n), (this.scheduler = t), (this.work = n), (this.pending = !1);
+    }
+    schedule(t, n = 0) {
+        var r;
+        if (this.closed) return this;
+        this.state = t;
+        let o = this.id,
+            i = this.scheduler;
+        return (
+            o != null && (this.id = this.recycleAsyncId(i, o, n)),
+            (this.pending = !0),
+            (this.delay = n),
+            (this.id =
+                (r = this.id) !== null && r !== void 0
+                    ? r
+                    : this.requestAsyncId(i, this.id, n)),
+            this
+        );
+    }
+    requestAsyncId(t, n, r = 0) {
+        return Ht.setInterval(t.flush.bind(t, this), r);
+    }
+    recycleAsyncId(t, n, r = 0) {
+        if (r != null && this.delay === r && this.pending === !1) return n;
+        n != null && Ht.clearInterval(n);
+    }
+    execute(t, n) {
+        if (this.closed) return new Error("executing a cancelled action");
+        this.pending = !1;
+        let r = this._execute(t, n);
+        if (r) return r;
+        this.pending === !1 &&
+            this.id != null &&
+            (this.id = this.recycleAsyncId(this.scheduler, this.id, null));
+    }
+    _execute(t, n) {
+        let r = !1,
+            o;
+        try {
+            this.work(t);
+        } catch (i) {
+            (r = !0),
+                (o = i || new Error("Scheduled action threw falsy error"));
+        }
+        if (r) return this.unsubscribe(), o;
+    }
+    unsubscribe() {
+        if (!this.closed) {
+            let { id: t, scheduler: n } = this,
+                { actions: r } = n;
+            (this.work = this.state = this.scheduler = null),
+                (this.pending = !1),
+                Ve(r, this),
+                t != null && (this.id = this.recycleAsyncId(n, t, null)),
+                (this.delay = null),
+                super.unsubscribe();
+        }
+    }
+};
+var md = 1,
+    fo,
+    po = {};
+function ea(e) {
+    return e in po ? (delete po[e], !0) : !1;
+}
+var ta = {
+    setImmediate(e) {
+        let t = md++;
+        return (
+            (po[t] = !0),
+            fo || (fo = Promise.resolve()),
+            fo.then(() => ea(t) && e()),
+            t
+        );
+    },
+    clearImmediate(e) {
+        ea(e);
+    },
+};
+var { setImmediate: yd, clearImmediate: Dd } = ta,
+    Ut = {
+        setImmediate(...e) {
+            let { delegate: t } = Ut;
+            return (t?.setImmediate || yd)(...e);
+        },
+        clearImmediate(e) {
+            let { delegate: t } = Ut;
+            return (t?.clearImmediate || Dd)(e);
+        },
+        delegate: void 0,
+    };
+var Cn = class extends gt {
+    constructor(t, n) {
+        super(t, n), (this.scheduler = t), (this.work = n);
+    }
+    requestAsyncId(t, n, r = 0) {
+        return r !== null && r > 0
+            ? super.requestAsyncId(t, n, r)
+            : (t.actions.push(this),
+              t._scheduled ||
+                  (t._scheduled = Ut.setImmediate(t.flush.bind(t, void 0))));
+    }
+    recycleAsyncId(t, n, r = 0) {
+        var o;
+        if (r != null ? r > 0 : this.delay > 0)
+            return super.recycleAsyncId(t, n, r);
+        let { actions: i } = t;
+        n != null &&
+            ((o = i[i.length - 1]) === null || o === void 0 ? void 0 : o.id) !==
+                n &&
+            (Ut.clearImmediate(n),
+            t._scheduled === n && (t._scheduled = void 0));
+    }
+};
+var mt = class e {
+    constructor(t, n = e.now) {
+        (this.schedulerActionCtor = t), (this.now = n);
+    }
+    schedule(t, n = 0, r) {
+        return new this.schedulerActionCtor(this, t).schedule(r, n);
+    }
+};
+mt.now = lo.now;
+var yt = class extends mt {
+    constructor(t, n = mt.now) {
+        super(t, n), (this.actions = []), (this._active = !1);
+    }
+    flush(t) {
+        let { actions: n } = this;
+        if (this._active) {
+            n.push(t);
+            return;
+        }
+        let r;
+        this._active = !0;
+        do if ((r = t.execute(t.state, t.delay))) break;
+        while ((t = n.shift()));
+        if (((this._active = !1), r)) {
+            for (; (t = n.shift()); ) t.unsubscribe();
+            throw r;
+        }
+    }
+};
+var bn = class extends yt {
+    flush(t) {
+        this._active = !0;
+        let n = this._scheduled;
+        this._scheduled = void 0;
+        let { actions: r } = this,
+            o;
+        t = t || r.shift();
+        do if ((o = t.execute(t.state, t.delay))) break;
+        while ((t = r[0]) && t.id === n && r.shift());
+        if (((this._active = !1), o)) {
+            for (; (t = r[0]) && t.id === n && r.shift(); ) t.unsubscribe();
+            throw o;
+        }
+    }
+};
+var vd = new bn(Cn);
+var Ue = new yt(gt),
+    na = Ue;
+var Ge = new C((e) => e.complete());
+function _n(e) {
+    return e && g(e.schedule);
+}
+function ho(e) {
+    return e[e.length - 1];
+}
+function Mn(e) {
+    return g(ho(e)) ? e.pop() : void 0;
+}
+function le(e) {
+    return _n(ho(e)) ? e.pop() : void 0;
+}
+function ra(e, t) {
+    return typeof ho(e) == "number" ? e.pop() : t;
+}
+function ia(e, t, n, r) {
+    function o(i) {
+        return i instanceof n
+            ? i
+            : new n(function (s) {
+                  s(i);
+              });
+    }
+    return new (n || (n = Promise))(function (i, s) {
+        function a(l) {
+            try {
+                c(r.next(l));
+            } catch (d) {
+                s(d);
+            }
+        }
+        function u(l) {
+            try {
+                c(r.throw(l));
+            } catch (d) {
+                s(d);
+            }
+        }
+        function c(l) {
+            l.done ? i(l.value) : o(l.value).then(a, u);
+        }
+        c((r = r.apply(e, t || [])).next());
+    });
+}
+function oa(e) {
+    var t = typeof Symbol == "function" && Symbol.iterator,
+        n = t && e[t],
+        r = 0;
+    if (n) return n.call(e);
+    if (e && typeof e.length == "number")
+        return {
+            next: function () {
+                return (
+                    e && r >= e.length && (e = void 0),
+                    { value: e && e[r++], done: !e }
+                );
+            },
+        };
+    throw new TypeError(
+        t ? "Object is not iterable." : "Symbol.iterator is not defined."
+    );
+}
+function ze(e) {
+    return this instanceof ze ? ((this.v = e), this) : new ze(e);
+}
+function sa(e, t, n) {
+    if (!Symbol.asyncIterator)
+        throw new TypeError("Symbol.asyncIterator is not defined.");
+    var r = n.apply(e, t || []),
+        o,
+        i = [];
+    return (
+        (o = {}),
+        s("next"),
+        s("throw"),
+        s("return"),
+        (o[Symbol.asyncIterator] = function () {
+            return this;
+        }),
+        o
+    );
+    function s(f) {
+        r[f] &&
+            (o[f] = function (p) {
+                return new Promise(function (h, w) {
+                    i.push([f, p, h, w]) > 1 || a(f, p);
+                });
+            });
+    }
+    function a(f, p) {
+        try {
+            u(r[f](p));
+        } catch (h) {
+            d(i[0][3], h);
+        }
+    }
+    function u(f) {
+        f.value instanceof ze
+            ? Promise.resolve(f.value.v).then(c, l)
+            : d(i[0][2], f);
+    }
+    function c(f) {
+        a("next", f);
+    }
+    function l(f) {
+        a("throw", f);
+    }
+    function d(f, p) {
+        f(p), i.shift(), i.length && a(i[0][0], i[0][1]);
+    }
+}
+function aa(e) {
+    if (!Symbol.asyncIterator)
+        throw new TypeError("Symbol.asyncIterator is not defined.");
+    var t = e[Symbol.asyncIterator],
+        n;
+    return t
+        ? t.call(e)
+        : ((e = typeof oa == "function" ? oa(e) : e[Symbol.iterator]()),
+          (n = {}),
+          r("next"),
+          r("throw"),
+          r("return"),
+          (n[Symbol.asyncIterator] = function () {
+              return this;
+          }),
+          n);
+    function r(i) {
+        n[i] =
+            e[i] &&
+            function (s) {
+                return new Promise(function (a, u) {
+                    (s = e[i](s)), o(a, u, s.done, s.value);
+                });
+            };
+    }
+    function o(i, s, a, u) {
+        Promise.resolve(u).then(function (c) {
+            i({ value: c, done: a });
+        }, s);
+    }
+}
+var Dt = (e) => e && typeof e.length == "number" && typeof e != "function";
+function xn(e) {
+    return g(e?.then);
+}
+function Sn(e) {
+    return g(e[ht]);
+}
+function Tn(e) {
+    return Symbol.asyncIterator && g(e?.[Symbol.asyncIterator]);
+}
+function Nn(e) {
+    return new TypeError(
+        `You provided ${e !== null && typeof e == "object" ? "an invalid object" : `'${e}'`} where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.`
+    );
+}
+function Id() {
+    return typeof Symbol != "function" || !Symbol.iterator
+        ? "@@iterator"
+        : Symbol.iterator;
+}
+var An = Id();
+function On(e) {
+    return g(e?.[An]);
+}
+function Fn(e) {
+    return sa(this, arguments, function* () {
+        let n = e.getReader();
+        try {
+            for (;;) {
+                let { value: r, done: o } = yield ze(n.read());
+                if (o) return yield ze(void 0);
+                yield yield ze(r);
+            }
+        } finally {
+            n.releaseLock();
+        }
+    });
+}
+function Rn(e) {
+    return g(e?.getReader);
+}
+function x(e) {
+    if (e instanceof C) return e;
+    if (e != null) {
+        if (Sn(e)) return wd(e);
+        if (Dt(e)) return Ed(e);
+        if (xn(e)) return Cd(e);
+        if (Tn(e)) return ua(e);
+        if (On(e)) return bd(e);
+        if (Rn(e)) return _d(e);
+    }
+    throw Nn(e);
+}
+function wd(e) {
+    return new C((t) => {
+        let n = e[ht]();
+        if (g(n.subscribe)) return n.subscribe(t);
+        throw new TypeError(
+            "Provided object does not correctly implement Symbol.observable"
+        );
+    });
+}
+function Ed(e) {
+    return new C((t) => {
+        for (let n = 0; n < e.length && !t.closed; n++) t.next(e[n]);
+        t.complete();
+    });
+}
+function Cd(e) {
+    return new C((t) => {
+        e.then(
+            (n) => {
+                t.closed || (t.next(n), t.complete());
+            },
+            (n) => t.error(n)
+        ).then(null, vn);
+    });
+}
+function bd(e) {
+    return new C((t) => {
+        for (let n of e) if ((t.next(n), t.closed)) return;
+        t.complete();
+    });
+}
+function ua(e) {
+    return new C((t) => {
+        Md(e, t).catch((n) => t.error(n));
+    });
+}
+function _d(e) {
+    return ua(Fn(e));
+}
+function Md(e, t) {
+    var n, r, o, i;
+    return ia(this, void 0, void 0, function* () {
+        try {
+            for (n = aa(e); (r = yield n.next()), !r.done; ) {
+                let s = r.value;
+                if ((t.next(s), t.closed)) return;
+            }
+        } catch (s) {
+            o = { error: s };
+        } finally {
+            try {
+                r && !r.done && (i = n.return) && (yield i.call(n));
+            } finally {
+                if (o) throw o.error;
+            }
+        }
+        t.complete();
+    });
+}
+function G(e, t, n, r = 0, o = !1) {
+    let i = t.schedule(function () {
+        n(), o ? e.add(this.schedule(null, r)) : this.unsubscribe();
+    }, r);
+    if ((e.add(i), !o)) return i;
+}
+function Pn(e, t = 0) {
+    return D((n, r) => {
+        n.subscribe(
+            y(
+                r,
+                (o) => G(r, e, () => r.next(o), t),
+                () => G(r, e, () => r.complete(), t),
+                (o) => G(r, e, () => r.error(o), t)
+            )
+        );
+    });
+}
+function kn(e, t = 0) {
+    return D((n, r) => {
+        r.add(e.schedule(() => n.subscribe(r), t));
+    });
+}
+function ca(e, t) {
+    return x(e).pipe(kn(t), Pn(t));
+}
+function la(e, t) {
+    return x(e).pipe(kn(t), Pn(t));
+}
+function da(e, t) {
+    return new C((n) => {
+        let r = 0;
+        return t.schedule(function () {
+            r === e.length
+                ? n.complete()
+                : (n.next(e[r++]), n.closed || this.schedule());
+        });
+    });
+}
+function fa(e, t) {
+    return new C((n) => {
+        let r;
+        return (
+            G(n, t, () => {
+                (r = e[An]()),
+                    G(
+                        n,
+                        t,
+                        () => {
+                            let o, i;
+                            try {
+                                ({ value: o, done: i } = r.next());
+                            } catch (s) {
+                                n.error(s);
+                                return;
+                            }
+                            i ? n.complete() : n.next(o);
+                        },
+                        0,
+                        !0
+                    );
+            }),
+            () => g(r?.return) && r.return()
+        );
+    });
+}
+function Ln(e, t) {
+    if (!e) throw new Error("Iterable cannot be null");
+    return new C((n) => {
+        G(n, t, () => {
+            let r = e[Symbol.asyncIterator]();
+            G(
+                n,
+                t,
+                () => {
+                    r.next().then((o) => {
+                        o.done ? n.complete() : n.next(o.value);
+                    });
+                },
+                0,
+                !0
+            );
+        });
+    });
+}
+function pa(e, t) {
+    return Ln(Fn(e), t);
+}
+function ha(e, t) {
+    if (e != null) {
+        if (Sn(e)) return ca(e, t);
+        if (Dt(e)) return da(e, t);
+        if (xn(e)) return la(e, t);
+        if (Tn(e)) return Ln(e, t);
+        if (On(e)) return fa(e, t);
+        if (Rn(e)) return pa(e, t);
+    }
+    throw Nn(e);
+}
+function de(e, t) {
+    return t ? ha(e, t) : x(e);
+}
+function xd(...e) {
+    let t = le(e);
+    return de(e, t);
+}
+function Sd(e, t) {
+    let n = g(e) ? e : () => e,
+        r = (o) => o.error(n());
+    return new C(t ? (o) => t.schedule(r, 0, o) : r);
+}
+function Td(e) {
+    return !!e && (e instanceof C || (g(e.lift) && g(e.subscribe)));
+}
+var We = dt(
+    (e) =>
+        function () {
+            e(this),
+                (this.name = "EmptyError"),
+                (this.message = "no elements in sequence");
+        }
+);
+function ga(e) {
+    return e instanceof Date && !isNaN(e);
+}
+function De(e, t) {
+    return D((n, r) => {
+        let o = 0;
+        n.subscribe(
+            y(r, (i) => {
+                r.next(e.call(t, i, o++));
+            })
+        );
+    });
+}
+var { isArray: Nd } = Array;
+function Ad(e, t) {
+    return Nd(t) ? e(...t) : e(t);
+}
+function vt(e) {
+    return De((t) => Ad(e, t));
+}
+var { isArray: Od } = Array,
+    { getPrototypeOf: Fd, prototype: Rd, keys: Pd } = Object;
+function jn(e) {
+    if (e.length === 1) {
+        let t = e[0];
+        if (Od(t)) return { args: t, keys: null };
+        if (kd(t)) {
+            let n = Pd(t);
+            return { args: n.map((r) => t[r]), keys: n };
+        }
+    }
+    return { args: e, keys: null };
+}
+function kd(e) {
+    return e && typeof e == "object" && Fd(e) === Rd;
+}
+function Vn(e, t) {
+    return e.reduce((n, r, o) => ((n[r] = t[o]), n), {});
+}
+function Ld(...e) {
+    let t = le(e),
+        n = Mn(e),
+        { args: r, keys: o } = jn(e);
+    if (r.length === 0) return de([], t);
+    let i = new C(jd(r, t, o ? (s) => Vn(o, s) : B));
+    return n ? i.pipe(vt(n)) : i;
+}
+function jd(e, t, n = B) {
+    return (r) => {
+        ma(
+            t,
+            () => {
+                let { length: o } = e,
+                    i = new Array(o),
+                    s = o,
+                    a = o;
+                for (let u = 0; u < o; u++)
+                    ma(
+                        t,
+                        () => {
+                            let c = de(e[u], t),
+                                l = !1;
+                            c.subscribe(
+                                y(
+                                    r,
+                                    (d) => {
+                                        (i[u] = d),
+                                            l || ((l = !0), a--),
+                                            a || r.next(n(i.slice()));
+                                    },
+                                    () => {
+                                        --s || r.complete();
+                                    }
+                                )
+                            );
+                        },
+                        r
+                    );
+            },
+            r
+        );
+    };
+}
+function ma(e, t, n) {
+    e ? G(n, e, t) : t();
+}
+function ya(e, t, n, r, o, i, s, a) {
+    let u = [],
+        c = 0,
+        l = 0,
+        d = !1,
+        f = () => {
+            d && !u.length && !c && t.complete();
+        },
+        p = (w) => (c < r ? h(w) : u.push(w)),
+        h = (w) => {
+            i && t.next(w), c++;
+            let k = !1;
+            x(n(w, l++)).subscribe(
+                y(
+                    t,
+                    (N) => {
+                        o?.(N), i ? p(N) : t.next(N);
+                    },
+                    () => {
+                        k = !0;
+                    },
+                    void 0,
+                    () => {
+                        if (k)
+                            try {
+                                for (c--; u.length && c < r; ) {
+                                    let N = u.shift();
+                                    s ? G(t, s, () => h(N)) : h(N);
+                                }
+                                f();
+                            } catch (N) {
+                                t.error(N);
+                            }
+                    }
+                )
+            );
+        };
+    return (
+        e.subscribe(
+            y(t, p, () => {
+                (d = !0), f();
+            })
+        ),
+        () => {
+            a?.();
+        }
+    );
+}
+function ne(e, t, n = 1 / 0) {
+    return g(t)
+        ? ne((r, o) => De((i, s) => t(r, i, o, s))(x(e(r, o))), n)
+        : (typeof t == "number" && (n = t), D((r, o) => ya(r, o, e, n)));
+}
+function Gt(e = 1 / 0) {
+    return ne(B, e);
+}
+function Da() {
+    return Gt(1);
+}
+function It(...e) {
+    return Da()(de(e, le(e)));
+}
+function Vd(e) {
+    return new C((t) => {
+        x(e()).subscribe(t);
+    });
+}
+function Bd(...e) {
+    let t = Mn(e),
+        { args: n, keys: r } = jn(e),
+        o = new C((i) => {
+            let { length: s } = n;
+            if (!s) {
+                i.complete();
+                return;
+            }
+            let a = new Array(s),
+                u = s,
+                c = s;
+            for (let l = 0; l < s; l++) {
+                let d = !1;
+                x(n[l]).subscribe(
+                    y(
+                        i,
+                        (f) => {
+                            d || ((d = !0), c--), (a[l] = f);
+                        },
+                        () => u--,
+                        void 0,
+                        () => {
+                            (!u || !d) &&
+                                (c || i.next(r ? Vn(r, a) : a), i.complete());
+                        }
+                    )
+                );
+            }
+        });
+    return t ? o.pipe(vt(t)) : o;
+}
+var $d = ["addListener", "removeListener"],
+    Hd = ["addEventListener", "removeEventListener"],
+    Ud = ["on", "off"];
+function go(e, t, n, r) {
+    if ((g(n) && ((r = n), (n = void 0)), r)) return go(e, t, n).pipe(vt(r));
+    let [o, i] = Wd(e)
+        ? Hd.map((s) => (a) => e[s](t, a, n))
+        : Gd(e)
+          ? $d.map(va(e, t))
+          : zd(e)
+            ? Ud.map(va(e, t))
+            : [];
+    if (!o && Dt(e)) return ne((s) => go(s, t, n))(x(e));
+    if (!o) throw new TypeError("Invalid event target");
+    return new C((s) => {
+        let a = (...u) => s.next(1 < u.length ? u : u[0]);
+        return o(a), () => i(a);
+    });
+}
+function va(e, t) {
+    return (n) => (r) => e[n](t, r);
+}
+function Gd(e) {
+    return g(e.addListener) && g(e.removeListener);
+}
+function zd(e) {
+    return g(e.on) && g(e.off);
+}
+function Wd(e) {
+    return g(e.addEventListener) && g(e.removeEventListener);
+}
+function Bn(e = 0, t, n = na) {
+    let r = -1;
+    return (
+        t != null && (_n(t) ? (n = t) : (r = t)),
+        new C((o) => {
+            let i = ga(e) ? +e - n.now() : e;
+            i < 0 && (i = 0);
+            let s = 0;
+            return n.schedule(function () {
+                o.closed ||
+                    (o.next(s++),
+                    0 <= r ? this.schedule(void 0, r) : o.complete());
+            }, i);
+        })
+    );
+}
+function qd(...e) {
+    let t = le(e),
+        n = ra(e, 1 / 0),
+        r = e;
+    return r.length ? (r.length === 1 ? x(r[0]) : Gt(n)(de(r, t))) : Ge;
+}
+function qe(e, t) {
+    return D((n, r) => {
+        let o = 0;
+        n.subscribe(y(r, (i) => e.call(t, i, o++) && r.next(i)));
+    });
+}
+function Ia(e) {
+    return D((t, n) => {
+        let r = !1,
+            o = null,
+            i = null,
+            s = !1,
+            a = () => {
+                if ((i?.unsubscribe(), (i = null), r)) {
+                    r = !1;
+                    let c = o;
+                    (o = null), n.next(c);
+                }
+                s && n.complete();
+            },
+            u = () => {
+                (i = null), s && n.complete();
+            };
+        t.subscribe(
+            y(
+                n,
+                (c) => {
+                    (r = !0), (o = c), i || x(e(c)).subscribe((i = y(n, a, u)));
+                },
+                () => {
+                    (s = !0), (!r || !i || i.closed) && n.complete();
+                }
+            )
+        );
+    });
+}
+function Yd(e, t = Ue) {
+    return Ia(() => Bn(e, t));
+}
+function wa(e) {
+    return D((t, n) => {
+        let r = null,
+            o = !1,
+            i;
+        (r = t.subscribe(
+            y(n, void 0, void 0, (s) => {
+                (i = x(e(s, wa(e)(t)))),
+                    r
+                        ? (r.unsubscribe(), (r = null), i.subscribe(n))
+                        : (o = !0);
+            })
+        )),
+            o && (r.unsubscribe(), (r = null), i.subscribe(n));
+    });
+}
+function Ea(e, t, n, r, o) {
+    return (i, s) => {
+        let a = n,
+            u = t,
+            c = 0;
+        i.subscribe(
+            y(
+                s,
+                (l) => {
+                    let d = c++;
+                    (u = a ? e(u, l, d) : ((a = !0), l)), r && s.next(u);
+                },
+                o &&
+                    (() => {
+                        a && s.next(u), s.complete();
+                    })
+            )
+        );
+    };
+}
+function Qd(e, t) {
+    return g(t) ? ne(e, t, 1) : ne(e, 1);
+}
+function Zd(e, t = Ue) {
+    return D((n, r) => {
+        let o = null,
+            i = null,
+            s = null,
+            a = () => {
+                if (o) {
+                    o.unsubscribe(), (o = null);
+                    let c = i;
+                    (i = null), r.next(c);
+                }
+            };
+        function u() {
+            let c = s + e,
+                l = t.now();
+            if (l < c) {
+                (o = this.schedule(void 0, c - l)), r.add(o);
+                return;
+            }
+            a();
+        }
+        n.subscribe(
+            y(
+                r,
+                (c) => {
+                    (i = c),
+                        (s = t.now()),
+                        o || ((o = t.schedule(u, e)), r.add(o));
+                },
+                () => {
+                    a(), r.complete();
+                },
+                void 0,
+                () => {
+                    i = o = null;
+                }
+            )
+        );
+    });
+}
+function zt(e) {
+    return D((t, n) => {
+        let r = !1;
+        t.subscribe(
+            y(
+                n,
+                (o) => {
+                    (r = !0), n.next(o);
+                },
+                () => {
+                    r || n.next(e), n.complete();
+                }
+            )
+        );
+    });
+}
+function wt(e) {
+    return e <= 0
+        ? () => Ge
+        : D((t, n) => {
+              let r = 0;
+              t.subscribe(
+                  y(n, (o) => {
+                      ++r <= e && (n.next(o), e <= r && n.complete());
+                  })
+              );
+          });
+}
+function Ca() {
+    return D((e, t) => {
+        e.subscribe(y(t, Be));
+    });
+}
+function mo(e) {
+    return De(() => e);
+}
+function yo(e, t) {
+    return t
+        ? (n) => It(t.pipe(wt(1), Ca()), n.pipe(yo(e)))
+        : ne((n, r) => x(e(n, r)).pipe(wt(1), mo(n)));
+}
+function Kd(e, t = Ue) {
+    let n = Bn(e, t);
+    return yo(() => n);
+}
+function Jd(e, t = B) {
+    return (
+        (e = e ?? Xd),
+        D((n, r) => {
+            let o,
+                i = !0;
+            n.subscribe(
+                y(r, (s) => {
+                    let a = t(s);
+                    (i || !e(o, a)) && ((i = !1), (o = a), r.next(s));
+                })
+            );
+        })
+    );
+}
+function Xd(e, t) {
+    return e === t;
+}
+function $n(e = ef) {
+    return D((t, n) => {
+        let r = !1;
+        t.subscribe(
+            y(
+                n,
+                (o) => {
+                    (r = !0), n.next(o);
+                },
+                () => (r ? n.complete() : n.error(e()))
+            )
+        );
+    });
+}
+function ef() {
+    return new We();
+}
+function tf(e) {
+    return D((t, n) => {
+        try {
+            t.subscribe(n);
+        } finally {
+            n.add(e);
+        }
+    });
+}
+function ba(e, t) {
+    let n = arguments.length >= 2;
+    return (r) =>
+        r.pipe(
+            e ? qe((o, i) => e(o, i, r)) : B,
+            wt(1),
+            n ? zt(t) : $n(() => new We())
+        );
+}
+function Do(e) {
+    return e <= 0
+        ? () => Ge
+        : D((t, n) => {
+              let r = [];
+              t.subscribe(
+                  y(
+                      n,
+                      (o) => {
+                          r.push(o), e < r.length && r.shift();
+                      },
+                      () => {
+                          for (let o of r) n.next(o);
+                          n.complete();
+                      },
+                      void 0,
+                      () => {
+                          r = null;
+                      }
+                  )
+              );
+          });
+}
+function nf(e, t) {
+    let n = arguments.length >= 2;
+    return (r) =>
+        r.pipe(
+            e ? qe((o, i) => e(o, i, r)) : B,
+            Do(1),
+            n ? zt(t) : $n(() => new We())
+        );
+}
+function rf(e, t) {
+    return D(Ea(e, t, arguments.length >= 2, !0));
+}
+function of(e = {}) {
+    let {
+        connector: t = () => new ce(),
+        resetOnError: n = !0,
+        resetOnComplete: r = !0,
+        resetOnRefCountZero: o = !0,
+    } = e;
+    return (i) => {
+        let s,
+            a,
+            u,
+            c = 0,
+            l = !1,
+            d = !1,
+            f = () => {
+                a?.unsubscribe(), (a = void 0);
+            },
+            p = () => {
+                f(), (s = u = void 0), (l = d = !1);
+            },
+            h = () => {
+                let w = s;
+                p(), w?.unsubscribe();
+            };
+        return D((w, k) => {
+            c++, !d && !l && f();
+            let N = (u = u ?? t());
+            k.add(() => {
+                c--, c === 0 && !d && !l && (a = vo(h, o));
+            }),
+                N.subscribe(k),
+                !s &&
+                    c > 0 &&
+                    ((s = new ye({
+                        next: (Z) => N.next(Z),
+                        error: (Z) => {
+                            (d = !0), f(), (a = vo(p, n, Z)), N.error(Z);
+                        },
+                        complete: () => {
+                            (l = !0), f(), (a = vo(p, r)), N.complete();
+                        },
+                    })),
+                    x(w).subscribe(s));
+        })(i);
+    };
+}
+function vo(e, t, ...n) {
+    if (t === !0) {
+        e();
+        return;
+    }
+    if (t === !1) return;
+    let r = new ye({
+        next: () => {
+            r.unsubscribe(), e();
+        },
+    });
+    return x(t(...n)).subscribe(r);
+}
+function sf(e) {
+    return qe((t, n) => e <= n);
+}
+function af(...e) {
+    let t = le(e);
+    return D((n, r) => {
+        (t ? It(e, n, t) : It(e, n)).subscribe(r);
+    });
+}
+function uf(e, t) {
+    return D((n, r) => {
+        let o = null,
+            i = 0,
+            s = !1,
+            a = () => s && !o && r.complete();
+        n.subscribe(
+            y(
+                r,
+                (u) => {
+                    o?.unsubscribe();
+                    let c = 0,
+                        l = i++;
+                    x(e(u, l)).subscribe(
+                        (o = y(
+                            r,
+                            (d) => r.next(t ? t(u, d, l, c++) : d),
+                            () => {
+                                (o = null), a();
+                            }
+                        ))
+                    );
+                },
+                () => {
+                    (s = !0), a();
+                }
+            )
+        );
+    });
+}
+function cf(e) {
+    return D((t, n) => {
+        x(e).subscribe(y(n, () => n.complete(), Be)),
+            !n.closed && t.subscribe(n);
+    });
+}
+function lf(e, t, n) {
+    let r = g(e) || t || n ? { next: e, error: t, complete: n } : e;
+    return r
+        ? D((o, i) => {
+              var s;
+              (s = r.subscribe) === null || s === void 0 || s.call(r);
+              let a = !0;
+              o.subscribe(
+                  y(
+                      i,
+                      (u) => {
+                          var c;
+                          (c = r.next) === null || c === void 0 || c.call(r, u),
+                              i.next(u);
+                      },
+                      () => {
+                          var u;
+                          (a = !1),
+                              (u = r.complete) === null ||
+                                  u === void 0 ||
+                                  u.call(r),
+                              i.complete();
+                      },
+                      (u) => {
+                          var c;
+                          (a = !1),
+                              (c = r.error) === null ||
+                                  c === void 0 ||
+                                  c.call(r, u),
+                              i.error(u);
+                      },
+                      () => {
+                          var u, c;
+                          a &&
+                              ((u = r.unsubscribe) === null ||
+                                  u === void 0 ||
+                                  u.call(r)),
+                              (c = r.finalize) === null ||
+                                  c === void 0 ||
+                                  c.call(r);
+                      }
+                  )
+              );
+          })
+        : B;
+}
+var lu = "https://g.co/ng/security#xss",
+    _ = class extends Error {
+        constructor(t, n) {
+            super(du(t, n)), (this.code = t);
+        }
+    };
+function du(e, t) {
+    return `${`NG0${Math.abs(e)}`}${t ? ": " + t : ""}`;
+}
+function on(e) {
+    return { toString: e }.toString();
+}
+var Hn = "__parameters__";
+function df(e) {
+    return function (...n) {
+        if (e) {
+            let r = e(...n);
+            for (let o in r) this[o] = r[o];
+        }
+    };
+}
+function fu(e, t, n) {
+    return on(() => {
+        let r = df(t);
+        function o(...i) {
+            if (this instanceof o) return r.apply(this, i), this;
+            let s = new o(...i);
+            return (a.annotation = s), a;
+            function a(u, c, l) {
+                let d = u.hasOwnProperty(Hn)
+                    ? u[Hn]
+                    : Object.defineProperty(u, Hn, { value: [] })[Hn];
+                for (; d.length <= l; ) d.push(null);
+                return (d[l] = d[l] || []).push(s), u;
+            }
+        }
+        return (
+            n && (o.prototype = Object.create(n.prototype)),
+            (o.prototype.ngMetadataName = e),
+            (o.annotationCls = o),
+            o
+        );
+    });
+}
+var ve = globalThis;
+function A(e) {
+    for (let t in e) if (e[t] === A) return t;
+    throw Error("Could not find renamed property on target object.");
+}
+function ff(e, t) {
+    for (let n in t)
+        t.hasOwnProperty(n) && !e.hasOwnProperty(n) && (e[n] = t[n]);
+}
+function H(e) {
+    if (typeof e == "string") return e;
+    if (Array.isArray(e)) return "[" + e.map(H).join(", ") + "]";
+    if (e == null) return "" + e;
+    if (e.overriddenName) return `${e.overriddenName}`;
+    if (e.name) return `${e.name}`;
+    let t = e.toString();
+    if (t == null) return "" + t;
+    let n = t.indexOf(`
+`);
+    return n === -1 ? t : t.substring(0, n);
+}
+function Fo(e, t) {
+    return e == null || e === ""
+        ? t === null
+            ? ""
+            : t
+        : t == null || t === ""
+          ? e
+          : e + " " + t;
+}
+var pf = A({ __forward_ref__: A });
+function pu(e) {
+    return (
+        (e.__forward_ref__ = pu),
+        (e.toString = function () {
+            return H(this());
+        }),
+        e
+    );
+}
+function $(e) {
+    return hu(e) ? e() : e;
+}
+function hu(e) {
+    return (
+        typeof e == "function" &&
+        e.hasOwnProperty(pf) &&
+        e.__forward_ref__ === pu
+    );
+}
+function O(e) {
+    return {
+        token: e.token,
+        providedIn: e.providedIn || null,
+        factory: e.factory,
+        value: void 0,
+    };
+}
+function Bi(e) {
+    return { providers: e.providers || [], imports: e.imports || [] };
+}
+function Mr(e) {
+    return _a(e, gu) || _a(e, mu);
+}
+function R_(e) {
+    return Mr(e) !== null;
+}
+function _a(e, t) {
+    return e.hasOwnProperty(t) ? e[t] : null;
+}
+function hf(e) {
+    let t = e && (e[gu] || e[mu]);
+    return t || null;
+}
+function Ma(e) {
+    return e && (e.hasOwnProperty(xa) || e.hasOwnProperty(gf)) ? e[xa] : null;
+}
+var gu = A({ ɵprov: A }),
+    xa = A({ ɵinj: A }),
+    mu = A({ ngInjectableDef: A }),
+    gf = A({ ngInjectorDef: A }),
+    T = class {
+        constructor(t, n) {
+            (this._desc = t),
+                (this.ngMetadataName = "InjectionToken"),
+                (this.ɵprov = void 0),
+                typeof n == "number"
+                    ? (this.__NG_ELEMENT_ID__ = n)
+                    : n !== void 0 &&
+                      (this.ɵprov = O({
+                          token: this,
+                          providedIn: n.providedIn || "root",
+                          factory: n.factory,
+                      }));
+        }
+        get multi() {
+            return this;
+        }
+        toString() {
+            return `InjectionToken ${this._desc}`;
+        }
+    };
+function yu(e) {
+    return e && !!e.ɵproviders;
+}
+var mf = A({ ɵcmp: A }),
+    yf = A({ ɵdir: A }),
+    Df = A({ ɵpipe: A }),
+    vf = A({ ɵmod: A }),
+    nr = A({ ɵfac: A }),
+    Wt = A({ __NG_ELEMENT_ID__: A }),
+    Sa = A({ __NG_ENV_ID__: A });
+function xr(e) {
+    return typeof e == "string" ? e : e == null ? "" : String(e);
+}
+function If(e) {
+    return typeof e == "function"
+        ? e.name || e.toString()
+        : typeof e == "object" && e != null && typeof e.type == "function"
+          ? e.type.name || e.type.toString()
+          : xr(e);
+}
+function wf(e, t) {
+    let n = t ? `. Dependency path: ${t.join(" > ")} > ${e}` : "";
+    throw new _(-200, e);
+}
+function $i(e, t) {
+    throw new _(-201, !1);
+}
+var b = (function (e) {
+        return (
+            (e[(e.Default = 0)] = "Default"),
+            (e[(e.Host = 1)] = "Host"),
+            (e[(e.Self = 2)] = "Self"),
+            (e[(e.SkipSelf = 4)] = "SkipSelf"),
+            (e[(e.Optional = 8)] = "Optional"),
+            e
+        );
+    })(b || {}),
+    Ro;
+function Du() {
+    return Ro;
+}
+function K(e) {
+    let t = Ro;
+    return (Ro = e), t;
+}
+function vu(e, t, n) {
+    let r = Mr(e);
+    if (r && r.providedIn == "root")
+        return r.value === void 0 ? (r.value = r.factory()) : r.value;
+    if (n & b.Optional) return null;
+    if (t !== void 0) return t;
+    $i(e, "Injector");
+}
+var Ef = {},
+    Yt = Ef,
+    Po = "__NG_DI_FLAG__",
+    rr = "ngTempTokenPath",
+    Cf = "ngTokenPath",
+    bf = /\n/gm,
+    _f = "\u0275",
+    Ta = "__source",
+    Mt;
+function Mf() {
+    return Mt;
+}
+function Se(e) {
+    let t = Mt;
+    return (Mt = e), t;
+}
+function xf(e, t = b.Default) {
+    if (Mt === void 0) throw new _(-203, !1);
+    return Mt === null
+        ? vu(e, void 0, t)
+        : Mt.get(e, t & b.Optional ? null : void 0, t);
+}
+function R(e, t = b.Default) {
+    return (Du() || xf)($(e), t);
+}
+function S(e, t = b.Default) {
+    return R(e, Sr(t));
+}
+function Sr(e) {
+    return typeof e > "u" || typeof e == "number"
+        ? e
+        : 0 |
+              (e.optional && 8) |
+              (e.host && 1) |
+              (e.self && 2) |
+              (e.skipSelf && 4);
+}
+function ko(e) {
+    let t = [];
+    for (let n = 0; n < e.length; n++) {
+        let r = $(e[n]);
+        if (Array.isArray(r)) {
+            if (r.length === 0) throw new _(900, !1);
+            let o,
+                i = b.Default;
+            for (let s = 0; s < r.length; s++) {
+                let a = r[s],
+                    u = Sf(a);
+                typeof u == "number"
+                    ? u === -1
+                        ? (o = a.token)
+                        : (i |= u)
+                    : (o = a);
+            }
+            t.push(R(o, i));
+        } else t.push(R(r));
+    }
+    return t;
+}
+function Iu(e, t) {
+    return (e[Po] = t), (e.prototype[Po] = t), e;
+}
+function Sf(e) {
+    return e[Po];
+}
+function Tf(e, t, n, r) {
+    let o = e[rr];
+    throw (
+        (t[Ta] && o.unshift(t[Ta]),
+        (e.message = Nf(
+            `
+` + e.message,
+            o,
+            n,
+            r
+        )),
+        (e[Cf] = o),
+        (e[rr] = null),
+        e)
+    );
+}
+function Nf(e, t, n, r = null) {
+    e =
+        e &&
+        e.charAt(0) ===
+            `
+` &&
+        e.charAt(1) == _f
+            ? e.slice(2)
+            : e;
+    let o = H(t);
+    if (Array.isArray(t)) o = t.map(H).join(" -> ");
+    else if (typeof t == "object") {
+        let i = [];
+        for (let s in t)
+            if (t.hasOwnProperty(s)) {
+                let a = t[s];
+                i.push(
+                    s + ":" + (typeof a == "string" ? JSON.stringify(a) : H(a))
+                );
+            }
+        o = `{${i.join(", ")}}`;
+    }
+    return `${n}${r ? "(" + r + ")" : ""}[${o}]: ${e.replace(
+        bf,
+        `
+  `
+    )}`;
+}
+var Af = Iu(fu("Optional"), 8);
+var Of = Iu(fu("SkipSelf"), 4);
+function St(e, t) {
+    let n = e.hasOwnProperty(nr);
+    return n ? e[nr] : null;
+}
+function Ff(e, t, n) {
+    if (e.length !== t.length) return !1;
+    for (let r = 0; r < e.length; r++) {
+        let o = e[r],
+            i = t[r];
+        if ((n && ((o = n(o)), (i = n(i))), i !== o)) return !1;
+    }
+    return !0;
+}
+function Rf(e) {
+    return e.flat(Number.POSITIVE_INFINITY);
+}
+function Hi(e, t) {
+    e.forEach((n) => (Array.isArray(n) ? Hi(n, t) : t(n)));
+}
+function wu(e, t, n) {
+    t >= e.length ? e.push(n) : e.splice(t, 0, n);
+}
+function or(e, t) {
+    return t >= e.length - 1 ? e.pop() : e.splice(t, 1)[0];
+}
+function Pf(e, t) {
+    let n = [];
+    for (let r = 0; r < e; r++) n.push(t);
+    return n;
+}
+function kf(e, t, n, r) {
+    let o = e.length;
+    if (o == t) e.push(n, r);
+    else if (o === 1) e.push(r, e[0]), (e[0] = n);
+    else {
+        for (o--, e.push(e[o - 1], e[o]); o > t; ) {
+            let i = o - 2;
+            (e[o] = e[i]), o--;
+        }
+        (e[t] = n), (e[t + 1] = r);
+    }
+}
+function Ui(e, t, n) {
+    let r = sn(e, t);
+    return r >= 0 ? (e[r | 1] = n) : ((r = ~r), kf(e, r, t, n)), r;
+}
+function Io(e, t) {
+    let n = sn(e, t);
+    if (n >= 0) return e[n | 1];
+}
+function sn(e, t) {
+    return Lf(e, t, 1);
+}
+function Lf(e, t, n) {
+    let r = 0,
+        o = e.length >> n;
+    for (; o !== r; ) {
+        let i = r + ((o - r) >> 1),
+            s = e[i << n];
+        if (t === s) return i << n;
+        s > t ? (o = i) : (r = i + 1);
+    }
+    return ~(o << n);
+}
+var Tt = {},
+    z = [],
+    ir = new T(""),
+    Eu = new T("", -1),
+    Cu = new T(""),
+    sr = class {
+        get(t, n = Yt) {
+            if (n === Yt) {
+                let r = new Error(
+                    `NullInjectorError: No provider for ${H(t)}!`
+                );
+                throw ((r.name = "NullInjectorError"), r);
+            }
+            return n;
+        }
+    },
+    bu = (function (e) {
+        return (
+            (e[(e.OnPush = 0)] = "OnPush"), (e[(e.Default = 1)] = "Default"), e
+        );
+    })(bu || {}),
+    Qt = (function (e) {
+        return (
+            (e[(e.Emulated = 0)] = "Emulated"),
+            (e[(e.None = 2)] = "None"),
+            (e[(e.ShadowDom = 3)] = "ShadowDom"),
+            e
+        );
+    })(Qt || {}),
+    Ze = (function (e) {
+        return (
+            (e[(e.None = 0)] = "None"),
+            (e[(e.SignalBased = 1)] = "SignalBased"),
+            (e[(e.HasDecoratorInputTransform = 2)] =
+                "HasDecoratorInputTransform"),
+            e
+        );
+    })(Ze || {});
+function jf(e, t, n) {
+    let r = e.length;
+    for (;;) {
+        let o = e.indexOf(t, n);
+        if (o === -1) return o;
+        if (o === 0 || e.charCodeAt(o - 1) <= 32) {
+            let i = t.length;
+            if (o + i === r || e.charCodeAt(o + i) <= 32) return o;
+        }
+        n = o + 1;
+    }
+}
+function Lo(e, t, n) {
+    let r = 0;
+    for (; r < n.length; ) {
+        let o = n[r];
+        if (typeof o == "number") {
+            if (o !== 0) break;
+            r++;
+            let i = n[r++],
+                s = n[r++],
+                a = n[r++];
+            e.setAttribute(t, s, a, i);
+        } else {
+            let i = o,
+                s = n[++r];
+            Vf(i) ? e.setProperty(t, i, s) : e.setAttribute(t, i, s), r++;
+        }
+    }
+    return r;
+}
+function _u(e) {
+    return e === 3 || e === 4 || e === 6;
+}
+function Vf(e) {
+    return e.charCodeAt(0) === 64;
+}
+function Zt(e, t) {
+    if (!(t === null || t.length === 0))
+        if (e === null || e.length === 0) e = t.slice();
+        else {
+            let n = -1;
+            for (let r = 0; r < t.length; r++) {
+                let o = t[r];
+                typeof o == "number"
+                    ? (n = o)
+                    : n === 0 ||
+                      (n === -1 || n === 2
+                          ? Na(e, n, o, null, t[++r])
+                          : Na(e, n, o, null, null));
+            }
+        }
+    return e;
+}
+function Na(e, t, n, r, o) {
+    let i = 0,
+        s = e.length;
+    if (t === -1) s = -1;
+    else
+        for (; i < e.length; ) {
+            let a = e[i++];
+            if (typeof a == "number") {
+                if (a === t) {
+                    s = -1;
+                    break;
+                } else if (a > t) {
+                    s = i - 1;
+                    break;
+                }
+            }
+        }
+    for (; i < e.length; ) {
+        let a = e[i];
+        if (typeof a == "number") break;
+        if (a === n) {
+            if (r === null) {
+                o !== null && (e[i + 1] = o);
+                return;
+            } else if (r === e[i + 1]) {
+                e[i + 2] = o;
+                return;
+            }
+        }
+        i++, r !== null && i++, o !== null && i++;
+    }
+    s !== -1 && (e.splice(s, 0, t), (i = s + 1)),
+        e.splice(i++, 0, n),
+        r !== null && e.splice(i++, 0, r),
+        o !== null && e.splice(i++, 0, o);
+}
+var Mu = "ng-template";
+function Bf(e, t, n, r) {
+    let o = 0;
+    if (r) {
+        for (; o < t.length && typeof t[o] == "string"; o += 2)
+            if (t[o] === "class" && jf(t[o + 1].toLowerCase(), n, 0) !== -1)
+                return !0;
+    } else if (Gi(e)) return !1;
+    if (((o = t.indexOf(1, o)), o > -1)) {
+        let i;
+        for (; ++o < t.length && typeof (i = t[o]) == "string"; )
+            if (i.toLowerCase() === n) return !0;
+    }
+    return !1;
+}
+function Gi(e) {
+    return e.type === 4 && e.value !== Mu;
+}
+function $f(e, t, n) {
+    let r = e.type === 4 && !n ? Mu : e.value;
+    return t === r;
+}
+function Hf(e, t, n) {
+    let r = 4,
+        o = e.attrs,
+        i = o !== null ? zf(o) : 0,
+        s = !1;
+    for (let a = 0; a < t.length; a++) {
+        let u = t[a];
+        if (typeof u == "number") {
+            if (!s && !re(r) && !re(u)) return !1;
+            if (s && re(u)) continue;
+            (s = !1), (r = u | (r & 1));
+            continue;
+        }
+        if (!s)
+            if (r & 4) {
+                if (
+                    ((r = 2 | (r & 1)),
+                    (u !== "" && !$f(e, u, n)) || (u === "" && t.length === 1))
+                ) {
+                    if (re(r)) return !1;
+                    s = !0;
+                }
+            } else if (r & 8) {
+                if (o === null || !Bf(e, o, u, n)) {
+                    if (re(r)) return !1;
+                    s = !0;
+                }
+            } else {
+                let c = t[++a],
+                    l = Uf(u, o, Gi(e), n);
+                if (l === -1) {
+                    if (re(r)) return !1;
+                    s = !0;
+                    continue;
+                }
+                if (c !== "") {
+                    let d;
+                    if (
+                        (l > i ? (d = "") : (d = o[l + 1].toLowerCase()),
+                        r & 2 && c !== d)
+                    ) {
+                        if (re(r)) return !1;
+                        s = !0;
+                    }
+                }
+            }
+    }
+    return re(r) || s;
+}
+function re(e) {
+    return (e & 1) === 0;
+}
+function Uf(e, t, n, r) {
+    if (t === null) return -1;
+    let o = 0;
+    if (r || !n) {
+        let i = !1;
+        for (; o < t.length; ) {
+            let s = t[o];
+            if (s === e) return o;
+            if (s === 3 || s === 6) i = !0;
+            else if (s === 1 || s === 2) {
+                let a = t[++o];
+                for (; typeof a == "string"; ) a = t[++o];
+                continue;
+            } else {
+                if (s === 4) break;
+                if (s === 0) {
+                    o += 4;
+                    continue;
+                }
+            }
+            o += i ? 1 : 2;
+        }
+        return -1;
+    } else return Wf(t, e);
+}
+function xu(e, t, n = !1) {
+    for (let r = 0; r < t.length; r++) if (Hf(e, t[r], n)) return !0;
+    return !1;
+}
+function Gf(e) {
+    let t = e.attrs;
+    if (t != null) {
+        let n = t.indexOf(5);
+        if (!(n & 1)) return t[n + 1];
+    }
+    return null;
+}
+function zf(e) {
+    for (let t = 0; t < e.length; t++) {
+        let n = e[t];
+        if (_u(n)) return t;
+    }
+    return e.length;
+}
+function Wf(e, t) {
+    let n = e.indexOf(4);
+    if (n > -1)
+        for (n++; n < e.length; ) {
+            let r = e[n];
+            if (typeof r == "number") return -1;
+            if (r === t) return n;
+            n++;
+        }
+    return -1;
+}
+function qf(e, t) {
+    e: for (let n = 0; n < t.length; n++) {
+        let r = t[n];
+        if (e.length === r.length) {
+            for (let o = 0; o < e.length; o++) if (e[o] !== r[o]) continue e;
+            return !0;
+        }
+    }
+    return !1;
+}
+function Aa(e, t) {
+    return e ? ":not(" + t.trim() + ")" : t;
+}
+function Yf(e) {
+    let t = e[0],
+        n = 1,
+        r = 2,
+        o = "",
+        i = !1;
+    for (; n < e.length; ) {
+        let s = e[n];
+        if (typeof s == "string")
+            if (r & 2) {
+                let a = e[++n];
+                o += "[" + s + (a.length > 0 ? '="' + a + '"' : "") + "]";
+            } else r & 8 ? (o += "." + s) : r & 4 && (o += " " + s);
+        else
+            o !== "" && !re(s) && ((t += Aa(i, o)), (o = "")),
+                (r = s),
+                (i = i || !re(r));
+        n++;
+    }
+    return o !== "" && (t += Aa(i, o)), t;
+}
+function Qf(e) {
+    return e.map(Yf).join(",");
+}
+function Zf(e) {
+    let t = [],
+        n = [],
+        r = 1,
+        o = 2;
+    for (; r < e.length; ) {
+        let i = e[r];
+        if (typeof i == "string")
+            o === 2 ? i !== "" && t.push(i, e[++r]) : o === 8 && n.push(i);
+        else {
+            if (!re(o)) break;
+            o = i;
+        }
+        r++;
+    }
+    return { attrs: t, classes: n };
+}
+function P_(e) {
+    return on(() => {
+        let t = Au(e),
+            n = lt(xe({}, t), {
+                decls: e.decls,
+                vars: e.vars,
+                template: e.template,
+                consts: e.consts || null,
+                ngContentSelectors: e.ngContentSelectors,
+                onPush: e.changeDetection === bu.OnPush,
+                directiveDefs: null,
+                pipeDefs: null,
+                dependencies: (t.standalone && e.dependencies) || null,
+                getStandaloneInjector: null,
+                signals: e.signals ?? !1,
+                data: e.data || {},
+                encapsulation: e.encapsulation || Qt.Emulated,
+                styles: e.styles || z,
+                _: null,
+                schemas: e.schemas || null,
+                tView: null,
+                id: "",
+            });
+        Ou(n);
+        let r = e.dependencies;
+        return (
+            (n.directiveDefs = Fa(r, !1)),
+            (n.pipeDefs = Fa(r, !0)),
+            (n.id = ep(n)),
+            n
+        );
+    });
+}
+function Kf(e) {
+    return Ne(e) || Su(e);
+}
+function Jf(e) {
+    return e !== null;
+}
+function zi(e) {
+    return on(() => ({
+        type: e.type,
+        bootstrap: e.bootstrap || z,
+        declarations: e.declarations || z,
+        imports: e.imports || z,
+        exports: e.exports || z,
+        transitiveCompileScopes: null,
+        schemas: e.schemas || null,
+        id: e.id || null,
+    }));
+}
+function Oa(e, t) {
+    if (e == null) return Tt;
+    let n = {};
+    for (let r in e)
+        if (e.hasOwnProperty(r)) {
+            let o = e[r],
+                i,
+                s,
+                a = Ze.None;
+            Array.isArray(o)
+                ? ((a = o[0]), (i = o[1]), (s = o[2] ?? i))
+                : ((i = o), (s = o)),
+                t
+                    ? ((n[i] = a !== Ze.None ? [r, a] : r), (t[i] = s))
+                    : (n[i] = r);
+        }
+    return n;
+}
+function Wi(e) {
+    return on(() => {
+        let t = Au(e);
+        return Ou(t), t;
+    });
+}
+function Ne(e) {
+    return e[mf] || null;
+}
+function Su(e) {
+    return e[yf] || null;
+}
+function Tu(e) {
+    return e[Df] || null;
+}
+function Xf(e) {
+    let t = Ne(e) || Su(e) || Tu(e);
+    return t !== null ? t.standalone : !1;
+}
+function Nu(e, t) {
+    let n = e[vf] || null;
+    if (!n && t === !0)
+        throw new Error(`Type ${H(e)} does not have '\u0275mod' property.`);
+    return n;
+}
+function Au(e) {
+    let t = {};
+    return {
+        type: e.type,
+        providersResolver: null,
+        factory: null,
+        hostBindings: e.hostBindings || null,
+        hostVars: e.hostVars || 0,
+        hostAttrs: e.hostAttrs || null,
+        contentQueries: e.contentQueries || null,
+        declaredInputs: t,
+        inputTransforms: null,
+        inputConfig: e.inputs || Tt,
+        exportAs: e.exportAs || null,
+        standalone: e.standalone === !0,
+        signals: e.signals === !0,
+        selectors: e.selectors || z,
+        viewQuery: e.viewQuery || null,
+        features: e.features || null,
+        setInput: null,
+        findHostDirectiveDefs: null,
+        hostDirectives: null,
+        inputs: Oa(e.inputs, t),
+        outputs: Oa(e.outputs),
+        debugInfo: null,
+    };
+}
+function Ou(e) {
+    e.features?.forEach((t) => t(e));
+}
+function Fa(e, t) {
+    if (!e) return null;
+    let n = t ? Tu : Kf;
+    return () => (typeof e == "function" ? e() : e).map((r) => n(r)).filter(Jf);
+}
+function ep(e) {
+    let t = 0,
+        n = [
+            e.selectors,
+            e.ngContentSelectors,
+            e.hostVars,
+            e.hostAttrs,
+            e.consts,
+            e.vars,
+            e.decls,
+            e.encapsulation,
+            e.standalone,
+            e.signals,
+            e.exportAs,
+            JSON.stringify(e.inputs),
+            JSON.stringify(e.outputs),
+            Object.getOwnPropertyNames(e.type.prototype),
+            !!e.contentQueries,
+            !!e.viewQuery,
+        ].join("|");
+    for (let o of n) t = (Math.imul(31, t) + o.charCodeAt(0)) << 0;
+    return (t += 2147483648), "c" + t;
+}
+function k_(e) {
+    return { ɵproviders: e };
+}
+function tp(...e) {
+    return { ɵproviders: Fu(!0, e), ɵfromNgModule: !0 };
+}
+function Fu(e, ...t) {
+    let n = [],
+        r = new Set(),
+        o,
+        i = (s) => {
+            n.push(s);
+        };
+    return (
+        Hi(t, (s) => {
+            let a = s;
+            jo(a, i, [], r) && ((o ||= []), o.push(a));
+        }),
+        o !== void 0 && Ru(o, i),
+        n
+    );
+}
+function Ru(e, t) {
+    for (let n = 0; n < e.length; n++) {
+        let { ngModule: r, providers: o } = e[n];
+        qi(o, (i) => {
+            t(i, r);
+        });
+    }
+}
+function jo(e, t, n, r) {
+    if (((e = $(e)), !e)) return !1;
+    let o = null,
+        i = Ma(e),
+        s = !i && Ne(e);
+    if (!i && !s) {
+        let u = e.ngModule;
+        if (((i = Ma(u)), i)) o = u;
+        else return !1;
+    } else {
+        if (s && !s.standalone) return !1;
+        o = e;
+    }
+    let a = r.has(o);
+    if (s) {
+        if (a) return !1;
+        if ((r.add(o), s.dependencies)) {
+            let u =
+                typeof s.dependencies == "function"
+                    ? s.dependencies()
+                    : s.dependencies;
+            for (let c of u) jo(c, t, n, r);
+        }
+    } else if (i) {
+        if (i.imports != null && !a) {
+            r.add(o);
+            let c;
+            try {
+                Hi(i.imports, (l) => {
+                    jo(l, t, n, r) && ((c ||= []), c.push(l));
+                });
+            } finally {
+            }
+            c !== void 0 && Ru(c, t);
+        }
+        if (!a) {
+            let c = St(o) || (() => new o());
+            t({ provide: o, useFactory: c, deps: z }, o),
+                t({ provide: Cu, useValue: o, multi: !0 }, o),
+                t({ provide: ir, useValue: () => R(o), multi: !0 }, o);
+        }
+        let u = i.providers;
+        if (u != null && !a) {
+            let c = e;
+            qi(u, (l) => {
+                t(l, c);
+            });
+        }
+    } else return !1;
+    return o !== e && e.providers !== void 0;
+}
+function qi(e, t) {
+    for (let n of e)
+        yu(n) && (n = n.ɵproviders), Array.isArray(n) ? qi(n, t) : t(n);
+}
+var np = A({ provide: String, useValue: A });
+function Pu(e) {
+    return e !== null && typeof e == "object" && np in e;
+}
+function rp(e) {
+    return !!(e && e.useExisting);
+}
+function op(e) {
+    return !!(e && e.useFactory);
+}
+function Nt(e) {
+    return typeof e == "function";
+}
+function ip(e) {
+    return !!e.useClass;
+}
+var ku = new T(""),
+    Qn = {},
+    sp = {},
+    wo;
+function Yi() {
+    return wo === void 0 && (wo = new sr()), wo;
+}
+var Ae = class {},
+    Kt = class extends Ae {
+        get destroyed() {
+            return this._destroyed;
+        }
+        constructor(t, n, r, o) {
+            super(),
+                (this.parent = n),
+                (this.source = r),
+                (this.scopes = o),
+                (this.records = new Map()),
+                (this._ngOnDestroyHooks = new Set()),
+                (this._onDestroyHooks = []),
+                (this._destroyed = !1),
+                Bo(t, (s) => this.processProvider(s)),
+                this.records.set(Eu, Et(void 0, this)),
+                o.has("environment") && this.records.set(Ae, Et(void 0, this));
+            let i = this.records.get(ku);
+            i != null && typeof i.value == "string" && this.scopes.add(i.value),
+                (this.injectorDefTypes = new Set(this.get(Cu, z, b.Self)));
+        }
+        destroy() {
+            this.assertNotDestroyed(), (this._destroyed = !0);
+            let t = M(null);
+            try {
+                for (let r of this._ngOnDestroyHooks) r.ngOnDestroy();
+                let n = this._onDestroyHooks;
+                this._onDestroyHooks = [];
+                for (let r of n) r();
+            } finally {
+                this.records.clear(),
+                    this._ngOnDestroyHooks.clear(),
+                    this.injectorDefTypes.clear(),
+                    M(t);
+            }
+        }
+        onDestroy(t) {
+            return (
+                this.assertNotDestroyed(),
+                this._onDestroyHooks.push(t),
+                () => this.removeOnDestroy(t)
+            );
+        }
+        runInContext(t) {
+            this.assertNotDestroyed();
+            let n = Se(this),
+                r = K(void 0),
+                o;
+            try {
+                return t();
+            } finally {
+                Se(n), K(r);
+            }
+        }
+        get(t, n = Yt, r = b.Default) {
+            if ((this.assertNotDestroyed(), t.hasOwnProperty(Sa)))
+                return t[Sa](this);
+            r = Sr(r);
+            let o,
+                i = Se(this),
+                s = K(void 0);
+            try {
+                if (!(r & b.SkipSelf)) {
+                    let u = this.records.get(t);
+                    if (u === void 0) {
+                        let c = dp(t) && Mr(t);
+                        c && this.injectableDefInScope(c)
+                            ? (u = Et(Vo(t), Qn))
+                            : (u = null),
+                            this.records.set(t, u);
+                    }
+                    if (u != null) return this.hydrate(t, u);
+                }
+                let a = r & b.Self ? Yi() : this.parent;
+                return (n = r & b.Optional && n === Yt ? null : n), a.get(t, n);
+            } catch (a) {
+                if (a.name === "NullInjectorError") {
+                    if (((a[rr] = a[rr] || []).unshift(H(t)), i)) throw a;
+                    return Tf(a, t, "R3InjectorError", this.source);
+                } else throw a;
+            } finally {
+                K(s), Se(i);
+            }
+        }
+        resolveInjectorInitializers() {
+            let t = M(null),
+                n = Se(this),
+                r = K(void 0),
+                o;
+            try {
+                let i = this.get(ir, z, b.Self);
+                for (let s of i) s();
+            } finally {
+                Se(n), K(r), M(t);
+            }
+        }
+        toString() {
+            let t = [],
+                n = this.records;
+            for (let r of n.keys()) t.push(H(r));
+            return `R3Injector[${t.join(", ")}]`;
+        }
+        assertNotDestroyed() {
+            if (this._destroyed) throw new _(205, !1);
+        }
+        processProvider(t) {
+            t = $(t);
+            let n = Nt(t) ? t : $(t && t.provide),
+                r = up(t);
+            if (!Nt(t) && t.multi === !0) {
+                let o = this.records.get(n);
+                o ||
+                    ((o = Et(void 0, Qn, !0)),
+                    (o.factory = () => ko(o.multi)),
+                    this.records.set(n, o)),
+                    (n = t),
+                    o.multi.push(t);
+            }
+            this.records.set(n, r);
+        }
+        hydrate(t, n) {
+            let r = M(null);
+            try {
+                return (
+                    n.value === Qn && ((n.value = sp), (n.value = n.factory())),
+                    typeof n.value == "object" &&
+                        n.value &&
+                        lp(n.value) &&
+                        this._ngOnDestroyHooks.add(n.value),
+                    n.value
+                );
+            } finally {
+                M(r);
+            }
+        }
+        injectableDefInScope(t) {
+            if (!t.providedIn) return !1;
+            let n = $(t.providedIn);
+            return typeof n == "string"
+                ? n === "any" || this.scopes.has(n)
+                : this.injectorDefTypes.has(n);
+        }
+        removeOnDestroy(t) {
+            let n = this._onDestroyHooks.indexOf(t);
+            n !== -1 && this._onDestroyHooks.splice(n, 1);
+        }
+    };
+function Vo(e) {
+    let t = Mr(e),
+        n = t !== null ? t.factory : St(e);
+    if (n !== null) return n;
+    if (e instanceof T) throw new _(204, !1);
+    if (e instanceof Function) return ap(e);
+    throw new _(204, !1);
+}
+function ap(e) {
+    if (e.length > 0) throw new _(204, !1);
+    let n = hf(e);
+    return n !== null ? () => n.factory(e) : () => new e();
+}
+function up(e) {
+    if (Pu(e)) return Et(void 0, e.useValue);
+    {
+        let t = Lu(e);
+        return Et(t, Qn);
+    }
+}
+function Lu(e, t, n) {
+    let r;
+    if (Nt(e)) {
+        let o = $(e);
+        return St(o) || Vo(o);
+    } else if (Pu(e)) r = () => $(e.useValue);
+    else if (op(e)) r = () => e.useFactory(...ko(e.deps || []));
+    else if (rp(e)) r = () => R($(e.useExisting));
+    else {
+        let o = $(e && (e.useClass || e.provide));
+        if (cp(e)) r = () => new o(...ko(e.deps));
+        else return St(o) || Vo(o);
+    }
+    return r;
+}
+function Et(e, t, n = !1) {
+    return { factory: e, value: t, multi: n ? [] : void 0 };
+}
+function cp(e) {
+    return !!e.deps;
+}
+function lp(e) {
+    return (
+        e !== null && typeof e == "object" && typeof e.ngOnDestroy == "function"
+    );
+}
+function dp(e) {
+    return typeof e == "function" || (typeof e == "object" && e instanceof T);
+}
+function Bo(e, t) {
+    for (let n of e)
+        Array.isArray(n) ? Bo(n, t) : n && yu(n) ? Bo(n.ɵproviders, t) : t(n);
+}
+function fp(e, t) {
+    e instanceof Kt && e.assertNotDestroyed();
+    let n,
+        r = Se(e),
+        o = K(void 0);
+    try {
+        return t();
+    } finally {
+        Se(r), K(o);
+    }
+}
+function ju() {
+    return Du() !== void 0 || Mf() != null;
+}
+function Vu(e) {
+    if (!ju()) throw new _(-203, !1);
+}
+function pp(e) {
+    let t = ve.ng;
+    if (t && t.ɵcompilerFacade) return t.ɵcompilerFacade;
+    throw new Error("JIT compiler unavailable");
+}
+function hp(e) {
+    return typeof e == "function";
+}
+var Ee = 0,
+    v = 1,
+    m = 2,
+    j = 3,
+    se = 4,
+    Q = 5,
+    Jt = 6,
+    Xt = 7,
+    J = 8,
+    At = 9,
+    ae = 10,
+    F = 11,
+    en = 12,
+    Ra = 13,
+    kt = 14,
+    ue = 15,
+    an = 16,
+    Ct = 17,
+    Ie = 18,
+    Tr = 19,
+    Bu = 20,
+    Te = 21,
+    Zn = 22,
+    Ke = 23,
+    Y = 25,
+    $u = 1;
+var Je = 7,
+    ar = 8,
+    Ot = 9,
+    W = 10,
+    Qi = (function (e) {
+        return (
+            (e[(e.None = 0)] = "None"),
+            (e[(e.HasTransplantedViews = 2)] = "HasTransplantedViews"),
+            e
+        );
+    })(Qi || {});
+function Ye(e) {
+    return Array.isArray(e) && typeof e[$u] == "object";
+}
+function Ce(e) {
+    return Array.isArray(e) && e[$u] === !0;
+}
+function Zi(e) {
+    return (e.flags & 4) !== 0;
+}
+function Nr(e) {
+    return e.componentOffset > -1;
+}
+function Ar(e) {
+    return (e.flags & 1) === 1;
+}
+function Oe(e) {
+    return !!e.template;
+}
+function gp(e) {
+    return (e[m] & 512) !== 0;
+}
+var $o = class {
+    constructor(t, n, r) {
+        (this.previousValue = t),
+            (this.currentValue = n),
+            (this.firstChange = r);
+    }
+    isFirstChange() {
+        return this.firstChange;
+    }
+};
+function Hu(e, t, n, r) {
+    t !== null ? t.applyValueToInputSignal(t, r) : (e[n] = r);
+}
+function Uu() {
+    return Gu;
+}
+function Gu(e) {
+    return e.type.prototype.ngOnChanges && (e.setInput = yp), mp;
+}
+Uu.ngInherit = !0;
+function mp() {
+    let e = Wu(this),
+        t = e?.current;
+    if (t) {
+        let n = e.previous;
+        if (n === Tt) e.previous = t;
+        else for (let r in t) n[r] = t[r];
+        (e.current = null), this.ngOnChanges(t);
+    }
+}
+function yp(e, t, n, r, o) {
+    let i = this.declaredInputs[r],
+        s = Wu(e) || Dp(e, { previous: Tt, current: null }),
+        a = s.current || (s.current = {}),
+        u = s.previous,
+        c = u[i];
+    (a[i] = new $o(c && c.currentValue, n, u === Tt)), Hu(e, t, o, n);
+}
+var zu = "__ngSimpleChanges__";
+function Wu(e) {
+    return e[zu] || null;
+}
+function Dp(e, t) {
+    return (e[zu] = t);
+}
+var Pa = null;
+var fe = function (e, t, n) {
+        Pa?.(e, t, n);
+    },
+    qu = "svg",
+    vp = "math",
+    Ip = !1;
+function wp() {
+    return Ip;
+}
+function he(e) {
+    for (; Array.isArray(e); ) e = e[Ee];
+    return e;
+}
+function Yu(e, t) {
+    return he(t[e]);
+}
+function X(e, t) {
+    return he(t[e.index]);
+}
+function Ki(e, t) {
+    return e.data[t];
+}
+function Ep(e, t) {
+    return e[t];
+}
+function ke(e, t) {
+    let n = t[e];
+    return Ye(n) ? n : n[Ee];
+}
+function Cp(e) {
+    return (e[m] & 4) === 4;
+}
+function Ji(e) {
+    return (e[m] & 128) === 128;
+}
+function bp(e) {
+    return Ce(e[j]);
+}
+function Ft(e, t) {
+    return t == null ? null : e[t];
+}
+function Qu(e) {
+    e[Ct] = 0;
+}
+function _p(e) {
+    e[m] & 1024 || ((e[m] |= 1024), Ji(e) && tn(e));
+}
+function Mp(e, t) {
+    for (; e > 0; ) (t = t[kt]), e--;
+    return t;
+}
+function Xi(e) {
+    return !!(e[m] & 9216 || e[Ke]?.dirty);
+}
+function Ho(e) {
+    e[ae].changeDetectionScheduler?.notify(1),
+        Xi(e)
+            ? tn(e)
+            : e[m] & 64 &&
+              (wp()
+                  ? ((e[m] |= 1024), tn(e))
+                  : e[ae].changeDetectionScheduler?.notify());
+}
+function tn(e) {
+    e[ae].changeDetectionScheduler?.notify();
+    let t = nn(e);
+    for (; t !== null && !(t[m] & 8192 || ((t[m] |= 8192), !Ji(t))); )
+        t = nn(t);
+}
+function Zu(e, t) {
+    if ((e[m] & 256) === 256) throw new _(911, !1);
+    e[Te] === null && (e[Te] = []), e[Te].push(t);
+}
+function xp(e, t) {
+    if (e[Te] === null) return;
+    let n = e[Te].indexOf(t);
+    n !== -1 && e[Te].splice(n, 1);
+}
+function nn(e) {
+    let t = e[j];
+    return Ce(t) ? t[j] : t;
+}
+var I = { lFrame: oc(null), bindingsEnabled: !0, skipHydrationRootTNode: null };
+function Sp() {
+    return I.lFrame.elementDepthCount;
+}
+function Tp() {
+    I.lFrame.elementDepthCount++;
+}
+function Np() {
+    I.lFrame.elementDepthCount--;
+}
+function Ku() {
+    return I.bindingsEnabled;
+}
+function Ju() {
+    return I.skipHydrationRootTNode !== null;
+}
+function Ap(e) {
+    return I.skipHydrationRootTNode === e;
+}
+function Op() {
+    I.skipHydrationRootTNode = null;
+}
+function E() {
+    return I.lFrame.lView;
+}
+function P() {
+    return I.lFrame.tView;
+}
+function L_(e) {
+    return (I.lFrame.contextLView = e), e[J];
+}
+function j_(e) {
+    return (I.lFrame.contextLView = null), e;
+}
+function V() {
+    let e = Xu();
+    for (; e !== null && e.type === 64; ) e = e.parent;
+    return e;
+}
+function Xu() {
+    return I.lFrame.currentTNode;
+}
+function Fp() {
+    let e = I.lFrame,
+        t = e.currentTNode;
+    return e.isParent ? t : t.parent;
+}
+function it(e, t) {
+    let n = I.lFrame;
+    (n.currentTNode = e), (n.isParent = t);
+}
+function es() {
+    return I.lFrame.isParent;
+}
+function ts() {
+    I.lFrame.isParent = !1;
+}
+function Rp() {
+    return I.lFrame.contextLView;
+}
+function Pp() {
+    let e = I.lFrame,
+        t = e.bindingRootIndex;
+    return t === -1 && (t = e.bindingRootIndex = e.tView.bindingStartIndex), t;
+}
+function kp(e) {
+    return (I.lFrame.bindingIndex = e);
+}
+function un() {
+    return I.lFrame.bindingIndex++;
+}
+function ec(e) {
+    let t = I.lFrame,
+        n = t.bindingIndex;
+    return (t.bindingIndex = t.bindingIndex + e), n;
+}
+function Lp() {
+    return I.lFrame.inI18n;
+}
+function jp(e, t) {
+    let n = I.lFrame;
+    (n.bindingIndex = n.bindingRootIndex = e), Uo(t);
+}
+function Vp() {
+    return I.lFrame.currentDirectiveIndex;
+}
+function Uo(e) {
+    I.lFrame.currentDirectiveIndex = e;
+}
+function Bp(e) {
+    let t = I.lFrame.currentDirectiveIndex;
+    return t === -1 ? null : e[t];
+}
+function tc() {
+    return I.lFrame.currentQueryIndex;
+}
+function ns(e) {
+    I.lFrame.currentQueryIndex = e;
+}
+function $p(e) {
+    let t = e[v];
+    return t.type === 2 ? t.declTNode : t.type === 1 ? e[Q] : null;
+}
+function nc(e, t, n) {
+    if (n & b.SkipSelf) {
+        let o = t,
+            i = e;
+        for (; (o = o.parent), o === null && !(n & b.Host); )
+            if (((o = $p(i)), o === null || ((i = i[kt]), o.type & 10))) break;
+        if (o === null) return !1;
+        (t = o), (e = i);
+    }
+    let r = (I.lFrame = rc());
+    return (r.currentTNode = t), (r.lView = e), !0;
+}
+function rs(e) {
+    let t = rc(),
+        n = e[v];
+    (I.lFrame = t),
+        (t.currentTNode = n.firstChild),
+        (t.lView = e),
+        (t.tView = n),
+        (t.contextLView = e),
+        (t.bindingIndex = n.bindingStartIndex),
+        (t.inI18n = !1);
+}
+function rc() {
+    let e = I.lFrame,
+        t = e === null ? null : e.child;
+    return t === null ? oc(e) : t;
+}
+function oc(e) {
+    let t = {
+        currentTNode: null,
+        isParent: !0,
+        lView: null,
+        tView: null,
+        selectedIndex: -1,
+        contextLView: null,
+        elementDepthCount: 0,
+        currentNamespace: null,
+        currentDirectiveIndex: -1,
+        bindingRootIndex: -1,
+        bindingIndex: -1,
+        currentQueryIndex: 0,
+        parent: e,
+        child: null,
+        inI18n: !1,
+    };
+    return e !== null && (e.child = t), t;
+}
+function ic() {
+    let e = I.lFrame;
+    return (I.lFrame = e.parent), (e.currentTNode = null), (e.lView = null), e;
+}
+var sc = ic;
+function os() {
+    let e = ic();
+    (e.isParent = !0),
+        (e.tView = null),
+        (e.selectedIndex = -1),
+        (e.contextLView = null),
+        (e.elementDepthCount = 0),
+        (e.currentDirectiveIndex = -1),
+        (e.currentNamespace = null),
+        (e.bindingRootIndex = -1),
+        (e.bindingIndex = -1),
+        (e.currentQueryIndex = 0);
+}
+function Hp(e) {
+    return (I.lFrame.contextLView = Mp(e, I.lFrame.contextLView))[J];
+}
+function st() {
+    return I.lFrame.selectedIndex;
+}
+function Xe(e) {
+    I.lFrame.selectedIndex = e;
+}
+function Or() {
+    let e = I.lFrame;
+    return Ki(e.tView, e.selectedIndex);
+}
+function V_() {
+    I.lFrame.currentNamespace = qu;
+}
+function Up() {
+    return I.lFrame.currentNamespace;
+}
+var ac = !0;
+function Fr() {
+    return ac;
+}
+function Rr(e) {
+    ac = e;
+}
+function Gp(e, t, n) {
+    let { ngOnChanges: r, ngOnInit: o, ngDoCheck: i } = t.type.prototype;
+    if (r) {
+        let s = Gu(t);
+        (n.preOrderHooks ??= []).push(e, s),
+            (n.preOrderCheckHooks ??= []).push(e, s);
+    }
+    o && (n.preOrderHooks ??= []).push(0 - e, o),
+        i &&
+            ((n.preOrderHooks ??= []).push(e, i),
+            (n.preOrderCheckHooks ??= []).push(e, i));
+}
+function Pr(e, t) {
+    for (let n = t.directiveStart, r = t.directiveEnd; n < r; n++) {
+        let i = e.data[n].type.prototype,
+            {
+                ngAfterContentInit: s,
+                ngAfterContentChecked: a,
+                ngAfterViewInit: u,
+                ngAfterViewChecked: c,
+                ngOnDestroy: l,
+            } = i;
+        s && (e.contentHooks ??= []).push(-n, s),
+            a &&
+                ((e.contentHooks ??= []).push(n, a),
+                (e.contentCheckHooks ??= []).push(n, a)),
+            u && (e.viewHooks ??= []).push(-n, u),
+            c &&
+                ((e.viewHooks ??= []).push(n, c),
+                (e.viewCheckHooks ??= []).push(n, c)),
+            l != null && (e.destroyHooks ??= []).push(n, l);
+    }
+}
+function Kn(e, t, n) {
+    uc(e, t, 3, n);
+}
+function Jn(e, t, n, r) {
+    (e[m] & 3) === n && uc(e, t, n, r);
+}
+function Eo(e, t) {
+    let n = e[m];
+    (n & 3) === t && ((n &= 16383), (n += 1), (e[m] = n));
+}
+function uc(e, t, n, r) {
+    let o = r !== void 0 ? e[Ct] & 65535 : 0,
+        i = r ?? -1,
+        s = t.length - 1,
+        a = 0;
+    for (let u = o; u < s; u++)
+        if (typeof t[u + 1] == "number") {
+            if (((a = t[u]), r != null && a >= r)) break;
+        } else
+            t[u] < 0 && (e[Ct] += 65536),
+                (a < i || i == -1) &&
+                    (zp(e, n, t, u), (e[Ct] = (e[Ct] & 4294901760) + u + 2)),
+                u++;
+}
+function ka(e, t) {
+    fe(4, e, t);
+    let n = M(null);
+    try {
+        t.call(e);
+    } finally {
+        M(n), fe(5, e, t);
+    }
+}
+function zp(e, t, n, r) {
+    let o = n[r] < 0,
+        i = n[r + 1],
+        s = o ? -n[r] : n[r],
+        a = e[s];
+    o
+        ? e[m] >> 14 < e[Ct] >> 16 &&
+          (e[m] & 3) === t &&
+          ((e[m] += 16384), ka(a, i))
+        : ka(a, i);
+}
+var xt = -1,
+    et = class {
+        constructor(t, n, r) {
+            (this.factory = t),
+                (this.resolving = !1),
+                (this.canSeeViewProviders = n),
+                (this.injectImpl = r);
+        }
+    };
+function Wp(e) {
+    return e instanceof et;
+}
+function qp(e) {
+    return (e.flags & 8) !== 0;
+}
+function Yp(e) {
+    return (e.flags & 16) !== 0;
+}
+function cc(e) {
+    return e !== xt;
+}
+function ur(e) {
+    return e & 32767;
+}
+function Qp(e) {
+    return e >> 16;
+}
+function cr(e, t) {
+    let n = Qp(e),
+        r = t;
+    for (; n > 0; ) (r = r[kt]), n--;
+    return r;
+}
+var Go = !0;
+function La(e) {
+    let t = Go;
+    return (Go = e), t;
+}
+var Zp = 256,
+    lc = Zp - 1,
+    dc = 5,
+    Kp = 0,
+    pe = {};
+function Jp(e, t, n) {
+    let r;
+    typeof n == "string"
+        ? (r = n.charCodeAt(0) || 0)
+        : n.hasOwnProperty(Wt) && (r = n[Wt]),
+        r == null && (r = n[Wt] = Kp++);
+    let o = r & lc,
+        i = 1 << o;
+    t.data[e + (o >> dc)] |= i;
+}
+function lr(e, t) {
+    let n = fc(e, t);
+    if (n !== -1) return n;
+    let r = t[v];
+    r.firstCreatePass &&
+        ((e.injectorIndex = t.length),
+        Co(r.data, e),
+        Co(t, null),
+        Co(r.blueprint, null));
+    let o = is(e, t),
+        i = e.injectorIndex;
+    if (cc(o)) {
+        let s = ur(o),
+            a = cr(o, t),
+            u = a[v].data;
+        for (let c = 0; c < 8; c++) t[i + c] = a[s + c] | u[s + c];
+    }
+    return (t[i + 8] = o), i;
+}
+function Co(e, t) {
+    e.push(0, 0, 0, 0, 0, 0, 0, 0, t);
+}
+function fc(e, t) {
+    return e.injectorIndex === -1 ||
+        (e.parent && e.parent.injectorIndex === e.injectorIndex) ||
+        t[e.injectorIndex + 8] === null
+        ? -1
+        : e.injectorIndex;
+}
+function is(e, t) {
+    if (e.parent && e.parent.injectorIndex !== -1)
+        return e.parent.injectorIndex;
+    let n = 0,
+        r = null,
+        o = t;
+    for (; o !== null; ) {
+        if (((r = yc(o)), r === null)) return xt;
+        if ((n++, (o = o[kt]), r.injectorIndex !== -1))
+            return r.injectorIndex | (n << 16);
+    }
+    return xt;
+}
+function zo(e, t, n) {
+    Jp(e, t, n);
+}
+function Xp(e, t) {
+    if (t === "class") return e.classes;
+    if (t === "style") return e.styles;
+    let n = e.attrs;
+    if (n) {
+        let r = n.length,
+            o = 0;
+        for (; o < r; ) {
+            let i = n[o];
+            if (_u(i)) break;
+            if (i === 0) o = o + 2;
+            else if (typeof i == "number")
+                for (o++; o < r && typeof n[o] == "string"; ) o++;
+            else {
+                if (i === t) return n[o + 1];
+                o = o + 2;
+            }
+        }
+    }
+    return null;
+}
+function pc(e, t, n) {
+    if (n & b.Optional || e !== void 0) return e;
+    $i(t, "NodeInjector");
+}
+function hc(e, t, n, r) {
+    if (
+        (n & b.Optional && r === void 0 && (r = null), !(n & (b.Self | b.Host)))
+    ) {
+        let o = e[At],
+            i = K(void 0);
+        try {
+            return o ? o.get(t, r, n & b.Optional) : vu(t, r, n & b.Optional);
+        } finally {
+            K(i);
+        }
+    }
+    return pc(r, t, n);
+}
+function gc(e, t, n, r = b.Default, o) {
+    if (e !== null) {
+        if (t[m] & 2048 && !(r & b.Self)) {
+            let s = rh(e, t, n, r, pe);
+            if (s !== pe) return s;
+        }
+        let i = mc(e, t, n, r, pe);
+        if (i !== pe) return i;
+    }
+    return hc(t, n, r, o);
+}
+function mc(e, t, n, r, o) {
+    let i = th(n);
+    if (typeof i == "function") {
+        if (!nc(t, e, r)) return r & b.Host ? pc(o, n, r) : hc(t, n, r, o);
+        try {
+            let s;
+            if (((s = i(r)), s == null && !(r & b.Optional))) $i(n);
+            else return s;
+        } finally {
+            sc();
+        }
+    } else if (typeof i == "number") {
+        let s = null,
+            a = fc(e, t),
+            u = xt,
+            c = r & b.Host ? t[ue][Q] : null;
+        for (
+            (a === -1 || r & b.SkipSelf) &&
+            ((u = a === -1 ? is(e, t) : t[a + 8]),
+            u === xt || !Va(r, !1)
+                ? (a = -1)
+                : ((s = t[v]), (a = ur(u)), (t = cr(u, t))));
+            a !== -1;
+
+        ) {
+            let l = t[v];
+            if (ja(i, a, l.data)) {
+                let d = eh(a, t, n, s, r, c);
+                if (d !== pe) return d;
+            }
+            (u = t[a + 8]),
+                u !== xt && Va(r, t[v].data[a + 8] === c) && ja(i, a, t)
+                    ? ((s = l), (a = ur(u)), (t = cr(u, t)))
+                    : (a = -1);
+        }
+    }
+    return o;
+}
+function eh(e, t, n, r, o, i) {
+    let s = t[v],
+        a = s.data[e + 8],
+        u = r == null ? Nr(a) && Go : r != s && (a.type & 3) !== 0,
+        c = o & b.Host && i === a,
+        l = Xn(a, s, n, u, c);
+    return l !== null ? tt(t, s, l, a) : pe;
+}
+function Xn(e, t, n, r, o) {
+    let i = e.providerIndexes,
+        s = t.data,
+        a = i & 1048575,
+        u = e.directiveStart,
+        c = e.directiveEnd,
+        l = i >> 20,
+        d = r ? a : a + l,
+        f = o ? a + l : c;
+    for (let p = d; p < f; p++) {
+        let h = s[p];
+        if ((p < u && n === h) || (p >= u && h.type === n)) return p;
+    }
+    if (o) {
+        let p = s[u];
+        if (p && Oe(p) && p.type === n) return u;
+    }
+    return null;
+}
+function tt(e, t, n, r) {
+    let o = e[n],
+        i = t.data;
+    if (Wp(o)) {
+        let s = o;
+        s.resolving && wf(If(i[n]));
+        let a = La(s.canSeeViewProviders);
+        s.resolving = !0;
+        let u,
+            c = s.injectImpl ? K(s.injectImpl) : null,
+            l = nc(e, r, b.Default);
+        try {
+            (o = e[n] = s.factory(void 0, i, e, r)),
+                t.firstCreatePass && n >= r.directiveStart && Gp(n, i[n], t);
+        } finally {
+            c !== null && K(c), La(a), (s.resolving = !1), sc();
+        }
+    }
+    return o;
+}
+function th(e) {
+    if (typeof e == "string") return e.charCodeAt(0) || 0;
+    let t = e.hasOwnProperty(Wt) ? e[Wt] : void 0;
+    return typeof t == "number" ? (t >= 0 ? t & lc : nh) : t;
+}
+function ja(e, t, n) {
+    let r = 1 << e;
+    return !!(n[t + (e >> dc)] & r);
+}
+function Va(e, t) {
+    return !(e & b.Self) && !(e & b.Host && t);
+}
+var Qe = class {
+    constructor(t, n) {
+        (this._tNode = t), (this._lView = n);
+    }
+    get(t, n, r) {
+        return gc(this._tNode, this._lView, t, Sr(r), n);
+    }
+};
+function nh() {
+    return new Qe(V(), E());
+}
+function B_(e) {
+    return on(() => {
+        let t = e.prototype.constructor,
+            n = t[nr] || Wo(t),
+            r = Object.prototype,
+            o = Object.getPrototypeOf(e.prototype).constructor;
+        for (; o && o !== r; ) {
+            let i = o[nr] || Wo(o);
+            if (i && i !== n) return i;
+            o = Object.getPrototypeOf(o);
+        }
+        return (i) => new i();
+    });
+}
+function Wo(e) {
+    return hu(e)
+        ? () => {
+              let t = Wo($(e));
+              return t && t();
+          }
+        : St(e);
+}
+function rh(e, t, n, r, o) {
+    let i = e,
+        s = t;
+    for (; i !== null && s !== null && s[m] & 2048 && !(s[m] & 512); ) {
+        let a = mc(i, s, n, r | b.Self, pe);
+        if (a !== pe) return a;
+        let u = i.parent;
+        if (!u) {
+            let c = s[Bu];
+            if (c) {
+                let l = c.get(n, pe, r);
+                if (l !== pe) return l;
+            }
+            (u = yc(s)), (s = s[kt]);
+        }
+        i = u;
+    }
+    return o;
+}
+function yc(e) {
+    let t = e[v],
+        n = t.type;
+    return n === 2 ? t.declTNode : n === 1 ? e[Q] : null;
+}
+function oh(e) {
+    return Xp(V(), e);
+}
+function Ba(e, t = null, n = null, r) {
+    let o = Dc(e, t, n, r);
+    return o.resolveInjectorInitializers(), o;
+}
+function Dc(e, t = null, n = null, r, o = new Set()) {
+    let i = [n || z, tp(e)];
+    return (
+        (r = r || (typeof e == "object" ? void 0 : H(e))),
+        new Kt(i, t || Yi(), r || null, o)
+    );
+}
+var Le = (() => {
+    let t = class t {
+        static create(r, o) {
+            if (Array.isArray(r)) return Ba({ name: "" }, o, r, "");
+            {
+                let i = r.name ?? "";
+                return Ba({ name: i }, r.parent, r.providers, i);
+            }
+        }
+    };
+    (t.THROW_IF_NOT_FOUND = Yt),
+        (t.NULL = new sr()),
+        (t.ɵprov = O({ token: t, providedIn: "any", factory: () => R(Eu) })),
+        (t.__NG_ELEMENT_ID__ = -1);
+    let e = t;
+    return e;
+})();
+var ih = "ngOriginalError";
+function bo(e) {
+    return e[ih];
+}
+var Fe = class {
+        constructor() {
+            this._console = console;
+        }
+        handleError(t) {
+            let n = this._findOriginalError(t);
+            this._console.error("ERROR", t),
+                n && this._console.error("ORIGINAL ERROR", n);
+        }
+        _findOriginalError(t) {
+            let n = t && bo(t);
+            for (; n && bo(n); ) n = bo(n);
+            return n || null;
+        }
+    },
+    vc = new T("", {
+        providedIn: "root",
+        factory: () => S(Fe).handleError.bind(void 0),
+    }),
+    kr = (() => {
+        let t = class t {};
+        (t.__NG_ELEMENT_ID__ = sh), (t.__NG_ENV_ID__ = (r) => r);
+        let e = t;
+        return e;
+    })(),
+    qo = class extends kr {
+        constructor(t) {
+            super(), (this._lView = t);
+        }
+        onDestroy(t) {
+            return Zu(this._lView, t), () => xp(this._lView, t);
+        }
+    };
+function sh() {
+    return new qo(E());
+}
+function ah() {
+    return Lt(V(), E());
+}
+function Lt(e, t) {
+    return new jt(X(e, t));
+}
+var jt = (() => {
+    let t = class t {
+        constructor(r) {
+            this.nativeElement = r;
+        }
+    };
+    t.__NG_ELEMENT_ID__ = ah;
+    let e = t;
+    return e;
+})();
+function uh(e) {
+    return e instanceof jt ? e.nativeElement : e;
+}
+var Yo = class extends ce {
+    constructor(t = !1) {
+        super(),
+            (this.destroyRef = void 0),
+            (this.__isAsync = t),
+            ju() && (this.destroyRef = S(kr, { optional: !0 }) ?? void 0);
+    }
+    emit(t) {
+        let n = M(null);
+        try {
+            super.next(t);
+        } finally {
+            M(n);
+        }
+    }
+    subscribe(t, n, r) {
+        let o = t,
+            i = n || (() => null),
+            s = r;
+        if (t && typeof t == "object") {
+            let u = t;
+            (o = u.next?.bind(u)),
+                (i = u.error?.bind(u)),
+                (s = u.complete?.bind(u));
+        }
+        this.__isAsync && ((i = _o(i)), o && (o = _o(o)), s && (s = _o(s)));
+        let a = super.subscribe({ next: o, error: i, complete: s });
+        return t instanceof L && t.add(a), a;
+    }
+};
+function _o(e) {
+    return (t) => {
+        setTimeout(e, void 0, t);
+    };
+}
+var ie = Yo;
+function ch() {
+    return this._results[Symbol.iterator]();
+}
+var Qo = class e {
+    get changes() {
+        return (this._changes ??= new ie());
+    }
+    constructor(t = !1) {
+        (this._emitDistinctChangesOnly = t),
+            (this.dirty = !0),
+            (this._onDirty = void 0),
+            (this._results = []),
+            (this._changesDetected = !1),
+            (this._changes = void 0),
+            (this.length = 0),
+            (this.first = void 0),
+            (this.last = void 0);
+        let n = e.prototype;
+        n[Symbol.iterator] || (n[Symbol.iterator] = ch);
+    }
+    get(t) {
+        return this._results[t];
+    }
+    map(t) {
+        return this._results.map(t);
+    }
+    filter(t) {
+        return this._results.filter(t);
+    }
+    find(t) {
+        return this._results.find(t);
+    }
+    reduce(t, n) {
+        return this._results.reduce(t, n);
+    }
+    forEach(t) {
+        this._results.forEach(t);
+    }
+    some(t) {
+        return this._results.some(t);
+    }
+    toArray() {
+        return this._results.slice();
+    }
+    toString() {
+        return this._results.toString();
+    }
+    reset(t, n) {
+        this.dirty = !1;
+        let r = Rf(t);
+        (this._changesDetected = !Ff(this._results, r, n)) &&
+            ((this._results = r),
+            (this.length = r.length),
+            (this.last = r[this.length - 1]),
+            (this.first = r[0]));
+    }
+    notifyOnChanges() {
+        this._changes !== void 0 &&
+            (this._changesDetected || !this._emitDistinctChangesOnly) &&
+            this._changes.emit(this);
+    }
+    onDirty(t) {
+        this._onDirty = t;
+    }
+    setDirty() {
+        (this.dirty = !0), this._onDirty?.();
+    }
+    destroy() {
+        this._changes !== void 0 &&
+            (this._changes.complete(), this._changes.unsubscribe());
+    }
+};
+function Ic(e) {
+    return (e.flags & 128) === 128;
+}
+var wc = new Map(),
+    lh = 0;
+function dh() {
+    return lh++;
+}
+function fh(e) {
+    wc.set(e[Tr], e);
+}
+function ph(e) {
+    wc.delete(e[Tr]);
+}
+var $a = "__ngContext__";
+function Re(e, t) {
+    Ye(t) ? ((e[$a] = t[Tr]), fh(t)) : (e[$a] = t);
+}
+function Ec(e) {
+    return bc(e[en]);
+}
+function Cc(e) {
+    return bc(e[se]);
+}
+function bc(e) {
+    for (; e !== null && !Ce(e); ) e = e[se];
+    return e;
+}
+var Zo;
+function $_(e) {
+    Zo = e;
+}
+function hh() {
+    if (Zo !== void 0) return Zo;
+    if (typeof document < "u") return document;
+    throw new _(210, !1);
+}
+var H_ = new T("", { providedIn: "root", factory: () => gh }),
+    gh = "ng",
+    mh = new T(""),
+    ss = new T("", { providedIn: "platform", factory: () => "unknown" });
+var U_ = new T(""),
+    G_ = new T("", {
+        providedIn: "root",
+        factory: () =>
+            hh()
+                .body?.querySelector("[ngCspNonce]")
+                ?.getAttribute("ngCspNonce") || null,
+    });
+var yh = "h",
+    Dh = "b";
+var vh = () => null;
+function as(e, t, n = !1) {
+    return vh(e, t, n);
+}
+var _c = !1,
+    Ih = new T("", { providedIn: "root", factory: () => _c });
+var Un;
+function wh() {
+    if (Un === void 0 && ((Un = null), ve.trustedTypes))
+        try {
+            Un = ve.trustedTypes.createPolicy("angular", {
+                createHTML: (e) => e,
+                createScript: (e) => e,
+                createScriptURL: (e) => e,
+            });
+        } catch {}
+    return Un;
+}
+function Lr(e) {
+    return wh()?.createHTML(e) || e;
+}
+var Gn;
+function Eh() {
+    if (Gn === void 0 && ((Gn = null), ve.trustedTypes))
+        try {
+            Gn = ve.trustedTypes.createPolicy("angular#unsafe-bypass", {
+                createHTML: (e) => e,
+                createScript: (e) => e,
+                createScriptURL: (e) => e,
+            });
+        } catch {}
+    return Gn;
+}
+function Ha(e) {
+    return Eh()?.createScriptURL(e) || e;
+}
+var we = class {
+        constructor(t) {
+            this.changingThisBreaksApplicationSecurity = t;
+        }
+        toString() {
+            return `SafeValue must use [property]=binding: ${this.changingThisBreaksApplicationSecurity} (see ${lu})`;
+        }
+    },
+    Ko = class extends we {
+        getTypeName() {
+            return "HTML";
+        }
+    },
+    Jo = class extends we {
+        getTypeName() {
+            return "Style";
+        }
+    },
+    Xo = class extends we {
+        getTypeName() {
+            return "Script";
+        }
+    },
+    ei = class extends we {
+        getTypeName() {
+            return "URL";
+        }
+    },
+    ti = class extends we {
+        getTypeName() {
+            return "ResourceURL";
+        }
+    };
+function cn(e) {
+    return e instanceof we ? e.changingThisBreaksApplicationSecurity : e;
+}
+function Mc(e, t) {
+    let n = Ch(e);
+    if (n != null && n !== t) {
+        if (n === "ResourceURL" && t === "URL") return !0;
+        throw new Error(`Required a safe ${t}, got a ${n} (see ${lu})`);
+    }
+    return n === t;
+}
+function Ch(e) {
+    return (e instanceof we && e.getTypeName()) || null;
+}
+function z_(e) {
+    return new Ko(e);
+}
+function W_(e) {
+    return new Jo(e);
+}
+function q_(e) {
+    return new Xo(e);
+}
+function Y_(e) {
+    return new ei(e);
+}
+function Q_(e) {
+    return new ti(e);
+}
+function bh(e) {
+    let t = new ri(e);
+    return _h() ? new ni(t) : t;
+}
+var ni = class {
+        constructor(t) {
+            this.inertDocumentHelper = t;
+        }
+        getInertBodyElement(t) {
+            t = "<body><remove></remove>" + t;
+            try {
+                let n = new window.DOMParser().parseFromString(
+                    Lr(t),
+                    "text/html"
+                ).body;
+                return n === null
+                    ? this.inertDocumentHelper.getInertBodyElement(t)
+                    : (n.removeChild(n.firstChild), n);
+            } catch {
+                return null;
+            }
+        }
+    },
+    ri = class {
+        constructor(t) {
+            (this.defaultDoc = t),
+                (this.inertDocument =
+                    this.defaultDoc.implementation.createHTMLDocument(
+                        "sanitization-inert"
+                    ));
+        }
+        getInertBodyElement(t) {
+            let n = this.inertDocument.createElement("template");
+            return (n.innerHTML = Lr(t)), n;
+        }
+    };
+function _h() {
+    try {
+        return !!new window.DOMParser().parseFromString(Lr(""), "text/html");
+    } catch {
+        return !1;
+    }
+}
+var Mh = /^(?!javascript:)(?:[a-z0-9+.-]+:|[^&:\/?#]*(?:[\/?#]|$))/i;
+function xc(e) {
+    return (e = String(e)), e.match(Mh) ? e : "unsafe:" + e;
+}
+function be(e) {
+    let t = {};
+    for (let n of e.split(",")) t[n] = !0;
+    return t;
+}
+function ln(...e) {
+    let t = {};
+    for (let n of e) for (let r in n) n.hasOwnProperty(r) && (t[r] = !0);
+    return t;
+}
+var Sc = be("area,br,col,hr,img,wbr"),
+    Tc = be("colgroup,dd,dt,li,p,tbody,td,tfoot,th,thead,tr"),
+    Nc = be("rp,rt"),
+    xh = ln(Nc, Tc),
+    Sh = ln(
+        Tc,
+        be(
+            "address,article,aside,blockquote,caption,center,del,details,dialog,dir,div,dl,figure,figcaption,footer,h1,h2,h3,h4,h5,h6,header,hgroup,hr,ins,main,map,menu,nav,ol,pre,section,summary,table,ul"
+        )
+    ),
+    Th = ln(
+        Nc,
+        be(
+            "a,abbr,acronym,audio,b,bdi,bdo,big,br,cite,code,del,dfn,em,font,i,img,ins,kbd,label,map,mark,picture,q,ruby,rp,rt,s,samp,small,source,span,strike,strong,sub,sup,time,track,tt,u,var,video"
+        )
+    ),
+    Ua = ln(Sc, Sh, Th, xh),
+    Ac = be("background,cite,href,itemtype,longdesc,poster,src,xlink:href"),
+    Nh = be(
+        "abbr,accesskey,align,alt,autoplay,axis,bgcolor,border,cellpadding,cellspacing,class,clear,color,cols,colspan,compact,controls,coords,datetime,default,dir,download,face,headers,height,hidden,hreflang,hspace,ismap,itemscope,itemprop,kind,label,lang,language,loop,media,muted,nohref,nowrap,open,preload,rel,rev,role,rows,rowspan,rules,scope,scrolling,shape,size,sizes,span,srclang,srcset,start,summary,tabindex,target,title,translate,type,usemap,valign,value,vspace,width"
+    ),
+    Ah = be(
+        "aria-activedescendant,aria-atomic,aria-autocomplete,aria-busy,aria-checked,aria-colcount,aria-colindex,aria-colspan,aria-controls,aria-current,aria-describedby,aria-details,aria-disabled,aria-dropeffect,aria-errormessage,aria-expanded,aria-flowto,aria-grabbed,aria-haspopup,aria-hidden,aria-invalid,aria-keyshortcuts,aria-label,aria-labelledby,aria-level,aria-live,aria-modal,aria-multiline,aria-multiselectable,aria-orientation,aria-owns,aria-placeholder,aria-posinset,aria-pressed,aria-readonly,aria-relevant,aria-required,aria-roledescription,aria-rowcount,aria-rowindex,aria-rowspan,aria-selected,aria-setsize,aria-sort,aria-valuemax,aria-valuemin,aria-valuenow,aria-valuetext"
+    ),
+    Oh = ln(Ac, Nh, Ah),
+    Fh = be("script,style,template"),
+    oi = class {
+        constructor() {
+            (this.sanitizedSomething = !1), (this.buf = []);
+        }
+        sanitizeChildren(t) {
+            let n = t.firstChild,
+                r = !0,
+                o = [];
+            for (; n; ) {
+                if (
+                    (n.nodeType === Node.ELEMENT_NODE
+                        ? (r = this.startElement(n))
+                        : n.nodeType === Node.TEXT_NODE
+                          ? this.chars(n.nodeValue)
+                          : (this.sanitizedSomething = !0),
+                    r && n.firstChild)
+                ) {
+                    o.push(n), (n = kh(n));
+                    continue;
+                }
+                for (; n; ) {
+                    n.nodeType === Node.ELEMENT_NODE && this.endElement(n);
+                    let i = Ph(n);
+                    if (i) {
+                        n = i;
+                        break;
+                    }
+                    n = o.pop();
+                }
+            }
+            return this.buf.join("");
+        }
+        startElement(t) {
+            let n = Ga(t).toLowerCase();
+            if (!Ua.hasOwnProperty(n))
+                return (this.sanitizedSomething = !0), !Fh.hasOwnProperty(n);
+            this.buf.push("<"), this.buf.push(n);
+            let r = t.attributes;
+            for (let o = 0; o < r.length; o++) {
+                let i = r.item(o),
+                    s = i.name,
+                    a = s.toLowerCase();
+                if (!Oh.hasOwnProperty(a)) {
+                    this.sanitizedSomething = !0;
+                    continue;
+                }
+                let u = i.value;
+                Ac[a] && (u = xc(u)), this.buf.push(" ", s, '="', za(u), '"');
+            }
+            return this.buf.push(">"), !0;
+        }
+        endElement(t) {
+            let n = Ga(t).toLowerCase();
+            Ua.hasOwnProperty(n) &&
+                !Sc.hasOwnProperty(n) &&
+                (this.buf.push("</"), this.buf.push(n), this.buf.push(">"));
+        }
+        chars(t) {
+            this.buf.push(za(t));
+        }
+    };
+function Rh(e, t) {
+    return (
+        (e.compareDocumentPosition(t) & Node.DOCUMENT_POSITION_CONTAINED_BY) !==
+        Node.DOCUMENT_POSITION_CONTAINED_BY
+    );
+}
+function Ph(e) {
+    let t = e.nextSibling;
+    if (t && e !== t.previousSibling) throw Oc(t);
+    return t;
+}
+function kh(e) {
+    let t = e.firstChild;
+    if (t && Rh(e, t)) throw Oc(t);
+    return t;
+}
+function Ga(e) {
+    let t = e.nodeName;
+    return typeof t == "string" ? t : "FORM";
+}
+function Oc(e) {
+    return new Error(
+        `Failed to sanitize html because the element is clobbered: ${e.outerHTML}`
+    );
+}
+var Lh = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g,
+    jh = /([^\#-~ |!])/g;
+function za(e) {
+    return e
+        .replace(/&/g, "&amp;")
+        .replace(Lh, function (t) {
+            let n = t.charCodeAt(0),
+                r = t.charCodeAt(1);
+            return "&#" + ((n - 55296) * 1024 + (r - 56320) + 65536) + ";";
+        })
+        .replace(jh, function (t) {
+            return "&#" + t.charCodeAt(0) + ";";
+        })
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+}
+var zn;
+function Z_(e, t) {
+    let n = null;
+    try {
+        zn = zn || bh(e);
+        let r = t ? String(t) : "";
+        n = zn.getInertBodyElement(r);
+        let o = 5,
+            i = r;
+        do {
+            if (o === 0)
+                throw new Error(
+                    "Failed to sanitize html because the input is unstable"
+                );
+            o--, (r = i), (i = n.innerHTML), (n = zn.getInertBodyElement(r));
+        } while (r !== i);
+        let a = new oi().sanitizeChildren(Wa(n) || n);
+        return Lr(a);
+    } finally {
+        if (n) {
+            let r = Wa(n) || n;
+            for (; r.firstChild; ) r.removeChild(r.firstChild);
+        }
+    }
+}
+function Wa(e) {
+    return "content" in e && Vh(e) ? e.content : null;
+}
+function Vh(e) {
+    return e.nodeType === Node.ELEMENT_NODE && e.nodeName === "TEMPLATE";
+}
+var us = (function (e) {
+    return (
+        (e[(e.NONE = 0)] = "NONE"),
+        (e[(e.HTML = 1)] = "HTML"),
+        (e[(e.STYLE = 2)] = "STYLE"),
+        (e[(e.SCRIPT = 3)] = "SCRIPT"),
+        (e[(e.URL = 4)] = "URL"),
+        (e[(e.RESOURCE_URL = 5)] = "RESOURCE_URL"),
+        e
+    );
+})(us || {});
+function Bh(e) {
+    let t = Fc();
+    return t ? t.sanitize(us.URL, e) || "" : Mc(e, "URL") ? cn(e) : xc(xr(e));
+}
+function $h(e) {
+    let t = Fc();
+    if (t) return Ha(t.sanitize(us.RESOURCE_URL, e) || "");
+    if (Mc(e, "ResourceURL")) return Ha(cn(e));
+    throw new _(904, !1);
+}
+function Hh(e, t) {
+    return (t === "src" &&
+        (e === "embed" ||
+            e === "frame" ||
+            e === "iframe" ||
+            e === "media" ||
+            e === "script")) ||
+        (t === "href" && (e === "base" || e === "link"))
+        ? $h
+        : Bh;
+}
+function K_(e, t, n) {
+    return Hh(t, n)(e);
+}
+function Fc() {
+    let e = E();
+    return e && e[ae].sanitizer;
+}
+var Uh = /^>|^->|<!--|-->|--!>|<!-$/g,
+    Gh = /(<|>)/g,
+    zh = "\u200B$1\u200B";
+function Wh(e) {
+    return e.replace(Uh, (t) => t.replace(Gh, zh));
+}
+function Rc(e) {
+    return e instanceof Function ? e() : e;
+}
+function qh(e) {
+    return (e ?? S(Le)).get(ss) === "browser";
+}
+var dr = (function (e) {
+        return (
+            (e[(e.Important = 1)] = "Important"),
+            (e[(e.DashCase = 2)] = "DashCase"),
+            e
+        );
+    })(dr || {}),
+    Yh;
+function cs(e, t) {
+    return Yh(e, t);
+}
+function bt(e, t, n, r, o) {
+    if (r != null) {
+        let i,
+            s = !1;
+        Ce(r) ? (i = r) : Ye(r) && ((s = !0), (r = r[Ee]));
+        let a = he(r);
+        e === 0 && n !== null
+            ? o == null
+                ? Vc(t, n, a)
+                : pr(t, n, a, o || null, !0)
+            : e === 1 && n !== null
+              ? pr(t, n, a, o || null, !0)
+              : e === 2
+                ? lg(t, a, s)
+                : e === 3 && t.destroyNode(a),
+            i != null && fg(t, e, i, n, o);
+    }
+}
+function Qh(e, t) {
+    return e.createText(t);
+}
+function Zh(e, t, n) {
+    e.setValue(t, n);
+}
+function Kh(e, t) {
+    return e.createComment(Wh(t));
+}
+function Pc(e, t, n) {
+    return e.createElement(t, n);
+}
+function Jh(e, t) {
+    kc(e, t), (t[Ee] = null), (t[Q] = null);
+}
+function Xh(e, t, n, r, o, i) {
+    (r[Ee] = o), (r[Q] = t), Vr(e, r, n, 1, o, i);
+}
+function kc(e, t) {
+    t[ae].changeDetectionScheduler?.notify(1), Vr(e, t, t[F], 2, null, null);
+}
+function eg(e) {
+    let t = e[en];
+    if (!t) return Mo(e[v], e);
+    for (; t; ) {
+        let n = null;
+        if (Ye(t)) n = t[en];
+        else {
+            let r = t[W];
+            r && (n = r);
+        }
+        if (!n) {
+            for (; t && !t[se] && t !== e; ) Ye(t) && Mo(t[v], t), (t = t[j]);
+            t === null && (t = e), Ye(t) && Mo(t[v], t), (n = t && t[se]);
+        }
+        t = n;
+    }
+}
+function tg(e, t, n, r) {
+    let o = W + r,
+        i = n.length;
+    r > 0 && (n[o - 1][se] = t),
+        r < i - W
+            ? ((t[se] = n[o]), wu(n, W + r, t))
+            : (n.push(t), (t[se] = null)),
+        (t[j] = n);
+    let s = t[an];
+    s !== null && n !== s && ng(s, t);
+    let a = t[Ie];
+    a !== null && a.insertView(e), Ho(t), (t[m] |= 128);
+}
+function ng(e, t) {
+    let n = e[Ot],
+        o = t[j][j][ue];
+    t[ue] !== o && (e[m] |= Qi.HasTransplantedViews),
+        n === null ? (e[Ot] = [t]) : n.push(t);
+}
+function Lc(e, t) {
+    let n = e[Ot],
+        r = n.indexOf(t);
+    n.splice(r, 1);
+}
+function fr(e, t) {
+    if (e.length <= W) return;
+    let n = W + t,
+        r = e[n];
+    if (r) {
+        let o = r[an];
+        o !== null && o !== e && Lc(o, r), t > 0 && (e[n - 1][se] = r[se]);
+        let i = or(e, W + t);
+        Jh(r[v], r);
+        let s = i[Ie];
+        s !== null && s.detachView(i[v]),
+            (r[j] = null),
+            (r[se] = null),
+            (r[m] &= -129);
+    }
+    return r;
+}
+function ls(e, t) {
+    if (!(t[m] & 256)) {
+        let n = t[F];
+        n.destroyNode && Vr(e, t, n, 3, null, null), eg(t);
+    }
+}
+function Mo(e, t) {
+    if (t[m] & 256) return;
+    let n = M(null);
+    try {
+        (t[m] &= -129),
+            (t[m] |= 256),
+            t[Ke] && Kr(t[Ke]),
+            og(e, t),
+            rg(e, t),
+            t[v].type === 1 && t[F].destroy();
+        let r = t[an];
+        if (r !== null && Ce(t[j])) {
+            r !== t[j] && Lc(r, t);
+            let o = t[Ie];
+            o !== null && o.detachView(e);
+        }
+        ph(t);
+    } finally {
+        M(n);
+    }
+}
+function rg(e, t) {
+    let n = e.cleanup,
+        r = t[Xt];
+    if (n !== null)
+        for (let i = 0; i < n.length - 1; i += 2)
+            if (typeof n[i] == "string") {
+                let s = n[i + 3];
+                s >= 0 ? r[s]() : r[-s].unsubscribe(), (i += 2);
+            } else {
+                let s = r[n[i + 1]];
+                n[i].call(s);
+            }
+    r !== null && (t[Xt] = null);
+    let o = t[Te];
+    if (o !== null) {
+        t[Te] = null;
+        for (let i = 0; i < o.length; i++) {
+            let s = o[i];
+            s();
+        }
+    }
+}
+function og(e, t) {
+    let n;
+    if (e != null && (n = e.destroyHooks) != null)
+        for (let r = 0; r < n.length; r += 2) {
+            let o = t[n[r]];
+            if (!(o instanceof et)) {
+                let i = n[r + 1];
+                if (Array.isArray(i))
+                    for (let s = 0; s < i.length; s += 2) {
+                        let a = o[i[s]],
+                            u = i[s + 1];
+                        fe(4, a, u);
+                        try {
+                            u.call(a);
+                        } finally {
+                            fe(5, a, u);
+                        }
+                    }
+                else {
+                    fe(4, o, i);
+                    try {
+                        i.call(o);
+                    } finally {
+                        fe(5, o, i);
+                    }
+                }
+            }
+        }
+}
+function jc(e, t, n) {
+    return ig(e, t.parent, n);
+}
+function ig(e, t, n) {
+    let r = t;
+    for (; r !== null && r.type & 40; ) (t = r), (r = t.parent);
+    if (r === null) return n[Ee];
+    {
+        let { componentOffset: o } = r;
+        if (o > -1) {
+            let { encapsulation: i } = e.data[r.directiveStart + o];
+            if (i === Qt.None || i === Qt.Emulated) return null;
+        }
+        return X(r, n);
+    }
+}
+function pr(e, t, n, r, o) {
+    e.insertBefore(t, n, r, o);
+}
+function Vc(e, t, n) {
+    e.appendChild(t, n);
+}
+function qa(e, t, n, r, o) {
+    r !== null ? pr(e, t, n, r, o) : Vc(e, t, n);
+}
+function sg(e, t, n, r) {
+    e.removeChild(t, n, r);
+}
+function ds(e, t) {
+    return e.parentNode(t);
+}
+function ag(e, t) {
+    return e.nextSibling(t);
+}
+function Bc(e, t, n) {
+    return cg(e, t, n);
+}
+function ug(e, t, n) {
+    return e.type & 40 ? X(e, n) : null;
+}
+var cg = ug,
+    Ya;
+function jr(e, t, n, r) {
+    let o = jc(e, r, t),
+        i = t[F],
+        s = r.parent || t[Q],
+        a = Bc(s, r, t);
+    if (o != null)
+        if (Array.isArray(n))
+            for (let u = 0; u < n.length; u++) qa(i, o, n[u], a, !1);
+        else qa(i, o, n, a, !1);
+    Ya !== void 0 && Ya(i, r, t, n, o);
+}
+function er(e, t) {
+    if (t !== null) {
+        let n = t.type;
+        if (n & 3) return X(t, e);
+        if (n & 4) return ii(-1, e[t.index]);
+        if (n & 8) {
+            let r = t.child;
+            if (r !== null) return er(e, r);
+            {
+                let o = e[t.index];
+                return Ce(o) ? ii(-1, o) : he(o);
+            }
+        } else {
+            if (n & 32) return cs(t, e)() || he(e[t.index]);
+            {
+                let r = $c(e, t);
+                if (r !== null) {
+                    if (Array.isArray(r)) return r[0];
+                    let o = nn(e[ue]);
+                    return er(o, r);
+                } else return er(e, t.next);
+            }
+        }
+    }
+    return null;
+}
+function $c(e, t) {
+    if (t !== null) {
+        let r = e[ue][Q],
+            o = t.projection;
+        return r.projection[o];
+    }
+    return null;
+}
+function ii(e, t) {
+    let n = W + e + 1;
+    if (n < t.length) {
+        let r = t[n],
+            o = r[v].firstChild;
+        if (o !== null) return er(r, o);
+    }
+    return t[Je];
+}
+function lg(e, t, n) {
+    let r = ds(e, t);
+    r && sg(e, r, t, n);
+}
+function fs(e, t, n, r, o, i, s) {
+    for (; n != null; ) {
+        let a = r[n.index],
+            u = n.type;
+        if (
+            (s && t === 0 && (a && Re(he(a), r), (n.flags |= 2)),
+            (n.flags & 32) !== 32)
+        )
+            if (u & 8) fs(e, t, n.child, r, o, i, !1), bt(t, e, o, a, i);
+            else if (u & 32) {
+                let c = cs(n, r),
+                    l;
+                for (; (l = c()); ) bt(t, e, o, l, i);
+                bt(t, e, o, a, i);
+            } else u & 16 ? Hc(e, t, r, n, o, i) : bt(t, e, o, a, i);
+        n = s ? n.projectionNext : n.next;
+    }
+}
+function Vr(e, t, n, r, o, i) {
+    fs(n, r, e.firstChild, t, o, i, !1);
+}
+function dg(e, t, n) {
+    let r = t[F],
+        o = jc(e, n, t),
+        i = n.parent || t[Q],
+        s = Bc(i, n, t);
+    Hc(r, 0, t, n, o, s);
+}
+function Hc(e, t, n, r, o, i) {
+    let s = n[ue],
+        u = s[Q].projection[r.projection];
+    if (Array.isArray(u))
+        for (let c = 0; c < u.length; c++) {
+            let l = u[c];
+            bt(t, e, o, l, i);
+        }
+    else {
+        let c = u,
+            l = s[j];
+        Ic(r) && (c.flags |= 128), fs(e, t, c, l, o, i, !0);
+    }
+}
+function fg(e, t, n, r, o) {
+    let i = n[Je],
+        s = he(n);
+    i !== s && bt(t, e, r, i, o);
+    for (let a = W; a < n.length; a++) {
+        let u = n[a];
+        Vr(u[v], u, e, t, r, i);
+    }
+}
+function pg(e, t, n, r, o) {
+    if (t) o ? e.addClass(n, r) : e.removeClass(n, r);
+    else {
+        let i = r.indexOf("-") === -1 ? void 0 : dr.DashCase;
+        o == null
+            ? e.removeStyle(n, r, i)
+            : (typeof o == "string" &&
+                  o.endsWith("!important") &&
+                  ((o = o.slice(0, -10)), (i |= dr.Important)),
+              e.setStyle(n, r, o, i));
+    }
+}
+function hg(e, t, n) {
+    e.setAttribute(t, "style", n);
+}
+function Uc(e, t, n) {
+    n === "" ? e.removeAttribute(t, "class") : e.setAttribute(t, "class", n);
+}
+function Gc(e, t, n) {
+    let { mergedAttrs: r, classes: o, styles: i } = n;
+    r !== null && Lo(e, t, r),
+        o !== null && Uc(e, t, o),
+        i !== null && hg(e, t, i);
+}
+var ge = {};
+function J_(e = 1) {
+    zc(P(), E(), st() + e, !1);
+}
+function zc(e, t, n, r) {
+    if (!r)
+        if ((t[m] & 3) === 3) {
+            let i = e.preOrderCheckHooks;
+            i !== null && Kn(t, i, n);
+        } else {
+            let i = e.preOrderHooks;
+            i !== null && Jn(t, i, 0, n);
+        }
+    Xe(n);
+}
+function _e(e, t = b.Default) {
+    let n = E();
+    if (n === null) return R(e, t);
+    let r = V();
+    return gc(r, n, $(e), t);
+}
+function X_() {
+    let e = "invalid";
+    throw new Error(e);
+}
+function Wc(e, t, n, r, o, i) {
+    let s = M(null);
+    try {
+        let a = null;
+        o & Ze.SignalBased && (a = t[r][gn]),
+            a !== null && a.transformFn !== void 0 && (i = a.transformFn(i)),
+            o & Ze.HasDecoratorInputTransform &&
+                (i = e.inputTransforms[r].call(t, i)),
+            e.setInput !== null ? e.setInput(t, a, i, n, r) : Hu(t, a, r, i);
+    } finally {
+        M(s);
+    }
+}
+function gg(e, t) {
+    let n = e.hostBindingOpCodes;
+    if (n !== null)
+        try {
+            for (let r = 0; r < n.length; r++) {
+                let o = n[r];
+                if (o < 0) Xe(~o);
+                else {
+                    let i = o,
+                        s = n[++r],
+                        a = n[++r];
+                    jp(s, i);
+                    let u = t[i];
+                    a(2, u);
+                }
+            }
+        } finally {
+            Xe(-1);
+        }
+}
+function Br(e, t, n, r, o, i, s, a, u, c, l) {
+    let d = t.blueprint.slice();
+    return (
+        (d[Ee] = o),
+        (d[m] = r | 4 | 128 | 8 | 64),
+        (c !== null || (e && e[m] & 2048)) && (d[m] |= 2048),
+        Qu(d),
+        (d[j] = d[kt] = e),
+        (d[J] = n),
+        (d[ae] = s || (e && e[ae])),
+        (d[F] = a || (e && e[F])),
+        (d[At] = u || (e && e[At]) || null),
+        (d[Q] = i),
+        (d[Tr] = dh()),
+        (d[Jt] = l),
+        (d[Bu] = c),
+        (d[ue] = t.type == 2 ? e[ue] : d),
+        d
+    );
+}
+function Vt(e, t, n, r, o) {
+    let i = e.data[t];
+    if (i === null) (i = mg(e, t, n, r, o)), Lp() && (i.flags |= 32);
+    else if (i.type & 64) {
+        (i.type = n), (i.value = r), (i.attrs = o);
+        let s = Fp();
+        i.injectorIndex = s === null ? -1 : s.injectorIndex;
+    }
+    return it(i, !0), i;
+}
+function mg(e, t, n, r, o) {
+    let i = Xu(),
+        s = es(),
+        a = s ? i : i && i.parent,
+        u = (e.data[t] = Eg(e, a, n, t, r, o));
+    return (
+        e.firstChild === null && (e.firstChild = u),
+        i !== null &&
+            (s
+                ? i.child == null && u.parent !== null && (i.child = u)
+                : i.next === null && ((i.next = u), (u.prev = i))),
+        u
+    );
+}
+function qc(e, t, n, r) {
+    if (n === 0) return -1;
+    let o = t.length;
+    for (let i = 0; i < n; i++)
+        t.push(r), e.blueprint.push(r), e.data.push(null);
+    return o;
+}
+function Yc(e, t, n, r, o) {
+    let i = st(),
+        s = r & 2;
+    try {
+        Xe(-1), s && t.length > Y && zc(e, t, Y, !1), fe(s ? 2 : 0, o), n(r, o);
+    } finally {
+        Xe(i), fe(s ? 3 : 1, o);
+    }
+}
+function ps(e, t, n) {
+    if (Zi(t)) {
+        let r = M(null);
+        try {
+            let o = t.directiveStart,
+                i = t.directiveEnd;
+            for (let s = o; s < i; s++) {
+                let a = e.data[s];
+                if (a.contentQueries) {
+                    let u = n[s];
+                    a.contentQueries(1, u, s);
+                }
+            }
+        } finally {
+            M(r);
+        }
+    }
+}
+function hs(e, t, n) {
+    Ku() && (Sg(e, t, n, X(n, t)), (n.flags & 64) === 64 && Kc(e, t, n));
+}
+function gs(e, t, n = X) {
+    let r = t.localNames;
+    if (r !== null) {
+        let o = t.index + 1;
+        for (let i = 0; i < r.length; i += 2) {
+            let s = r[i + 1],
+                a = s === -1 ? n(t, e) : e[s];
+            e[o++] = a;
+        }
+    }
+}
+function Qc(e) {
+    let t = e.tView;
+    return t === null || t.incompleteFirstPass
+        ? (e.tView = ms(
+              1,
+              null,
+              e.template,
+              e.decls,
+              e.vars,
+              e.directiveDefs,
+              e.pipeDefs,
+              e.viewQuery,
+              e.schemas,
+              e.consts,
+              e.id
+          ))
+        : t;
+}
+function ms(e, t, n, r, o, i, s, a, u, c, l) {
+    let d = Y + r,
+        f = d + o,
+        p = yg(d, f),
+        h = typeof c == "function" ? c() : c;
+    return (p[v] = {
+        type: e,
+        blueprint: p,
+        template: n,
+        queries: null,
+        viewQuery: a,
+        declTNode: t,
+        data: p.slice().fill(null, d),
+        bindingStartIndex: d,
+        expandoStartIndex: f,
+        hostBindingOpCodes: null,
+        firstCreatePass: !0,
+        firstUpdatePass: !0,
+        staticViewQueries: !1,
+        staticContentQueries: !1,
+        preOrderHooks: null,
+        preOrderCheckHooks: null,
+        contentHooks: null,
+        contentCheckHooks: null,
+        viewHooks: null,
+        viewCheckHooks: null,
+        destroyHooks: null,
+        cleanup: null,
+        contentQueries: null,
+        components: null,
+        directiveRegistry: typeof i == "function" ? i() : i,
+        pipeRegistry: typeof s == "function" ? s() : s,
+        firstChild: null,
+        schemas: u,
+        consts: h,
+        incompleteFirstPass: !1,
+        ssrId: l,
+    });
+}
+function yg(e, t) {
+    let n = [];
+    for (let r = 0; r < t; r++) n.push(r < e ? null : ge);
+    return n;
+}
+function Dg(e, t, n, r) {
+    let i = r.get(Ih, _c) || n === Qt.ShadowDom,
+        s = e.selectRootElement(t, i);
+    return vg(s), s;
+}
+function vg(e) {
+    Ig(e);
+}
+var Ig = () => null;
+function wg(e, t, n, r) {
+    let o = el(t);
+    o.push(n), e.firstCreatePass && tl(e).push(r, o.length - 1);
+}
+function Eg(e, t, n, r, o, i) {
+    let s = t ? t.injectorIndex : -1,
+        a = 0;
+    return (
+        Ju() && (a |= 128),
+        {
+            type: n,
+            index: r,
+            insertBeforeIndex: null,
+            injectorIndex: s,
+            directiveStart: -1,
+            directiveEnd: -1,
+            directiveStylingLast: -1,
+            componentOffset: -1,
+            propertyBindings: null,
+            flags: a,
+            providerIndexes: 0,
+            value: o,
+            attrs: i,
+            mergedAttrs: null,
+            localNames: null,
+            initialInputs: void 0,
+            inputs: null,
+            outputs: null,
+            tView: null,
+            next: null,
+            prev: null,
+            projectionNext: null,
+            child: null,
+            parent: t,
+            projection: null,
+            styles: null,
+            stylesWithoutHost: null,
+            residualStyles: void 0,
+            classes: null,
+            classesWithoutHost: null,
+            residualClasses: void 0,
+            classBindings: 0,
+            styleBindings: 0,
+        }
+    );
+}
+function Qa(e, t, n, r, o) {
+    for (let i in t) {
+        if (!t.hasOwnProperty(i)) continue;
+        let s = t[i];
+        if (s === void 0) continue;
+        r ??= {};
+        let a,
+            u = Ze.None;
+        Array.isArray(s) ? ((a = s[0]), (u = s[1])) : (a = s);
+        let c = i;
+        if (o !== null) {
+            if (!o.hasOwnProperty(i)) continue;
+            c = o[i];
+        }
+        e === 0 ? Za(r, n, c, a, u) : Za(r, n, c, a);
+    }
+    return r;
+}
+function Za(e, t, n, r, o) {
+    let i;
+    e.hasOwnProperty(n) ? (i = e[n]).push(t, r) : (i = e[n] = [t, r]),
+        o !== void 0 && i.push(o);
+}
+function Cg(e, t, n) {
+    let r = t.directiveStart,
+        o = t.directiveEnd,
+        i = e.data,
+        s = t.attrs,
+        a = [],
+        u = null,
+        c = null;
+    for (let l = r; l < o; l++) {
+        let d = i[l],
+            f = n ? n.get(d) : null,
+            p = f ? f.inputs : null,
+            h = f ? f.outputs : null;
+        (u = Qa(0, d.inputs, l, u, p)), (c = Qa(1, d.outputs, l, c, h));
+        let w = u !== null && s !== null && !Gi(t) ? Vg(u, l, s) : null;
+        a.push(w);
+    }
+    u !== null &&
+        (u.hasOwnProperty("class") && (t.flags |= 8),
+        u.hasOwnProperty("style") && (t.flags |= 16)),
+        (t.initialInputs = a),
+        (t.inputs = u),
+        (t.outputs = c);
+}
+function bg(e) {
+    return e === "class"
+        ? "className"
+        : e === "for"
+          ? "htmlFor"
+          : e === "formaction"
+            ? "formAction"
+            : e === "innerHtml"
+              ? "innerHTML"
+              : e === "readonly"
+                ? "readOnly"
+                : e === "tabindex"
+                  ? "tabIndex"
+                  : e;
+}
+function ys(e, t, n, r, o, i, s, a) {
+    let u = X(t, n),
+        c = t.inputs,
+        l;
+    !a && c != null && (l = c[r])
+        ? (vs(e, n, l, r, o), Nr(t) && _g(n, t.index))
+        : t.type & 3
+          ? ((r = bg(r)),
+            (o = s != null ? s(o, t.value || "", r) : o),
+            i.setProperty(u, r, o))
+          : t.type & 12;
+}
+function _g(e, t) {
+    let n = ke(t, e);
+    n[m] & 16 || (n[m] |= 64);
+}
+function Ds(e, t, n, r) {
+    if (Ku()) {
+        let o = r === null ? null : { "": -1 },
+            i = Ng(e, n),
+            s,
+            a;
+        i === null ? (s = a = null) : ([s, a] = i),
+            s !== null && Zc(e, t, n, s, o, a),
+            o && Ag(n, r, o);
+    }
+    n.mergedAttrs = Zt(n.mergedAttrs, n.attrs);
+}
+function Zc(e, t, n, r, o, i) {
+    for (let c = 0; c < r.length; c++) zo(lr(n, t), e, r[c].type);
+    Fg(n, e.data.length, r.length);
+    for (let c = 0; c < r.length; c++) {
+        let l = r[c];
+        l.providersResolver && l.providersResolver(l);
+    }
+    let s = !1,
+        a = !1,
+        u = qc(e, t, r.length, null);
+    for (let c = 0; c < r.length; c++) {
+        let l = r[c];
+        (n.mergedAttrs = Zt(n.mergedAttrs, l.hostAttrs)),
+            Rg(e, n, t, u, l),
+            Og(u, l, o),
+            l.contentQueries !== null && (n.flags |= 4),
+            (l.hostBindings !== null ||
+                l.hostAttrs !== null ||
+                l.hostVars !== 0) &&
+                (n.flags |= 64);
+        let d = l.type.prototype;
+        !s &&
+            (d.ngOnChanges || d.ngOnInit || d.ngDoCheck) &&
+            ((e.preOrderHooks ??= []).push(n.index), (s = !0)),
+            !a &&
+                (d.ngOnChanges || d.ngDoCheck) &&
+                ((e.preOrderCheckHooks ??= []).push(n.index), (a = !0)),
+            u++;
+    }
+    Cg(e, n, i);
+}
+function Mg(e, t, n, r, o) {
+    let i = o.hostBindings;
+    if (i) {
+        let s = e.hostBindingOpCodes;
+        s === null && (s = e.hostBindingOpCodes = []);
+        let a = ~t.index;
+        xg(s) != a && s.push(a), s.push(n, r, i);
+    }
+}
+function xg(e) {
+    let t = e.length;
+    for (; t > 0; ) {
+        let n = e[--t];
+        if (typeof n == "number" && n < 0) return n;
+    }
+    return 0;
+}
+function Sg(e, t, n, r) {
+    let o = n.directiveStart,
+        i = n.directiveEnd;
+    Nr(n) && Pg(t, n, e.data[o + n.componentOffset]),
+        e.firstCreatePass || lr(n, t),
+        Re(r, t);
+    let s = n.initialInputs;
+    for (let a = o; a < i; a++) {
+        let u = e.data[a],
+            c = tt(t, e, a, n);
+        if ((Re(c, t), s !== null && jg(t, a - o, c, u, n, s), Oe(u))) {
+            let l = ke(n.index, t);
+            l[J] = tt(t, e, a, n);
+        }
+    }
+}
+function Kc(e, t, n) {
+    let r = n.directiveStart,
+        o = n.directiveEnd,
+        i = n.index,
+        s = Vp();
+    try {
+        Xe(i);
+        for (let a = r; a < o; a++) {
+            let u = e.data[a],
+                c = t[a];
+            Uo(a),
+                (u.hostBindings !== null ||
+                    u.hostVars !== 0 ||
+                    u.hostAttrs !== null) &&
+                    Tg(u, c);
+        }
+    } finally {
+        Xe(-1), Uo(s);
+    }
+}
+function Tg(e, t) {
+    e.hostBindings !== null && e.hostBindings(1, t);
+}
+function Ng(e, t) {
+    let n = e.directiveRegistry,
+        r = null,
+        o = null;
+    if (n)
+        for (let i = 0; i < n.length; i++) {
+            let s = n[i];
+            if (xu(t, s.selectors, !1))
+                if ((r || (r = []), Oe(s)))
+                    if (s.findHostDirectiveDefs !== null) {
+                        let a = [];
+                        (o = o || new Map()),
+                            s.findHostDirectiveDefs(s, a, o),
+                            r.unshift(...a, s);
+                        let u = a.length;
+                        si(e, t, u);
+                    } else r.unshift(s), si(e, t, 0);
+                else
+                    (o = o || new Map()),
+                        s.findHostDirectiveDefs?.(s, r, o),
+                        r.push(s);
+        }
+    return r === null ? null : [r, o];
+}
+function si(e, t, n) {
+    (t.componentOffset = n), (e.components ??= []).push(t.index);
+}
+function Ag(e, t, n) {
+    if (t) {
+        let r = (e.localNames = []);
+        for (let o = 0; o < t.length; o += 2) {
+            let i = n[t[o + 1]];
+            if (i == null) throw new _(-301, !1);
+            r.push(t[o], i);
+        }
+    }
+}
+function Og(e, t, n) {
+    if (n) {
+        if (t.exportAs)
+            for (let r = 0; r < t.exportAs.length; r++) n[t.exportAs[r]] = e;
+        Oe(t) && (n[""] = e);
+    }
+}
+function Fg(e, t, n) {
+    (e.flags |= 1),
+        (e.directiveStart = t),
+        (e.directiveEnd = t + n),
+        (e.providerIndexes = t);
+}
+function Rg(e, t, n, r, o) {
+    e.data[r] = o;
+    let i = o.factory || (o.factory = St(o.type, !0)),
+        s = new et(i, Oe(o), _e);
+    (e.blueprint[r] = s), (n[r] = s), Mg(e, t, r, qc(e, n, o.hostVars, ge), o);
+}
+function Pg(e, t, n) {
+    let r = X(t, e),
+        o = Qc(n),
+        i = e[ae].rendererFactory,
+        s = 16;
+    n.signals ? (s = 4096) : n.onPush && (s = 64);
+    let a = $r(
+        e,
+        Br(e, o, null, s, r, t, null, i.createRenderer(r, n), null, null, null)
+    );
+    e[t.index] = a;
+}
+function kg(e, t, n, r, o, i) {
+    let s = X(e, t);
+    Lg(t[F], s, i, e.value, n, r, o);
+}
+function Lg(e, t, n, r, o, i, s) {
+    if (i == null) e.removeAttribute(t, o, n);
+    else {
+        let a = s == null ? xr(i) : s(i, r || "", o);
+        e.setAttribute(t, o, a, n);
+    }
+}
+function jg(e, t, n, r, o, i) {
+    let s = i[t];
+    if (s !== null)
+        for (let a = 0; a < s.length; ) {
+            let u = s[a++],
+                c = s[a++],
+                l = s[a++],
+                d = s[a++];
+            Wc(r, n, u, c, l, d);
+        }
+}
+function Vg(e, t, n) {
+    let r = null,
+        o = 0;
+    for (; o < n.length; ) {
+        let i = n[o];
+        if (i === 0) {
+            o += 4;
+            continue;
+        } else if (i === 5) {
+            o += 2;
+            continue;
+        }
+        if (typeof i == "number") break;
+        if (e.hasOwnProperty(i)) {
+            r === null && (r = []);
+            let s = e[i];
+            for (let a = 0; a < s.length; a += 3)
+                if (s[a] === t) {
+                    r.push(i, s[a + 1], s[a + 2], n[o + 1]);
+                    break;
+                }
+        }
+        o += 2;
+    }
+    return r;
+}
+function Jc(e, t, n, r) {
+    return [e, !0, 0, t, null, r, null, n, null, null];
+}
+function Xc(e, t) {
+    let n = e.contentQueries;
+    if (n !== null) {
+        let r = M(null);
+        try {
+            for (let o = 0; o < n.length; o += 2) {
+                let i = n[o],
+                    s = n[o + 1];
+                if (s !== -1) {
+                    let a = e.data[s];
+                    ns(i), a.contentQueries(2, t[s], s);
+                }
+            }
+        } finally {
+            M(r);
+        }
+    }
+}
+function $r(e, t) {
+    return e[en] ? (e[Ra][se] = t) : (e[en] = t), (e[Ra] = t), t;
+}
+function ai(e, t, n) {
+    ns(0);
+    let r = M(null);
+    try {
+        t(e, n);
+    } finally {
+        M(r);
+    }
+}
+function el(e) {
+    return e[Xt] || (e[Xt] = []);
+}
+function tl(e) {
+    return e.cleanup || (e.cleanup = []);
+}
+function nl(e, t) {
+    let n = e[At],
+        r = n ? n.get(Fe, null) : null;
+    r && r.handleError(t);
+}
+function vs(e, t, n, r, o) {
+    for (let i = 0; i < n.length; ) {
+        let s = n[i++],
+            a = n[i++],
+            u = n[i++],
+            c = t[s],
+            l = e.data[s];
+        Wc(l, c, r, a, u, o);
+    }
+}
+function Bg(e, t, n) {
+    let r = Yu(t, e);
+    Zh(e[F], r, n);
+}
+function $g(e, t) {
+    let n = ke(t, e),
+        r = n[v];
+    Hg(r, n);
+    let o = n[Ee];
+    o !== null && n[Jt] === null && (n[Jt] = as(o, n[At])), Is(r, n, n[J]);
+}
+function Hg(e, t) {
+    for (let n = t.length; n < e.blueprint.length; n++) t.push(e.blueprint[n]);
+}
+function Is(e, t, n) {
+    rs(t);
+    try {
+        let r = e.viewQuery;
+        r !== null && ai(1, r, n);
+        let o = e.template;
+        o !== null && Yc(e, t, o, 1, n),
+            e.firstCreatePass && (e.firstCreatePass = !1),
+            t[Ie]?.finishViewCreation(e),
+            e.staticContentQueries && Xc(e, t),
+            e.staticViewQueries && ai(2, e.viewQuery, n);
+        let i = e.components;
+        i !== null && Ug(t, i);
+    } catch (r) {
+        throw (
+            (e.firstCreatePass &&
+                ((e.incompleteFirstPass = !0), (e.firstCreatePass = !1)),
+            r)
+        );
+    } finally {
+        (t[m] &= -5), os();
+    }
+}
+function Ug(e, t) {
+    for (let n = 0; n < t.length; n++) $g(e, t[n]);
+}
+function rl(e, t, n, r) {
+    let o = M(null);
+    try {
+        let i = t.tView,
+            a = e[m] & 4096 ? 4096 : 16,
+            u = Br(
+                e,
+                i,
+                n,
+                a,
+                null,
+                t,
+                null,
+                null,
+                r?.injector ?? null,
+                r?.embeddedViewInjector ?? null,
+                r?.dehydratedView ?? null
+            ),
+            c = e[t.index];
+        u[an] = c;
+        let l = e[Ie];
+        return l !== null && (u[Ie] = l.createEmbeddedView(i)), Is(i, u, n), u;
+    } finally {
+        M(o);
+    }
+}
+function Gg(e, t) {
+    let n = W + t;
+    if (n < e.length) return e[n];
+}
+function ui(e, t) {
+    return !t || t.firstChild === null || Ic(e);
+}
+function ol(e, t, n, r = !0) {
+    let o = t[v];
+    if ((tg(o, t, e, n), r)) {
+        let s = ii(n, e),
+            a = t[F],
+            u = ds(a, e[Je]);
+        u !== null && Xh(o, e[Q], a, t, u, s);
+    }
+    let i = t[Jt];
+    i !== null && i.firstChild !== null && (i.firstChild = null);
+}
+function zg(e, t) {
+    let n = fr(e, t);
+    return n !== void 0 && ls(n[v], n), n;
+}
+function hr(e, t, n, r, o = !1) {
+    for (; n !== null; ) {
+        let i = t[n.index];
+        i !== null && r.push(he(i)), Ce(i) && Wg(i, r);
+        let s = n.type;
+        if (s & 8) hr(e, t, n.child, r);
+        else if (s & 32) {
+            let a = cs(n, t),
+                u;
+            for (; (u = a()); ) r.push(u);
+        } else if (s & 16) {
+            let a = $c(t, n);
+            if (Array.isArray(a)) r.push(...a);
+            else {
+                let u = nn(t[ue]);
+                hr(u[v], u, a, r, !0);
+            }
+        }
+        n = o ? n.projectionNext : n.next;
+    }
+    return r;
+}
+function Wg(e, t) {
+    for (let n = W; n < e.length; n++) {
+        let r = e[n],
+            o = r[v].firstChild;
+        o !== null && hr(r[v], r, o, t);
+    }
+    e[Je] !== e[Ee] && t.push(e[Je]);
+}
+var il = [];
+function qg(e) {
+    return e[Ke] ?? Yg(e);
+}
+function Yg(e) {
+    let t = il.pop() ?? Object.create(Zg);
+    return (t.lView = e), t;
+}
+function Qg(e) {
+    e.lView[Ke] !== e && ((e.lView = null), il.push(e));
+}
+var Zg = lt(xe({}, Yr), {
+        consumerIsAlwaysLive: !0,
+        consumerMarkedDirty: (e) => {
+            tn(e.lView);
+        },
+        consumerOnSignalRead() {
+            this.lView[Ke] = this;
+        },
+    }),
+    sl = 100;
+function al(e, t = !0, n = 0) {
+    let r = e[ae],
+        o = r.rendererFactory,
+        i = !1;
+    i || o.begin?.();
+    try {
+        Kg(e, n);
+    } catch (s) {
+        throw (t && nl(e, s), s);
+    } finally {
+        i || (o.end?.(), r.inlineEffectRunner?.flush());
+    }
+}
+function Kg(e, t) {
+    ci(e, t);
+    let n = 0;
+    for (; Xi(e); ) {
+        if (n === sl) throw new _(103, !1);
+        n++, ci(e, 1);
+    }
+}
+function Jg(e, t, n, r) {
+    let o = t[m];
+    if ((o & 256) === 256) return;
+    let i = !1;
+    !i && t[ae].inlineEffectRunner?.flush(), rs(t);
+    let s = null,
+        a = null;
+    !i && Xg(e) && ((a = qg(t)), (s = Qr(a)));
+    try {
+        Qu(t), kp(e.bindingStartIndex), n !== null && Yc(e, t, n, 2, r);
+        let u = (o & 3) === 3;
+        if (!i)
+            if (u) {
+                let d = e.preOrderCheckHooks;
+                d !== null && Kn(t, d, null);
+            } else {
+                let d = e.preOrderHooks;
+                d !== null && Jn(t, d, 0, null), Eo(t, 0);
+            }
+        if ((em(t), ul(t, 0), e.contentQueries !== null && Xc(e, t), !i))
+            if (u) {
+                let d = e.contentCheckHooks;
+                d !== null && Kn(t, d);
+            } else {
+                let d = e.contentHooks;
+                d !== null && Jn(t, d, 1), Eo(t, 1);
+            }
+        gg(e, t);
+        let c = e.components;
+        c !== null && ll(t, c, 0);
+        let l = e.viewQuery;
+        if ((l !== null && ai(2, l, r), !i))
+            if (u) {
+                let d = e.viewCheckHooks;
+                d !== null && Kn(t, d);
+            } else {
+                let d = e.viewHooks;
+                d !== null && Jn(t, d, 2), Eo(t, 2);
+            }
+        if ((e.firstUpdatePass === !0 && (e.firstUpdatePass = !1), t[Zn])) {
+            for (let d of t[Zn]) d();
+            t[Zn] = null;
+        }
+        i || (t[m] &= -73);
+    } catch (u) {
+        throw (tn(t), u);
+    } finally {
+        a !== null && (Zr(a, s), Qg(a)), os();
+    }
+}
+function Xg(e) {
+    return e.type !== 2;
+}
+function ul(e, t) {
+    for (let n = Ec(e); n !== null; n = Cc(n))
+        for (let r = W; r < n.length; r++) {
+            let o = n[r];
+            cl(o, t);
+        }
+}
+function em(e) {
+    for (let t = Ec(e); t !== null; t = Cc(t)) {
+        if (!(t[m] & Qi.HasTransplantedViews)) continue;
+        let n = t[Ot];
+        for (let r = 0; r < n.length; r++) {
+            let o = n[r],
+                i = o[j];
+            _p(o);
+        }
+    }
+}
+function tm(e, t, n) {
+    let r = ke(t, e);
+    cl(r, n);
+}
+function cl(e, t) {
+    Ji(e) && ci(e, t);
+}
+function ci(e, t) {
+    let r = e[v],
+        o = e[m],
+        i = e[Ke],
+        s = !!(t === 0 && o & 16);
+    if (
+        ((s ||= !!(o & 64 && t === 0)),
+        (s ||= !!(o & 1024)),
+        (s ||= !!(i?.dirty && mn(i))),
+        i && (i.dirty = !1),
+        (e[m] &= -9217),
+        s)
+    )
+        Jg(r, e, r.template, e[J]);
+    else if (o & 8192) {
+        ul(e, 1);
+        let a = r.components;
+        a !== null && ll(e, a, 1);
+    }
+}
+function ll(e, t, n) {
+    for (let r = 0; r < t.length; r++) tm(e, t[r], n);
+}
+function ws(e) {
+    for (e[ae].changeDetectionScheduler?.notify(); e; ) {
+        e[m] |= 64;
+        let t = nn(e);
+        if (gp(e) && !t) return e;
+        e = t;
+    }
+    return null;
+}
+var nt = class {
+        get rootNodes() {
+            let t = this._lView,
+                n = t[v];
+            return hr(n, t, n.firstChild, []);
+        }
+        constructor(t, n, r = !0) {
+            (this._lView = t),
+                (this._cdRefInjectingView = n),
+                (this.notifyErrorHandler = r),
+                (this._appRef = null),
+                (this._attachedToViewContainer = !1);
+        }
+        get context() {
+            return this._lView[J];
+        }
+        set context(t) {
+            this._lView[J] = t;
+        }
+        get destroyed() {
+            return (this._lView[m] & 256) === 256;
+        }
+        destroy() {
+            if (this._appRef) this._appRef.detachView(this);
+            else if (this._attachedToViewContainer) {
+                let t = this._lView[j];
+                if (Ce(t)) {
+                    let n = t[ar],
+                        r = n ? n.indexOf(this) : -1;
+                    r > -1 && (fr(t, r), or(n, r));
+                }
+                this._attachedToViewContainer = !1;
+            }
+            ls(this._lView[v], this._lView);
+        }
+        onDestroy(t) {
+            Zu(this._lView, t);
+        }
+        markForCheck() {
+            ws(this._cdRefInjectingView || this._lView);
+        }
+        detach() {
+            this._lView[m] &= -129;
+        }
+        reattach() {
+            Ho(this._lView), (this._lView[m] |= 128);
+        }
+        detectChanges() {
+            (this._lView[m] |= 1024), al(this._lView, this.notifyErrorHandler);
+        }
+        checkNoChanges() {}
+        attachToViewContainerRef() {
+            if (this._appRef) throw new _(902, !1);
+            this._attachedToViewContainer = !0;
+        }
+        detachFromAppRef() {
+            (this._appRef = null), kc(this._lView[v], this._lView);
+        }
+        attachToAppRef(t) {
+            if (this._attachedToViewContainer) throw new _(902, !1);
+            (this._appRef = t), Ho(this._lView);
+        }
+    },
+    rt = (() => {
+        let t = class t {};
+        t.__NG_ELEMENT_ID__ = om;
+        let e = t;
+        return e;
+    })(),
+    nm = rt,
+    rm = class extends nm {
+        constructor(t, n, r) {
+            super(),
+                (this._declarationLView = t),
+                (this._declarationTContainer = n),
+                (this.elementRef = r);
+        }
+        get ssrId() {
+            return this._declarationTContainer.tView?.ssrId || null;
+        }
+        createEmbeddedView(t, n) {
+            return this.createEmbeddedViewImpl(t, n);
+        }
+        createEmbeddedViewImpl(t, n, r) {
+            let o = rl(this._declarationLView, this._declarationTContainer, t, {
+                embeddedViewInjector: n,
+                dehydratedView: r,
+            });
+            return new nt(o);
+        }
+    };
+function om() {
+    return Hr(V(), E());
+}
+function Hr(e, t) {
+    return e.type & 4 ? new rm(t, e, Lt(e, t)) : null;
+}
+var tM = new RegExp(`^(\\d+)*(${Dh}|${yh})*(.*)`);
+var im = () => null;
+function li(e, t) {
+    return im(e, t);
+}
+var gr = class {},
+    di = class {},
+    mr = class {};
+function sm(e) {
+    let t = Error(`No component factory found for ${H(e)}.`);
+    return (t[am] = e), t;
+}
+var am = "ngComponent";
+var fi = class {
+        resolveComponentFactory(t) {
+            throw sm(t);
+        }
+    },
+    Ur = (() => {
+        let t = class t {};
+        t.NULL = new fi();
+        let e = t;
+        return e;
+    })(),
+    pi = class {},
+    dl = (() => {
+        let t = class t {
+            constructor() {
+                this.destroyNode = null;
+            }
+        };
+        t.__NG_ELEMENT_ID__ = () => um();
+        let e = t;
+        return e;
+    })();
+function um() {
+    let e = E(),
+        t = V(),
+        n = ke(t.index, e);
+    return (Ye(n) ? n : e)[F];
+}
+var cm = (() => {
+        let t = class t {};
+        t.ɵprov = O({ token: t, providedIn: "root", factory: () => null });
+        let e = t;
+        return e;
+    })(),
+    xo = {};
+var Ka = new Set();
+function dn(e) {
+    Ka.has(e) ||
+        (Ka.add(e),
+        performance?.mark?.("mark_feature_usage", { detail: { feature: e } }));
+}
+function Ja(...e) {}
+function lm() {
+    let e = typeof ve.requestAnimationFrame == "function",
+        t = ve[e ? "requestAnimationFrame" : "setTimeout"],
+        n = ve[e ? "cancelAnimationFrame" : "clearTimeout"];
+    if (typeof Zone < "u" && t && n) {
+        let r = t[Zone.__symbol__("OriginalDelegate")];
+        r && (t = r);
+        let o = n[Zone.__symbol__("OriginalDelegate")];
+        o && (n = o);
+    }
+    return { nativeRequestAnimationFrame: t, nativeCancelAnimationFrame: n };
+}
+var q = class e {
+        constructor({
+            enableLongStackTrace: t = !1,
+            shouldCoalesceEventChangeDetection: n = !1,
+            shouldCoalesceRunChangeDetection: r = !1,
+        }) {
+            if (
+                ((this.hasPendingMacrotasks = !1),
+                (this.hasPendingMicrotasks = !1),
+                (this.isStable = !0),
+                (this.onUnstable = new ie(!1)),
+                (this.onMicrotaskEmpty = new ie(!1)),
+                (this.onStable = new ie(!1)),
+                (this.onError = new ie(!1)),
+                typeof Zone > "u")
+            )
+                throw new _(908, !1);
+            Zone.assertZonePatched();
+            let o = this;
+            (o._nesting = 0),
+                (o._outer = o._inner = Zone.current),
+                Zone.TaskTrackingZoneSpec &&
+                    (o._inner = o._inner.fork(new Zone.TaskTrackingZoneSpec())),
+                t &&
+                    Zone.longStackTraceZoneSpec &&
+                    (o._inner = o._inner.fork(Zone.longStackTraceZoneSpec)),
+                (o.shouldCoalesceEventChangeDetection = !r && n),
+                (o.shouldCoalesceRunChangeDetection = r),
+                (o.lastRequestAnimationFrameId = -1),
+                (o.nativeRequestAnimationFrame =
+                    lm().nativeRequestAnimationFrame),
+                pm(o);
+        }
+        static isInAngularZone() {
+            return (
+                typeof Zone < "u" && Zone.current.get("isAngularZone") === !0
+            );
+        }
+        static assertInAngularZone() {
+            if (!e.isInAngularZone()) throw new _(909, !1);
+        }
+        static assertNotInAngularZone() {
+            if (e.isInAngularZone()) throw new _(909, !1);
+        }
+        run(t, n, r) {
+            return this._inner.run(t, n, r);
+        }
+        runTask(t, n, r, o) {
+            let i = this._inner,
+                s = i.scheduleEventTask("NgZoneEvent: " + o, t, dm, Ja, Ja);
+            try {
+                return i.runTask(s, n, r);
+            } finally {
+                i.cancelTask(s);
+            }
+        }
+        runGuarded(t, n, r) {
+            return this._inner.runGuarded(t, n, r);
+        }
+        runOutsideAngular(t) {
+            return this._outer.run(t);
+        }
+    },
+    dm = {};
+function Es(e) {
+    if (e._nesting == 0 && !e.hasPendingMicrotasks && !e.isStable)
+        try {
+            e._nesting++, e.onMicrotaskEmpty.emit(null);
+        } finally {
+            if ((e._nesting--, !e.hasPendingMicrotasks))
+                try {
+                    e.runOutsideAngular(() => e.onStable.emit(null));
+                } finally {
+                    e.isStable = !0;
+                }
+        }
+}
+function fm(e) {
+    e.isCheckStableRunning ||
+        e.lastRequestAnimationFrameId !== -1 ||
+        ((e.lastRequestAnimationFrameId = e.nativeRequestAnimationFrame.call(
+            ve,
+            () => {
+                e.fakeTopEventTask ||
+                    (e.fakeTopEventTask = Zone.root.scheduleEventTask(
+                        "fakeTopEventTask",
+                        () => {
+                            (e.lastRequestAnimationFrameId = -1),
+                                hi(e),
+                                (e.isCheckStableRunning = !0),
+                                Es(e),
+                                (e.isCheckStableRunning = !1);
+                        },
+                        void 0,
+                        () => {},
+                        () => {}
+                    )),
+                    e.fakeTopEventTask.invoke();
+            }
+        )),
+        hi(e));
+}
+function pm(e) {
+    let t = () => {
+        fm(e);
+    };
+    e._inner = e._inner.fork({
+        name: "angular",
+        properties: { isAngularZone: !0 },
+        onInvokeTask: (n, r, o, i, s, a) => {
+            if (hm(a)) return n.invokeTask(o, i, s, a);
+            try {
+                return Xa(e), n.invokeTask(o, i, s, a);
+            } finally {
+                ((e.shouldCoalesceEventChangeDetection &&
+                    i.type === "eventTask") ||
+                    e.shouldCoalesceRunChangeDetection) &&
+                    t(),
+                    eu(e);
+            }
+        },
+        onInvoke: (n, r, o, i, s, a, u) => {
+            try {
+                return Xa(e), n.invoke(o, i, s, a, u);
+            } finally {
+                e.shouldCoalesceRunChangeDetection && t(), eu(e);
+            }
+        },
+        onHasTask: (n, r, o, i) => {
+            n.hasTask(o, i),
+                r === o &&
+                    (i.change == "microTask"
+                        ? ((e._hasPendingMicrotasks = i.microTask),
+                          hi(e),
+                          Es(e))
+                        : i.change == "macroTask" &&
+                          (e.hasPendingMacrotasks = i.macroTask));
+        },
+        onHandleError: (n, r, o, i) => (
+            n.handleError(o, i),
+            e.runOutsideAngular(() => e.onError.emit(i)),
+            !1
+        ),
+    });
+}
+function hi(e) {
+    e._hasPendingMicrotasks ||
+    ((e.shouldCoalesceEventChangeDetection ||
+        e.shouldCoalesceRunChangeDetection) &&
+        e.lastRequestAnimationFrameId !== -1)
+        ? (e.hasPendingMicrotasks = !0)
+        : (e.hasPendingMicrotasks = !1);
+}
+function Xa(e) {
+    e._nesting++, e.isStable && ((e.isStable = !1), e.onUnstable.emit(null));
+}
+function eu(e) {
+    e._nesting--, Es(e);
+}
+var gi = class {
+    constructor() {
+        (this.hasPendingMicrotasks = !1),
+            (this.hasPendingMacrotasks = !1),
+            (this.isStable = !0),
+            (this.onUnstable = new ie()),
+            (this.onMicrotaskEmpty = new ie()),
+            (this.onStable = new ie()),
+            (this.onError = new ie());
+    }
+    run(t, n, r) {
+        return t.apply(n, r);
+    }
+    runGuarded(t, n, r) {
+        return t.apply(n, r);
+    }
+    runOutsideAngular(t) {
+        return t();
+    }
+    runTask(t, n, r, o) {
+        return t.apply(n, r);
+    }
+};
+function hm(e) {
+    return !Array.isArray(e) || e.length !== 1
+        ? !1
+        : e[0].data?.__ignore_ng_zone__ === !0;
+}
+function gm(e = "zone.js", t) {
+    return e === "noop" ? new gi() : e === "zone.js" ? new q(t) : e;
+}
+var _t = (function (e) {
+        return (
+            (e[(e.EarlyRead = 0)] = "EarlyRead"),
+            (e[(e.Write = 1)] = "Write"),
+            (e[(e.MixedReadWrite = 2)] = "MixedReadWrite"),
+            (e[(e.Read = 3)] = "Read"),
+            e
+        );
+    })(_t || {}),
+    mm = { destroy() {} };
+function ym(e, t) {
+    !t && Vu(ym);
+    let n = t?.injector ?? S(Le);
+    if (!qh(n)) return mm;
+    dn("NgAfterNextRender");
+    let r = n.get(Cs),
+        o = (r.handler ??= new yi()),
+        i = t?.phase ?? _t.MixedReadWrite,
+        s = () => {
+            o.unregister(u), a();
+        },
+        a = n.get(kr).onDestroy(s),
+        u = fp(
+            n,
+            () =>
+                new mi(i, () => {
+                    s(), e();
+                })
+        );
+    return o.register(u), { destroy: s };
+}
+var mi = class {
+        constructor(t, n) {
+            (this.phase = t),
+                (this.callbackFn = n),
+                (this.zone = S(q)),
+                (this.errorHandler = S(Fe, { optional: !0 })),
+                S(gr, { optional: !0 })?.notify(1);
+        }
+        invoke() {
+            try {
+                this.zone.runOutsideAngular(this.callbackFn);
+            } catch (t) {
+                this.errorHandler?.handleError(t);
+            }
+        }
+    },
+    yi = class {
+        constructor() {
+            (this.executingCallbacks = !1),
+                (this.buckets = {
+                    [_t.EarlyRead]: new Set(),
+                    [_t.Write]: new Set(),
+                    [_t.MixedReadWrite]: new Set(),
+                    [_t.Read]: new Set(),
+                }),
+                (this.deferredCallbacks = new Set());
+        }
+        register(t) {
+            (this.executingCallbacks
+                ? this.deferredCallbacks
+                : this.buckets[t.phase]
+            ).add(t);
+        }
+        unregister(t) {
+            this.buckets[t.phase].delete(t), this.deferredCallbacks.delete(t);
+        }
+        execute() {
+            this.executingCallbacks = !0;
+            for (let t of Object.values(this.buckets))
+                for (let n of t) n.invoke();
+            this.executingCallbacks = !1;
+            for (let t of this.deferredCallbacks) this.buckets[t.phase].add(t);
+            this.deferredCallbacks.clear();
+        }
+        destroy() {
+            for (let t of Object.values(this.buckets)) t.clear();
+            this.deferredCallbacks.clear();
+        }
+    },
+    Cs = (() => {
+        let t = class t {
+            constructor() {
+                (this.handler = null), (this.internalCallbacks = []);
+            }
+            execute() {
+                this.executeInternalCallbacks(), this.handler?.execute();
+            }
+            executeInternalCallbacks() {
+                let r = [...this.internalCallbacks];
+                this.internalCallbacks.length = 0;
+                for (let o of r) o();
+            }
+            ngOnDestroy() {
+                this.handler?.destroy(),
+                    (this.handler = null),
+                    (this.internalCallbacks.length = 0);
+            }
+        };
+        t.ɵprov = O({ token: t, providedIn: "root", factory: () => new t() });
+        let e = t;
+        return e;
+    })();
+function yr(e, t, n) {
+    let r = n ? e.styles : null,
+        o = n ? e.classes : null,
+        i = 0;
+    if (t !== null)
+        for (let s = 0; s < t.length; s++) {
+            let a = t[s];
+            if (typeof a == "number") i = a;
+            else if (i == 1) o = Fo(o, a);
+            else if (i == 2) {
+                let u = a,
+                    c = t[++s];
+                r = Fo(r, u + ": " + c + ";");
+            }
+        }
+    n ? (e.styles = r) : (e.stylesWithoutHost = r),
+        n ? (e.classes = o) : (e.classesWithoutHost = o);
+}
+var Dr = class extends Ur {
+    constructor(t) {
+        super(), (this.ngModule = t);
+    }
+    resolveComponentFactory(t) {
+        let n = Ne(t);
+        return new Rt(n, this.ngModule);
+    }
+};
+function tu(e) {
+    let t = [];
+    for (let n in e) {
+        if (!e.hasOwnProperty(n)) continue;
+        let r = e[n];
+        r !== void 0 &&
+            t.push({ propName: Array.isArray(r) ? r[0] : r, templateName: n });
+    }
+    return t;
+}
+function Dm(e) {
+    let t = e.toLowerCase();
+    return t === "svg" ? qu : t === "math" ? vp : null;
+}
+var Di = class {
+        constructor(t, n) {
+            (this.injector = t), (this.parentInjector = n);
+        }
+        get(t, n, r) {
+            r = Sr(r);
+            let o = this.injector.get(t, xo, r);
+            return o !== xo || n === xo ? o : this.parentInjector.get(t, n, r);
+        }
+    },
+    Rt = class extends mr {
+        get inputs() {
+            let t = this.componentDef,
+                n = t.inputTransforms,
+                r = tu(t.inputs);
+            if (n !== null)
+                for (let o of r)
+                    n.hasOwnProperty(o.propName) &&
+                        (o.transform = n[o.propName]);
+            return r;
+        }
+        get outputs() {
+            return tu(this.componentDef.outputs);
+        }
+        constructor(t, n) {
+            super(),
+                (this.componentDef = t),
+                (this.ngModule = n),
+                (this.componentType = t.type),
+                (this.selector = Qf(t.selectors)),
+                (this.ngContentSelectors = t.ngContentSelectors
+                    ? t.ngContentSelectors
+                    : []),
+                (this.isBoundToModule = !!n);
+        }
+        create(t, n, r, o) {
+            let i = M(null);
+            try {
+                o = o || this.ngModule;
+                let s = o instanceof Ae ? o : o?.injector;
+                s &&
+                    this.componentDef.getStandaloneInjector !== null &&
+                    (s = this.componentDef.getStandaloneInjector(s) || s);
+                let a = s ? new Di(t, s) : t,
+                    u = a.get(pi, null);
+                if (u === null) throw new _(407, !1);
+                let c = a.get(cm, null),
+                    l = a.get(Cs, null),
+                    d = a.get(gr, null),
+                    f = {
+                        rendererFactory: u,
+                        sanitizer: c,
+                        inlineEffectRunner: null,
+                        afterRenderEventManager: l,
+                        changeDetectionScheduler: d,
+                    },
+                    p = u.createRenderer(null, this.componentDef),
+                    h = this.componentDef.selectors[0][0] || "div",
+                    w = r
+                        ? Dg(p, r, this.componentDef.encapsulation, a)
+                        : Pc(p, h, Dm(h)),
+                    k = 512;
+                this.componentDef.signals
+                    ? (k |= 4096)
+                    : this.componentDef.onPush || (k |= 16);
+                let N = null;
+                w !== null && (N = as(w, a, !0));
+                let Z = ms(
+                        0,
+                        null,
+                        null,
+                        1,
+                        0,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                    ),
+                    U = Br(null, Z, null, k, null, null, f, p, a, null, N);
+                rs(U);
+                let me, ut;
+                try {
+                    let ee = this.componentDef,
+                        ct,
+                        zr = null;
+                    ee.findHostDirectiveDefs
+                        ? ((ct = []),
+                          (zr = new Map()),
+                          ee.findHostDirectiveDefs(ee, ct, zr),
+                          ct.push(ee))
+                        : (ct = [ee]);
+                    let Kl = vm(U, w),
+                        Jl = Im(Kl, w, ee, ct, U, f, p);
+                    (ut = Ki(Z, Y)),
+                        w && Cm(p, ee, w, r),
+                        n !== void 0 && bm(ut, this.ngContentSelectors, n),
+                        (me = Em(Jl, ee, ct, zr, U, [_m])),
+                        Is(Z, U, null);
+                } finally {
+                    os();
+                }
+                return new vi(this.componentType, me, Lt(ut, U), U, ut);
+            } finally {
+                M(i);
+            }
+        }
+    },
+    vi = class extends di {
+        constructor(t, n, r, o, i) {
+            super(),
+                (this.location = r),
+                (this._rootLView = o),
+                (this._tNode = i),
+                (this.previousInputValues = null),
+                (this.instance = n),
+                (this.hostView = this.changeDetectorRef =
+                    new nt(o, void 0, !1)),
+                (this.componentType = t);
+        }
+        setInput(t, n) {
+            let r = this._tNode.inputs,
+                o;
+            if (r !== null && (o = r[t])) {
+                if (
+                    ((this.previousInputValues ??= new Map()),
+                    this.previousInputValues.has(t) &&
+                        Object.is(this.previousInputValues.get(t), n))
+                )
+                    return;
+                let i = this._rootLView;
+                vs(i[v], i, o, t, n), this.previousInputValues.set(t, n);
+                let s = ke(this._tNode.index, i);
+                ws(s);
+            }
+        }
+        get injector() {
+            return new Qe(this._tNode, this._rootLView);
+        }
+        destroy() {
+            this.hostView.destroy();
+        }
+        onDestroy(t) {
+            this.hostView.onDestroy(t);
+        }
+    };
+function vm(e, t) {
+    let n = e[v],
+        r = Y;
+    return (e[r] = t), Vt(n, r, 2, "#host", null);
+}
+function Im(e, t, n, r, o, i, s) {
+    let a = o[v];
+    wm(r, e, t, s);
+    let u = null;
+    t !== null && (u = as(t, o[At]));
+    let c = i.rendererFactory.createRenderer(t, n),
+        l = 16;
+    n.signals ? (l = 4096) : n.onPush && (l = 64);
+    let d = Br(o, Qc(n), null, l, o[e.index], e, i, c, null, null, u);
+    return (
+        a.firstCreatePass && si(a, e, r.length - 1), $r(o, d), (o[e.index] = d)
+    );
+}
+function wm(e, t, n, r) {
+    for (let o of e) t.mergedAttrs = Zt(t.mergedAttrs, o.hostAttrs);
+    t.mergedAttrs !== null &&
+        (yr(t, t.mergedAttrs, !0), n !== null && Gc(r, n, t));
+}
+function Em(e, t, n, r, o, i) {
+    let s = V(),
+        a = o[v],
+        u = X(s, o);
+    Zc(a, o, s, n, null, r);
+    for (let l = 0; l < n.length; l++) {
+        let d = s.directiveStart + l,
+            f = tt(o, a, d, s);
+        Re(f, o);
+    }
+    Kc(a, o, s), u && Re(u, o);
+    let c = tt(o, a, s.directiveStart + s.componentOffset, s);
+    if (((e[J] = o[J] = c), i !== null)) for (let l of i) l(c, t);
+    return ps(a, s, o), c;
+}
+function Cm(e, t, n, r) {
+    if (r) Lo(e, n, ["ng-version", "17.3.9"]);
+    else {
+        let { attrs: o, classes: i } = Zf(t.selectors[0]);
+        o && Lo(e, n, o), i && i.length > 0 && Uc(e, n, i.join(" "));
+    }
+}
+function bm(e, t, n) {
+    let r = (e.projection = []);
+    for (let o = 0; o < t.length; o++) {
+        let i = n[o];
+        r.push(i != null ? Array.from(i) : null);
+    }
+}
+function _m() {
+    let e = V();
+    Pr(E()[v], e);
+}
+var Bt = (() => {
+    let t = class t {};
+    t.__NG_ELEMENT_ID__ = Mm;
+    let e = t;
+    return e;
+})();
+function Mm() {
+    let e = V();
+    return pl(e, E());
+}
+var xm = Bt,
+    fl = class extends xm {
+        constructor(t, n, r) {
+            super(),
+                (this._lContainer = t),
+                (this._hostTNode = n),
+                (this._hostLView = r);
+        }
+        get element() {
+            return Lt(this._hostTNode, this._hostLView);
+        }
+        get injector() {
+            return new Qe(this._hostTNode, this._hostLView);
+        }
+        get parentInjector() {
+            let t = is(this._hostTNode, this._hostLView);
+            if (cc(t)) {
+                let n = cr(t, this._hostLView),
+                    r = ur(t),
+                    o = n[v].data[r + 8];
+                return new Qe(o, n);
+            } else return new Qe(null, this._hostLView);
+        }
+        clear() {
+            for (; this.length > 0; ) this.remove(this.length - 1);
+        }
+        get(t) {
+            let n = nu(this._lContainer);
+            return (n !== null && n[t]) || null;
+        }
+        get length() {
+            return this._lContainer.length - W;
+        }
+        createEmbeddedView(t, n, r) {
+            let o, i;
+            typeof r == "number"
+                ? (o = r)
+                : r != null && ((o = r.index), (i = r.injector));
+            let s = li(this._lContainer, t.ssrId),
+                a = t.createEmbeddedViewImpl(n || {}, i, s);
+            return this.insertImpl(a, o, ui(this._hostTNode, s)), a;
+        }
+        createComponent(t, n, r, o, i) {
+            let s = t && !hp(t),
+                a;
+            if (s) a = n;
+            else {
+                let h = n || {};
+                (a = h.index),
+                    (r = h.injector),
+                    (o = h.projectableNodes),
+                    (i = h.environmentInjector || h.ngModuleRef);
+            }
+            let u = s ? t : new Rt(Ne(t)),
+                c = r || this.parentInjector;
+            if (!i && u.ngModule == null) {
+                let w = (s ? c : this.parentInjector).get(Ae, null);
+                w && (i = w);
+            }
+            let l = Ne(u.componentType ?? {}),
+                d = li(this._lContainer, l?.id ?? null),
+                f = d?.firstChild ?? null,
+                p = u.create(c, o, f, i);
+            return this.insertImpl(p.hostView, a, ui(this._hostTNode, d)), p;
+        }
+        insert(t, n) {
+            return this.insertImpl(t, n, !0);
+        }
+        insertImpl(t, n, r) {
+            let o = t._lView;
+            if (bp(o)) {
+                let a = this.indexOf(t);
+                if (a !== -1) this.detach(a);
+                else {
+                    let u = o[j],
+                        c = new fl(u, u[Q], u[j]);
+                    c.detach(c.indexOf(t));
+                }
+            }
+            let i = this._adjustIndex(n),
+                s = this._lContainer;
+            return (
+                ol(s, o, i, r), t.attachToViewContainerRef(), wu(So(s), i, t), t
+            );
+        }
+        move(t, n) {
+            return this.insert(t, n);
+        }
+        indexOf(t) {
+            let n = nu(this._lContainer);
+            return n !== null ? n.indexOf(t) : -1;
+        }
+        remove(t) {
+            let n = this._adjustIndex(t, -1),
+                r = fr(this._lContainer, n);
+            r && (or(So(this._lContainer), n), ls(r[v], r));
+        }
+        detach(t) {
+            let n = this._adjustIndex(t, -1),
+                r = fr(this._lContainer, n);
+            return r && or(So(this._lContainer), n) != null ? new nt(r) : null;
+        }
+        _adjustIndex(t, n = 0) {
+            return t ?? this.length + n;
+        }
+    };
+function nu(e) {
+    return e[ar];
+}
+function So(e) {
+    return e[ar] || (e[ar] = []);
+}
+function pl(e, t) {
+    let n,
+        r = t[e.index];
+    return (
+        Ce(r) ? (n = r) : ((n = Jc(r, t, null, e)), (t[e.index] = n), $r(t, n)),
+        Tm(n, t, e, r),
+        new fl(n, e, t)
+    );
+}
+function Sm(e, t) {
+    let n = e[F],
+        r = n.createComment(""),
+        o = X(t, e),
+        i = ds(n, o);
+    return pr(n, i, r, ag(n, o), !1), r;
+}
+var Tm = Om,
+    Nm = () => !1;
+function Am(e, t, n) {
+    return Nm(e, t, n);
+}
+function Om(e, t, n, r) {
+    if (e[Je]) return;
+    let o;
+    n.type & 8 ? (o = he(r)) : (o = Sm(t, n)), (e[Je] = o);
+}
+var Ii = class e {
+        constructor(t) {
+            (this.queryList = t), (this.matches = null);
+        }
+        clone() {
+            return new e(this.queryList);
+        }
+        setDirty() {
+            this.queryList.setDirty();
+        }
+    },
+    wi = class e {
+        constructor(t = []) {
+            this.queries = t;
+        }
+        createEmbeddedView(t) {
+            let n = t.queries;
+            if (n !== null) {
+                let r =
+                        t.contentQueries !== null
+                            ? t.contentQueries[0]
+                            : n.length,
+                    o = [];
+                for (let i = 0; i < r; i++) {
+                    let s = n.getByIndex(i),
+                        a = this.queries[s.indexInDeclarationView];
+                    o.push(a.clone());
+                }
+                return new e(o);
+            }
+            return null;
+        }
+        insertView(t) {
+            this.dirtyQueriesWithMatches(t);
+        }
+        detachView(t) {
+            this.dirtyQueriesWithMatches(t);
+        }
+        finishViewCreation(t) {
+            this.dirtyQueriesWithMatches(t);
+        }
+        dirtyQueriesWithMatches(t) {
+            for (let n = 0; n < this.queries.length; n++)
+                bs(t, n).matches !== null && this.queries[n].setDirty();
+        }
+    },
+    vr = class {
+        constructor(t, n, r = null) {
+            (this.flags = n),
+                (this.read = r),
+                typeof t == "string"
+                    ? (this.predicate = Bm(t))
+                    : (this.predicate = t);
+        }
+    },
+    Ei = class e {
+        constructor(t = []) {
+            this.queries = t;
+        }
+        elementStart(t, n) {
+            for (let r = 0; r < this.queries.length; r++)
+                this.queries[r].elementStart(t, n);
+        }
+        elementEnd(t) {
+            for (let n = 0; n < this.queries.length; n++)
+                this.queries[n].elementEnd(t);
+        }
+        embeddedTView(t) {
+            let n = null;
+            for (let r = 0; r < this.length; r++) {
+                let o = n !== null ? n.length : 0,
+                    i = this.getByIndex(r).embeddedTView(t, o);
+                i &&
+                    ((i.indexInDeclarationView = r),
+                    n !== null ? n.push(i) : (n = [i]));
+            }
+            return n !== null ? new e(n) : null;
+        }
+        template(t, n) {
+            for (let r = 0; r < this.queries.length; r++)
+                this.queries[r].template(t, n);
+        }
+        getByIndex(t) {
+            return this.queries[t];
+        }
+        get length() {
+            return this.queries.length;
+        }
+        track(t) {
+            this.queries.push(t);
+        }
+    },
+    Ci = class e {
+        constructor(t, n = -1) {
+            (this.metadata = t),
+                (this.matches = null),
+                (this.indexInDeclarationView = -1),
+                (this.crossesNgTemplate = !1),
+                (this._appliesToNextNode = !0),
+                (this._declarationNodeIndex = n);
+        }
+        elementStart(t, n) {
+            this.isApplyingToNode(n) && this.matchTNode(t, n);
+        }
+        elementEnd(t) {
+            this._declarationNodeIndex === t.index &&
+                (this._appliesToNextNode = !1);
+        }
+        template(t, n) {
+            this.elementStart(t, n);
+        }
+        embeddedTView(t, n) {
+            return this.isApplyingToNode(t)
+                ? ((this.crossesNgTemplate = !0),
+                  this.addMatch(-t.index, n),
+                  new e(this.metadata))
+                : null;
+        }
+        isApplyingToNode(t) {
+            if (this._appliesToNextNode && (this.metadata.flags & 1) !== 1) {
+                let n = this._declarationNodeIndex,
+                    r = t.parent;
+                for (; r !== null && r.type & 8 && r.index !== n; )
+                    r = r.parent;
+                return n === (r !== null ? r.index : -1);
+            }
+            return this._appliesToNextNode;
+        }
+        matchTNode(t, n) {
+            let r = this.metadata.predicate;
+            if (Array.isArray(r))
+                for (let o = 0; o < r.length; o++) {
+                    let i = r[o];
+                    this.matchTNodeWithReadOption(t, n, Fm(n, i)),
+                        this.matchTNodeWithReadOption(
+                            t,
+                            n,
+                            Xn(n, t, i, !1, !1)
+                        );
+                }
+            else
+                r === rt
+                    ? n.type & 4 && this.matchTNodeWithReadOption(t, n, -1)
+                    : this.matchTNodeWithReadOption(t, n, Xn(n, t, r, !1, !1));
+        }
+        matchTNodeWithReadOption(t, n, r) {
+            if (r !== null) {
+                let o = this.metadata.read;
+                if (o !== null)
+                    if (o === jt || o === Bt || (o === rt && n.type & 4))
+                        this.addMatch(n.index, -2);
+                    else {
+                        let i = Xn(n, t, o, !1, !1);
+                        i !== null && this.addMatch(n.index, i);
+                    }
+                else this.addMatch(n.index, r);
+            }
+        }
+        addMatch(t, n) {
+            this.matches === null
+                ? (this.matches = [t, n])
+                : this.matches.push(t, n);
+        }
+    };
+function Fm(e, t) {
+    let n = e.localNames;
+    if (n !== null) {
+        for (let r = 0; r < n.length; r += 2) if (n[r] === t) return n[r + 1];
+    }
+    return null;
+}
+function Rm(e, t) {
+    return e.type & 11 ? Lt(e, t) : e.type & 4 ? Hr(e, t) : null;
+}
+function Pm(e, t, n, r) {
+    return n === -1 ? Rm(t, e) : n === -2 ? km(e, t, r) : tt(e, e[v], n, t);
+}
+function km(e, t, n) {
+    if (n === jt) return Lt(t, e);
+    if (n === rt) return Hr(t, e);
+    if (n === Bt) return pl(t, e);
+}
+function hl(e, t, n, r) {
+    let o = t[Ie].queries[r];
+    if (o.matches === null) {
+        let i = e.data,
+            s = n.matches,
+            a = [];
+        for (let u = 0; s !== null && u < s.length; u += 2) {
+            let c = s[u];
+            if (c < 0) a.push(null);
+            else {
+                let l = i[c];
+                a.push(Pm(t, l, s[u + 1], n.metadata.read));
+            }
+        }
+        o.matches = a;
+    }
+    return o.matches;
+}
+function bi(e, t, n, r) {
+    let o = e.queries.getByIndex(n),
+        i = o.matches;
+    if (i !== null) {
+        let s = hl(e, t, o, n);
+        for (let a = 0; a < i.length; a += 2) {
+            let u = i[a];
+            if (u > 0) r.push(s[a / 2]);
+            else {
+                let c = i[a + 1],
+                    l = t[-u];
+                for (let d = W; d < l.length; d++) {
+                    let f = l[d];
+                    f[an] === f[j] && bi(f[v], f, c, r);
+                }
+                if (l[Ot] !== null) {
+                    let d = l[Ot];
+                    for (let f = 0; f < d.length; f++) {
+                        let p = d[f];
+                        bi(p[v], p, c, r);
+                    }
+                }
+            }
+        }
+    }
+    return r;
+}
+function Lm(e, t) {
+    return e[Ie].queries[t].queryList;
+}
+function gl(e, t, n) {
+    let r = new Qo((n & 4) === 4);
+    return (
+        wg(e, t, r, r.destroy), (t[Ie] ??= new wi()).queries.push(new Ii(r)) - 1
+    );
+}
+function jm(e, t, n) {
+    let r = P();
+    return (
+        r.firstCreatePass &&
+            (ml(r, new vr(e, t, n), -1),
+            (t & 2) === 2 && (r.staticViewQueries = !0)),
+        gl(r, E(), t)
+    );
+}
+function Vm(e, t, n, r) {
+    let o = P();
+    if (o.firstCreatePass) {
+        let i = V();
+        ml(o, new vr(t, n, r), i.index),
+            $m(o, e),
+            (n & 2) === 2 && (o.staticContentQueries = !0);
+    }
+    return gl(o, E(), n);
+}
+function Bm(e) {
+    return e.split(",").map((t) => t.trim());
+}
+function ml(e, t, n) {
+    e.queries === null && (e.queries = new Ei()), e.queries.track(new Ci(t, n));
+}
+function $m(e, t) {
+    let n = e.contentQueries || (e.contentQueries = []),
+        r = n.length ? n[n.length - 1] : -1;
+    t !== r && n.push(e.queries.length - 1, t);
+}
+function bs(e, t) {
+    return e.queries.getByIndex(t);
+}
+function Hm(e, t) {
+    let n = e[v],
+        r = bs(n, t);
+    return r.crossesNgTemplate ? bi(n, e, t, []) : hl(n, e, r, t);
+}
+function Um(e) {
+    return typeof e == "function" && e[gn] !== void 0;
+}
+function yl(e) {
+    return Um(e) && typeof e.set == "function";
+}
+function Gm(e) {
+    let t = [],
+        n = new Map();
+    function r(o) {
+        let i = n.get(o);
+        if (!i) {
+            let s = e(o);
+            n.set(o, (i = s.then(Ym)));
+        }
+        return i;
+    }
+    return (
+        Ir.forEach((o, i) => {
+            let s = [];
+            o.templateUrl &&
+                s.push(
+                    r(o.templateUrl).then((c) => {
+                        o.template = c;
+                    })
+                );
+            let a = typeof o.styles == "string" ? [o.styles] : o.styles || [];
+            if (((o.styles = a), o.styleUrl && o.styleUrls?.length))
+                throw new Error(
+                    "@Component cannot define both `styleUrl` and `styleUrls`. Use `styleUrl` if the component has one stylesheet, or `styleUrls` if it has multiple"
+                );
+            if (o.styleUrls?.length) {
+                let c = o.styles.length,
+                    l = o.styleUrls;
+                o.styleUrls.forEach((d, f) => {
+                    a.push(""),
+                        s.push(
+                            r(d).then((p) => {
+                                (a[c + f] = p),
+                                    l.splice(l.indexOf(d), 1),
+                                    l.length == 0 && (o.styleUrls = void 0);
+                            })
+                        );
+                });
+            } else
+                o.styleUrl &&
+                    s.push(
+                        r(o.styleUrl).then((c) => {
+                            a.push(c), (o.styleUrl = void 0);
+                        })
+                    );
+            let u = Promise.all(s).then(() => Qm(i));
+            t.push(u);
+        }),
+        Wm(),
+        Promise.all(t).then(() => {})
+    );
+}
+var Ir = new Map(),
+    zm = new Set();
+function Wm() {
+    let e = Ir;
+    return (Ir = new Map()), e;
+}
+function qm() {
+    return Ir.size === 0;
+}
+function Ym(e) {
+    return typeof e == "string" ? e : e.text();
+}
+function Qm(e) {
+    zm.delete(e);
+}
+function Zm(e) {
+    return Object.getPrototypeOf(e.prototype).constructor;
+}
+function Km(e) {
+    let t = Zm(e.type),
+        n = !0,
+        r = [e];
+    for (; t; ) {
+        let o;
+        if (Oe(e)) o = t.ɵcmp || t.ɵdir;
+        else {
+            if (t.ɵcmp) throw new _(903, !1);
+            o = t.ɵdir;
+        }
+        if (o) {
+            if (n) {
+                r.push(o);
+                let s = e;
+                (s.inputs = Wn(e.inputs)),
+                    (s.inputTransforms = Wn(e.inputTransforms)),
+                    (s.declaredInputs = Wn(e.declaredInputs)),
+                    (s.outputs = Wn(e.outputs));
+                let a = o.hostBindings;
+                a && ny(e, a);
+                let u = o.viewQuery,
+                    c = o.contentQueries;
+                if (
+                    (u && ey(e, u),
+                    c && ty(e, c),
+                    Jm(e, o),
+                    ff(e.outputs, o.outputs),
+                    Oe(o) && o.data.animation)
+                ) {
+                    let l = e.data;
+                    l.animation = (l.animation || []).concat(o.data.animation);
+                }
+            }
+            let i = o.features;
+            if (i)
+                for (let s = 0; s < i.length; s++) {
+                    let a = i[s];
+                    a && a.ngInherit && a(e), a === Km && (n = !1);
+                }
+        }
+        t = Object.getPrototypeOf(t);
+    }
+    Xm(r);
+}
+function Jm(e, t) {
+    for (let n in t.inputs) {
+        if (!t.inputs.hasOwnProperty(n) || e.inputs.hasOwnProperty(n)) continue;
+        let r = t.inputs[n];
+        if (
+            r !== void 0 &&
+            ((e.inputs[n] = r),
+            (e.declaredInputs[n] = t.declaredInputs[n]),
+            t.inputTransforms !== null)
+        ) {
+            let o = Array.isArray(r) ? r[0] : r;
+            if (!t.inputTransforms.hasOwnProperty(o)) continue;
+            (e.inputTransforms ??= {}),
+                (e.inputTransforms[o] = t.inputTransforms[o]);
+        }
+    }
+}
+function Xm(e) {
+    let t = 0,
+        n = null;
+    for (let r = e.length - 1; r >= 0; r--) {
+        let o = e[r];
+        (o.hostVars = t += o.hostVars),
+            (o.hostAttrs = Zt(o.hostAttrs, (n = Zt(n, o.hostAttrs))));
+    }
+}
+function Wn(e) {
+    return e === Tt ? {} : e === z ? [] : e;
+}
+function ey(e, t) {
+    let n = e.viewQuery;
+    n
+        ? (e.viewQuery = (r, o) => {
+              t(r, o), n(r, o);
+          })
+        : (e.viewQuery = t);
+}
+function ty(e, t) {
+    let n = e.contentQueries;
+    n
+        ? (e.contentQueries = (r, o, i) => {
+              t(r, o, i), n(r, o, i);
+          })
+        : (e.contentQueries = t);
+}
+function ny(e, t) {
+    let n = e.hostBindings;
+    n
+        ? (e.hostBindings = (r, o) => {
+              t(r, o), n(r, o);
+          })
+        : (e.hostBindings = t);
+}
+function ry(e) {
+    let t = e.inputConfig,
+        n = {};
+    for (let r in t)
+        if (t.hasOwnProperty(r)) {
+            let o = t[r];
+            Array.isArray(o) && o[3] && (n[r] = o[3]);
+        }
+    e.inputTransforms = n;
+}
+var Pe = class {},
+    _i = class {};
+var wr = class extends Pe {
+        constructor(t, n, r) {
+            super(),
+                (this._parent = n),
+                (this._bootstrapComponents = []),
+                (this.destroyCbs = []),
+                (this.componentFactoryResolver = new Dr(this));
+            let o = Nu(t);
+            (this._bootstrapComponents = Rc(o.bootstrap)),
+                (this._r3Injector = Dc(
+                    t,
+                    n,
+                    [
+                        { provide: Pe, useValue: this },
+                        {
+                            provide: Ur,
+                            useValue: this.componentFactoryResolver,
+                        },
+                        ...r,
+                    ],
+                    H(t),
+                    new Set(["environment"])
+                )),
+                this._r3Injector.resolveInjectorInitializers(),
+                (this.instance = this._r3Injector.get(t));
+        }
+        get injector() {
+            return this._r3Injector;
+        }
+        destroy() {
+            let t = this._r3Injector;
+            !t.destroyed && t.destroy(),
+                this.destroyCbs.forEach((n) => n()),
+                (this.destroyCbs = null);
+        }
+        onDestroy(t) {
+            this.destroyCbs.push(t);
+        }
+    },
+    Er = class extends _i {
+        constructor(t) {
+            super(), (this.moduleType = t);
+        }
+        create(t) {
+            return new wr(this.moduleType, t, []);
+        }
+    };
+function oy(e, t, n) {
+    return new wr(e, t, n);
+}
+var Mi = class extends Pe {
+    constructor(t) {
+        super(),
+            (this.componentFactoryResolver = new Dr(this)),
+            (this.instance = null);
+        let n = new Kt(
+            [
+                ...t.providers,
+                { provide: Pe, useValue: this },
+                { provide: Ur, useValue: this.componentFactoryResolver },
+            ],
+            t.parent || Yi(),
+            t.debugName,
+            new Set(["environment"])
+        );
+        (this.injector = n),
+            t.runEnvironmentInitializers && n.resolveInjectorInitializers();
+    }
+    destroy() {
+        this.injector.destroy();
+    }
+    onDestroy(t) {
+        this.injector.onDestroy(t);
+    }
+};
+function iy(e, t, n = null) {
+    return new Mi({
+        providers: e,
+        parent: t,
+        debugName: n,
+        runEnvironmentInitializers: !0,
+    }).injector;
+}
+var _s = (() => {
+    let t = class t {
+        constructor() {
+            (this.taskId = 0),
+                (this.pendingTasks = new Set()),
+                (this.hasPendingTasks = new $t(!1));
+        }
+        get _hasPendingTasks() {
+            return this.hasPendingTasks.value;
+        }
+        add() {
+            this._hasPendingTasks || this.hasPendingTasks.next(!0);
+            let r = this.taskId++;
+            return this.pendingTasks.add(r), r;
+        }
+        remove(r) {
+            this.pendingTasks.delete(r),
+                this.pendingTasks.size === 0 &&
+                    this._hasPendingTasks &&
+                    this.hasPendingTasks.next(!1);
+        }
+        ngOnDestroy() {
+            this.pendingTasks.clear(),
+                this._hasPendingTasks && this.hasPendingTasks.next(!1);
+        }
+    };
+    (t.ɵfac = function (o) {
+        return new (o || t)();
+    }),
+        (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let e = t;
+    return e;
+})();
+function Dl(e) {
+    return ay(e)
+        ? Array.isArray(e) || (!(e instanceof Map) && Symbol.iterator in e)
+        : !1;
+}
+function sy(e, t) {
+    if (Array.isArray(e)) for (let n = 0; n < e.length; n++) t(e[n]);
+    else {
+        let n = e[Symbol.iterator](),
+            r;
+        for (; !(r = n.next()).done; ) t(r.value);
+    }
+}
+function ay(e) {
+    return e !== null && (typeof e == "function" || typeof e == "object");
+}
+function uy(e, t, n) {
+    return (e[t] = n);
+}
+function je(e, t, n) {
+    let r = e[t];
+    return Object.is(r, n) ? !1 : ((e[t] = n), !0);
+}
+function cy(e) {
+    return (e.flags & 32) === 32;
+}
+function ly(e, t, n, r, o, i, s, a, u) {
+    let c = t.consts,
+        l = Vt(t, e, 4, s || null, Ft(c, a));
+    Ds(t, n, l, Ft(c, u)), Pr(t, l);
+    let d = (l.tView = ms(
+        2,
+        l,
+        r,
+        o,
+        i,
+        t.directiveRegistry,
+        t.pipeRegistry,
+        null,
+        t.schemas,
+        c,
+        null
+    ));
+    return (
+        t.queries !== null &&
+            (t.queries.template(t, l),
+            (d.queries = t.queries.embeddedTView(l))),
+        l
+    );
+}
+function dy(e, t, n, r, o, i, s, a) {
+    let u = E(),
+        c = P(),
+        l = e + Y,
+        d = c.firstCreatePass ? ly(l, c, u, t, n, r, o, i, s) : c.data[l];
+    it(d, !1);
+    let f = fy(c, u, d, e);
+    Fr() && jr(c, u, f, d), Re(f, u);
+    let p = Jc(f, u, f, d);
+    return (
+        (u[l] = p),
+        $r(u, p),
+        Am(p, d, u),
+        Ar(d) && hs(c, u, d),
+        s != null && gs(u, d, a),
+        dy
+    );
+}
+var fy = py;
+function py(e, t, n, r) {
+    return Rr(!0), t[F].createComment("");
+}
+function hy(e, t, n, r) {
+    let o = E(),
+        i = un();
+    if (je(o, i, t)) {
+        let s = P(),
+            a = Or();
+        kg(a, o, e, t, n, r);
+    }
+    return hy;
+}
+function vl(e, t, n, r) {
+    return je(e, un(), n) ? t + xr(n) + r : ge;
+}
+function qn(e, t) {
+    return (e << 17) | (t << 2);
+}
+function ot(e) {
+    return (e >> 17) & 32767;
+}
+function gy(e) {
+    return (e & 2) == 2;
+}
+function my(e, t) {
+    return (e & 131071) | (t << 17);
+}
+function xi(e) {
+    return e | 2;
+}
+function Pt(e) {
+    return (e & 131068) >> 2;
+}
+function To(e, t) {
+    return (e & -131069) | (t << 2);
+}
+function yy(e) {
+    return (e & 1) === 1;
+}
+function Si(e) {
+    return e | 1;
+}
+function Dy(e, t, n, r, o, i) {
+    let s = i ? t.classBindings : t.styleBindings,
+        a = ot(s),
+        u = Pt(s);
+    e[r] = n;
+    let c = !1,
+        l;
+    if (Array.isArray(n)) {
+        let d = n;
+        (l = d[1]), (l === null || sn(d, l) > 0) && (c = !0);
+    } else l = n;
+    if (o)
+        if (u !== 0) {
+            let f = ot(e[a + 1]);
+            (e[r + 1] = qn(f, a)),
+                f !== 0 && (e[f + 1] = To(e[f + 1], r)),
+                (e[a + 1] = my(e[a + 1], r));
+        } else
+            (e[r + 1] = qn(a, 0)),
+                a !== 0 && (e[a + 1] = To(e[a + 1], r)),
+                (a = r);
+    else
+        (e[r + 1] = qn(u, 0)),
+            a === 0 ? (a = r) : (e[u + 1] = To(e[u + 1], r)),
+            (u = r);
+    c && (e[r + 1] = xi(e[r + 1])),
+        ru(e, l, r, !0),
+        ru(e, l, r, !1),
+        vy(t, l, e, r, i),
+        (s = qn(a, u)),
+        i ? (t.classBindings = s) : (t.styleBindings = s);
+}
+function vy(e, t, n, r, o) {
+    let i = o ? e.residualClasses : e.residualStyles;
+    i != null &&
+        typeof t == "string" &&
+        sn(i, t) >= 0 &&
+        (n[r + 1] = Si(n[r + 1]));
+}
+function ru(e, t, n, r) {
+    let o = e[n + 1],
+        i = t === null,
+        s = r ? ot(o) : Pt(o),
+        a = !1;
+    for (; s !== 0 && (a === !1 || i); ) {
+        let u = e[s],
+            c = e[s + 1];
+        Iy(u, t) && ((a = !0), (e[s + 1] = r ? Si(c) : xi(c))),
+            (s = r ? ot(c) : Pt(c));
+    }
+    a && (e[n + 1] = r ? xi(o) : Si(o));
+}
+function Iy(e, t) {
+    return e === null || t == null || (Array.isArray(e) ? e[1] : e) === t
+        ? !0
+        : Array.isArray(e) && typeof t == "string"
+          ? sn(e, t) >= 0
+          : !1;
+}
+var oe = { textEnd: 0, key: 0, keyEnd: 0, value: 0, valueEnd: 0 };
+function wy(e) {
+    return e.substring(oe.key, oe.keyEnd);
+}
+function Ey(e) {
+    return Cy(e), Il(e, wl(e, 0, oe.textEnd));
+}
+function Il(e, t) {
+    let n = oe.textEnd;
+    return n === t
+        ? -1
+        : ((t = oe.keyEnd = by(e, (oe.key = t), n)), wl(e, t, n));
+}
+function Cy(e) {
+    (oe.key = 0),
+        (oe.keyEnd = 0),
+        (oe.value = 0),
+        (oe.valueEnd = 0),
+        (oe.textEnd = e.length);
+}
+function wl(e, t, n) {
+    for (; t < n && e.charCodeAt(t) <= 32; ) t++;
+    return t;
+}
+function by(e, t, n) {
+    for (; t < n && e.charCodeAt(t) > 32; ) t++;
+    return t;
+}
+function _y(e, t, n) {
+    let r = E(),
+        o = un();
+    if (je(r, o, t)) {
+        let i = P(),
+            s = Or();
+        ys(i, s, r, e, t, r[F], n, !1);
+    }
+    return _y;
+}
+function Ti(e, t, n, r, o) {
+    let i = t.inputs,
+        s = o ? "class" : "style";
+    vs(e, n, i[s], s, r);
+}
+function My(e, t) {
+    return Sy(e, t, null, !0), My;
+}
+function rM(e) {
+    Ty(Py, xy, e, !0);
+}
+function xy(e, t) {
+    for (let n = Ey(t); n >= 0; n = Il(t, n)) Ui(e, wy(t), !0);
+}
+function Sy(e, t, n, r) {
+    let o = E(),
+        i = P(),
+        s = ec(2);
+    if ((i.firstUpdatePass && Cl(i, e, s, r), t !== ge && je(o, s, t))) {
+        let a = i.data[st()];
+        bl(i, a, o, o[F], e, (o[s + 1] = Ly(t, n)), r, s);
+    }
+}
+function Ty(e, t, n, r) {
+    let o = P(),
+        i = ec(2);
+    o.firstUpdatePass && Cl(o, null, i, r);
+    let s = E();
+    if (n !== ge && je(s, i, n)) {
+        let a = o.data[st()];
+        if (_l(a, r) && !El(o, i)) {
+            let u = r ? a.classesWithoutHost : a.stylesWithoutHost;
+            u !== null && (n = Fo(u, n || "")), Ti(o, a, s, n, r);
+        } else ky(o, a, s, s[F], s[i + 1], (s[i + 1] = Ry(e, t, n)), r, i);
+    }
+}
+function El(e, t) {
+    return t >= e.expandoStartIndex;
+}
+function Cl(e, t, n, r) {
+    let o = e.data;
+    if (o[n + 1] === null) {
+        let i = o[st()],
+            s = El(e, n);
+        _l(i, r) && t === null && !s && (t = !1),
+            (t = Ny(o, i, t, r)),
+            Dy(o, i, t, n, s, r);
+    }
+}
+function Ny(e, t, n, r) {
+    let o = Bp(e),
+        i = r ? t.residualClasses : t.residualStyles;
+    if (o === null)
+        (r ? t.classBindings : t.styleBindings) === 0 &&
+            ((n = No(null, e, t, n, r)), (n = rn(n, t.attrs, r)), (i = null));
+    else {
+        let s = t.directiveStylingLast;
+        if (s === -1 || e[s] !== o)
+            if (((n = No(o, e, t, n, r)), i === null)) {
+                let u = Ay(e, t, r);
+                u !== void 0 &&
+                    Array.isArray(u) &&
+                    ((u = No(null, e, t, u[1], r)),
+                    (u = rn(u, t.attrs, r)),
+                    Oy(e, t, r, u));
+            } else i = Fy(e, t, r);
+    }
+    return (
+        i !== void 0 && (r ? (t.residualClasses = i) : (t.residualStyles = i)),
+        n
+    );
+}
+function Ay(e, t, n) {
+    let r = n ? t.classBindings : t.styleBindings;
+    if (Pt(r) !== 0) return e[ot(r)];
+}
+function Oy(e, t, n, r) {
+    let o = n ? t.classBindings : t.styleBindings;
+    e[ot(o)] = r;
+}
+function Fy(e, t, n) {
+    let r,
+        o = t.directiveEnd;
+    for (let i = 1 + t.directiveStylingLast; i < o; i++) {
+        let s = e[i].hostAttrs;
+        r = rn(r, s, n);
+    }
+    return rn(r, t.attrs, n);
+}
+function No(e, t, n, r, o) {
+    let i = null,
+        s = n.directiveEnd,
+        a = n.directiveStylingLast;
+    for (
+        a === -1 ? (a = n.directiveStart) : a++;
+        a < s && ((i = t[a]), (r = rn(r, i.hostAttrs, o)), i !== e);
+
+    )
+        a++;
+    return e !== null && (n.directiveStylingLast = a), r;
+}
+function rn(e, t, n) {
+    let r = n ? 1 : 2,
+        o = -1;
+    if (t !== null)
+        for (let i = 0; i < t.length; i++) {
+            let s = t[i];
+            typeof s == "number"
+                ? (o = s)
+                : o === r &&
+                  (Array.isArray(e) || (e = e === void 0 ? [] : ["", e]),
+                  Ui(e, s, n ? !0 : t[++i]));
+        }
+    return e === void 0 ? null : e;
+}
+function Ry(e, t, n) {
+    if (n == null || n === "") return z;
+    let r = [],
+        o = cn(n);
+    if (Array.isArray(o)) for (let i = 0; i < o.length; i++) e(r, o[i], !0);
+    else if (typeof o == "object")
+        for (let i in o) o.hasOwnProperty(i) && e(r, i, o[i]);
+    else typeof o == "string" && t(r, o);
+    return r;
+}
+function Py(e, t, n) {
+    let r = String(t);
+    r !== "" && !r.includes(" ") && Ui(e, r, n);
+}
+function ky(e, t, n, r, o, i, s, a) {
+    o === ge && (o = z);
+    let u = 0,
+        c = 0,
+        l = 0 < o.length ? o[0] : null,
+        d = 0 < i.length ? i[0] : null;
+    for (; l !== null || d !== null; ) {
+        let f = u < o.length ? o[u + 1] : void 0,
+            p = c < i.length ? i[c + 1] : void 0,
+            h = null,
+            w;
+        l === d
+            ? ((u += 2), (c += 2), f !== p && ((h = d), (w = p)))
+            : d === null || (l !== null && l < d)
+              ? ((u += 2), (h = l))
+              : ((c += 2), (h = d), (w = p)),
+            h !== null && bl(e, t, n, r, h, w, s, a),
+            (l = u < o.length ? o[u] : null),
+            (d = c < i.length ? i[c] : null);
+    }
+}
+function bl(e, t, n, r, o, i, s, a) {
+    if (!(t.type & 3)) return;
+    let u = e.data,
+        c = u[a + 1],
+        l = yy(c) ? ou(u, t, n, o, Pt(c), s) : void 0;
+    if (!Cr(l)) {
+        Cr(i) || (gy(c) && (i = ou(u, null, n, o, a, s)));
+        let d = Yu(st(), n);
+        pg(r, s, d, o, i);
+    }
+}
+function ou(e, t, n, r, o, i) {
+    let s = t === null,
+        a;
+    for (; o > 0; ) {
+        let u = e[o],
+            c = Array.isArray(u),
+            l = c ? u[1] : u,
+            d = l === null,
+            f = n[o + 1];
+        f === ge && (f = d ? z : void 0);
+        let p = d ? Io(f, r) : l === r ? f : void 0;
+        if ((c && !Cr(p) && (p = Io(u, r)), Cr(p) && ((a = p), s))) return a;
+        let h = e[o + 1];
+        o = s ? ot(h) : Pt(h);
+    }
+    if (t !== null) {
+        let u = i ? t.residualClasses : t.residualStyles;
+        u != null && (a = Io(u, r));
+    }
+    return a;
+}
+function Cr(e) {
+    return e !== void 0;
+}
+function Ly(e, t) {
+    return (
+        e == null ||
+            e === "" ||
+            (typeof t == "string"
+                ? (e = e + t)
+                : typeof e == "object" && (e = H(cn(e)))),
+        e
+    );
+}
+function _l(e, t) {
+    return (e.flags & (t ? 8 : 16)) !== 0;
+}
+function oM(e, t, n) {
+    dn("NgControlFlow");
+    let r = E(),
+        o = un(),
+        i = jy(r, Y + e),
+        s = 0;
+    if (je(r, o, t)) {
+        let a = M(null);
+        try {
+            if ((zg(i, s), t !== -1)) {
+                let u = Vy(r[v], Y + t),
+                    c = li(i, u.tView.ssrId),
+                    l = rl(r, u, n, { dehydratedView: c });
+                ol(i, l, s, ui(u, c));
+            }
+        } finally {
+            M(a);
+        }
+    } else {
+        let a = Gg(i, s);
+        a !== void 0 && (a[J] = n);
+    }
+}
+function jy(e, t) {
+    return e[t];
+}
+function Vy(e, t) {
+    return Ki(e, t);
+}
+function By(e, t, n, r, o, i) {
+    let s = t.consts,
+        a = Ft(s, o),
+        u = Vt(t, e, 2, r, a);
+    return (
+        Ds(t, n, u, Ft(s, i)),
+        u.attrs !== null && yr(u, u.attrs, !1),
+        u.mergedAttrs !== null && yr(u, u.mergedAttrs, !0),
+        t.queries !== null && t.queries.elementStart(t, u),
+        u
+    );
+}
+function Ml(e, t, n, r) {
+    let o = E(),
+        i = P(),
+        s = Y + e,
+        a = o[F],
+        u = i.firstCreatePass ? By(s, i, o, t, n, r) : i.data[s],
+        c = Hy(i, o, u, a, t, e);
+    o[s] = c;
+    let l = Ar(u);
+    return (
+        it(u, !0),
+        Gc(a, c, u),
+        !cy(u) && Fr() && jr(i, o, c, u),
+        Sp() === 0 && Re(c, o),
+        Tp(),
+        l && (hs(i, o, u), ps(i, u, o)),
+        r !== null && gs(o, u),
+        Ml
+    );
+}
+function xl() {
+    let e = V();
+    es() ? ts() : ((e = e.parent), it(e, !1));
+    let t = e;
+    Ap(t) && Op(), Np();
+    let n = P();
+    return (
+        n.firstCreatePass && (Pr(n, e), Zi(e) && n.queries.elementEnd(e)),
+        t.classesWithoutHost != null &&
+            qp(t) &&
+            Ti(n, t, E(), t.classesWithoutHost, !0),
+        t.stylesWithoutHost != null &&
+            Yp(t) &&
+            Ti(n, t, E(), t.stylesWithoutHost, !1),
+        xl
+    );
+}
+function $y(e, t, n, r) {
+    return Ml(e, t, n, r), xl(), $y;
+}
+var Hy = (e, t, n, r, o, i) => (Rr(!0), Pc(r, o, Up()));
+function Uy(e, t, n, r, o) {
+    let i = t.consts,
+        s = Ft(i, r),
+        a = Vt(t, e, 8, "ng-container", s);
+    s !== null && yr(a, s, !0);
+    let u = Ft(i, o);
+    return (
+        Ds(t, n, a, u), t.queries !== null && t.queries.elementStart(t, a), a
+    );
+}
+function Sl(e, t, n) {
+    let r = E(),
+        o = P(),
+        i = e + Y,
+        s = o.firstCreatePass ? Uy(i, o, r, t, n) : o.data[i];
+    it(s, !0);
+    let a = zy(o, r, s, e);
+    return (
+        (r[i] = a),
+        Fr() && jr(o, r, a, s),
+        Re(a, r),
+        Ar(s) && (hs(o, r, s), ps(o, s, r)),
+        n != null && gs(r, s),
+        Sl
+    );
+}
+function Tl() {
+    let e = V(),
+        t = P();
+    return (
+        es() ? ts() : ((e = e.parent), it(e, !1)),
+        t.firstCreatePass && (Pr(t, e), Zi(e) && t.queries.elementEnd(e)),
+        Tl
+    );
+}
+function Gy(e, t, n) {
+    return Sl(e, t, n), Tl(), Gy;
+}
+var zy = (e, t, n, r) => (Rr(!0), Kh(t[F], ""));
+function iM() {
+    return E();
+}
+var br = "en-US";
+var Wy = br;
+function qy(e) {
+    typeof e == "string" && (Wy = e.toLowerCase().replace(/_/g, "-"));
+}
+function Yy(e, t, n, r) {
+    let o = E(),
+        i = P(),
+        s = V();
+    return Nl(i, o, o[F], s, e, t, r), Yy;
+}
+function Qy(e, t, n, r) {
+    let o = e.cleanup;
+    if (o != null)
+        for (let i = 0; i < o.length - 1; i += 2) {
+            let s = o[i];
+            if (s === n && o[i + 1] === r) {
+                let a = t[Xt],
+                    u = o[i + 2];
+                return a.length > u ? a[u] : null;
+            }
+            typeof s == "string" && (i += 2);
+        }
+    return null;
+}
+function Nl(e, t, n, r, o, i, s) {
+    let a = Ar(r),
+        c = e.firstCreatePass && tl(e),
+        l = t[J],
+        d = el(t),
+        f = !0;
+    if (r.type & 3 || s) {
+        let w = X(r, t),
+            k = s ? s(w) : w,
+            N = d.length,
+            Z = s ? (me) => s(he(me[r.index])) : r.index,
+            U = null;
+        if ((!s && a && (U = Qy(e, t, o, r.index)), U !== null)) {
+            let me = U.__ngLastListenerFn__ || U;
+            (me.__ngNextListenerFn__ = i),
+                (U.__ngLastListenerFn__ = i),
+                (f = !1);
+        } else {
+            i = su(r, t, l, i, !1);
+            let me = n.listen(k, o, i);
+            d.push(i, me), c && c.push(o, Z, N, N + 1);
+        }
+    } else i = su(r, t, l, i, !1);
+    let p = r.outputs,
+        h;
+    if (f && p !== null && (h = p[o])) {
+        let w = h.length;
+        if (w)
+            for (let k = 0; k < w; k += 2) {
+                let N = h[k],
+                    Z = h[k + 1],
+                    ut = t[N][Z].subscribe(i),
+                    ee = d.length;
+                d.push(i, ut), c && c.push(o, r.index, ee, -(ee + 1));
+            }
+    }
+}
+function iu(e, t, n, r) {
+    let o = M(null);
+    try {
+        return fe(6, t, n), n(r) !== !1;
+    } catch (i) {
+        return nl(e, i), !1;
+    } finally {
+        fe(7, t, n), M(o);
+    }
+}
+function su(e, t, n, r, o) {
+    return function i(s) {
+        if (s === Function) return r;
+        let a = e.componentOffset > -1 ? ke(e.index, t) : t;
+        ws(a);
+        let u = iu(t, n, r, s),
+            c = i.__ngNextListenerFn__;
+        for (; c; ) (u = iu(t, n, c, s) && u), (c = c.__ngNextListenerFn__);
+        return o && u === !1 && s.preventDefault(), u;
+    };
+}
+function sM(e = 1) {
+    return Hp(e);
+}
+function Zy(e, t) {
+    let n = null,
+        r = Gf(e);
+    for (let o = 0; o < t.length; o++) {
+        let i = t[o];
+        if (i === "*") {
+            n = o;
+            continue;
+        }
+        if (r === null ? xu(e, i, !0) : qf(r, i)) return o;
+    }
+    return n;
+}
+function aM(e) {
+    let t = E()[ue][Q];
+    if (!t.projection) {
+        let n = e ? e.length : 1,
+            r = (t.projection = Pf(n, null)),
+            o = r.slice(),
+            i = t.child;
+        for (; i !== null; ) {
+            let s = e ? Zy(i, e) : 0;
+            s !== null &&
+                (o[s] ? (o[s].projectionNext = i) : (r[s] = i), (o[s] = i)),
+                (i = i.next);
+        }
+    }
+}
+function uM(e, t = 0, n) {
+    let r = E(),
+        o = P(),
+        i = Vt(o, Y + e, 16, null, n || null);
+    i.projection === null && (i.projection = t),
+        ts(),
+        (!r[Jt] || Ju()) && (i.flags & 32) !== 32 && dg(o, r, i);
+}
+function Ky(e, t, n) {
+    return Al(e, "", t, "", n), Ky;
+}
+function Al(e, t, n, r, o) {
+    let i = E(),
+        s = vl(i, t, n, r);
+    if (s !== ge) {
+        let a = P(),
+            u = Or();
+        ys(a, u, i, e, s, i[F], o, !1);
+    }
+    return Al;
+}
+function cM(e, t, n, r) {
+    Vm(e, t, n, r);
+}
+function lM(e, t, n) {
+    jm(e, t, n);
+}
+function dM(e) {
+    let t = E(),
+        n = P(),
+        r = tc();
+    ns(r + 1);
+    let o = bs(n, r);
+    if (e.dirty && Cp(t) === ((o.metadata.flags & 2) === 2)) {
+        if (o.matches === null) e.reset([]);
+        else {
+            let i = Hm(t, r);
+            e.reset(i, uh), e.notifyOnChanges();
+        }
+        return !0;
+    }
+    return !1;
+}
+function fM() {
+    return Lm(E(), tc());
+}
+function pM(e) {
+    let t = Rp();
+    return Ep(t, Y + e);
+}
+function hM(e, t = "") {
+    let n = E(),
+        r = P(),
+        o = e + Y,
+        i = r.firstCreatePass ? Vt(r, o, 1, t, null) : r.data[o],
+        s = Jy(r, n, i, t, e);
+    (n[o] = s), Fr() && jr(r, n, s, i), it(i, !1);
+}
+var Jy = (e, t, n, r, o) => (Rr(!0), Qh(t[F], r));
+function Xy(e) {
+    return Ol("", e, ""), Xy;
+}
+function Ol(e, t, n) {
+    let r = E(),
+        o = vl(r, e, t, n);
+    return o !== ge && Bg(r, st(), o), Ol;
+}
+function eD(e, t, n) {
+    yl(t) && (t = t());
+    let r = E(),
+        o = un();
+    if (je(r, o, t)) {
+        let i = P(),
+            s = Or();
+        ys(i, s, r, e, t, r[F], n, !1);
+    }
+    return eD;
+}
+function gM(e, t) {
+    let n = yl(e);
+    return n && e.set(t), n;
+}
+function tD(e, t) {
+    let n = E(),
+        r = P(),
+        o = V();
+    return Nl(r, n, n[F], o, e, t), tD;
+}
+function nD(e, t, n) {
+    let r = P();
+    if (r.firstCreatePass) {
+        let o = Oe(e);
+        Ni(n, r.data, r.blueprint, o, !0), Ni(t, r.data, r.blueprint, o, !1);
+    }
+}
+function Ni(e, t, n, r, o) {
+    if (((e = $(e)), Array.isArray(e)))
+        for (let i = 0; i < e.length; i++) Ni(e[i], t, n, r, o);
+    else {
+        let i = P(),
+            s = E(),
+            a = V(),
+            u = Nt(e) ? e : $(e.provide),
+            c = Lu(e),
+            l = a.providerIndexes & 1048575,
+            d = a.directiveStart,
+            f = a.providerIndexes >> 20;
+        if (Nt(e) || !e.multi) {
+            let p = new et(c, o, _e),
+                h = Oo(u, t, o ? l : l + f, d);
+            h === -1
+                ? (zo(lr(a, s), i, u),
+                  Ao(i, e, t.length),
+                  t.push(u),
+                  a.directiveStart++,
+                  a.directiveEnd++,
+                  o && (a.providerIndexes += 1048576),
+                  n.push(p),
+                  s.push(p))
+                : ((n[h] = p), (s[h] = p));
+        } else {
+            let p = Oo(u, t, l + f, d),
+                h = Oo(u, t, l, l + f),
+                w = p >= 0 && n[p],
+                k = h >= 0 && n[h];
+            if ((o && !k) || (!o && !w)) {
+                zo(lr(a, s), i, u);
+                let N = iD(o ? oD : rD, n.length, o, r, c);
+                !o && k && (n[h].providerFactory = N),
+                    Ao(i, e, t.length, 0),
+                    t.push(u),
+                    a.directiveStart++,
+                    a.directiveEnd++,
+                    o && (a.providerIndexes += 1048576),
+                    n.push(N),
+                    s.push(N);
+            } else {
+                let N = Fl(n[o ? h : p], c, !o && r);
+                Ao(i, e, p > -1 ? p : h, N);
+            }
+            !o && r && k && n[h].componentProviders++;
+        }
+    }
+}
+function Ao(e, t, n, r) {
+    let o = Nt(t),
+        i = ip(t);
+    if (o || i) {
+        let u = (i ? $(t.useClass) : t).prototype.ngOnDestroy;
+        if (u) {
+            let c = e.destroyHooks || (e.destroyHooks = []);
+            if (!o && t.multi) {
+                let l = c.indexOf(n);
+                l === -1 ? c.push(n, [r, u]) : c[l + 1].push(r, u);
+            } else c.push(n, u);
+        }
+    }
+}
+function Fl(e, t, n) {
+    return n && e.componentProviders++, e.multi.push(t) - 1;
+}
+function Oo(e, t, n, r) {
+    for (let o = n; o < r; o++) if (t[o] === e) return o;
+    return -1;
+}
+function rD(e, t, n, r) {
+    return Ai(this.multi, []);
+}
+function oD(e, t, n, r) {
+    let o = this.multi,
+        i;
+    if (this.providerFactory) {
+        let s = this.providerFactory.componentProviders,
+            a = tt(n, n[v], this.providerFactory.index, r);
+        (i = a.slice(0, s)), Ai(o, i);
+        for (let u = s; u < a.length; u++) i.push(a[u]);
+    } else (i = []), Ai(o, i);
+    return i;
+}
+function Ai(e, t) {
+    for (let n = 0; n < e.length; n++) {
+        let r = e[n];
+        t.push(r());
+    }
+    return t;
+}
+function iD(e, t, n, r, o) {
+    let i = new et(e, n, _e);
+    return (
+        (i.multi = []),
+        (i.index = t),
+        (i.componentProviders = 0),
+        Fl(i, o, r && !n),
+        i
+    );
+}
+function mM(e, t = []) {
+    return (n) => {
+        n.providersResolver = (r, o) => nD(r, o ? o(e) : e, t);
+    };
+}
+var sD = (() => {
+    let t = class t {
+        constructor(r) {
+            (this._injector = r), (this.cachedInjectors = new Map());
+        }
+        getOrCreateStandaloneInjector(r) {
+            if (!r.standalone) return null;
+            if (!this.cachedInjectors.has(r)) {
+                let o = Fu(!1, r.type),
+                    i =
+                        o.length > 0
+                            ? iy(
+                                  [o],
+                                  this._injector,
+                                  `Standalone[${r.type.name}]`
+                              )
+                            : null;
+                this.cachedInjectors.set(r, i);
+            }
+            return this.cachedInjectors.get(r);
+        }
+        ngOnDestroy() {
+            try {
+                for (let r of this.cachedInjectors.values())
+                    r !== null && r.destroy();
+            } finally {
+                this.cachedInjectors.clear();
+            }
+        }
+    };
+    t.ɵprov = O({
+        token: t,
+        providedIn: "environment",
+        factory: () => new t(R(Ae)),
+    });
+    let e = t;
+    return e;
+})();
+function yM(e) {
+    dn("NgStandalone"),
+        (e.getStandaloneInjector = (t) =>
+            t.get(sD).getOrCreateStandaloneInjector(e));
+}
+function DM(e, t, n, r) {
+    return uD(E(), Pp(), e, t, n, r);
+}
+function aD(e, t) {
+    let n = e[t];
+    return n === ge ? void 0 : n;
+}
+function uD(e, t, n, r, o, i) {
+    let s = t + n;
+    return je(e, s, o) ? uy(e, s + 1, i ? r.call(i, o) : r(o)) : aD(e, s + 1);
+}
+function vM(e, t) {
+    return Hr(e, t);
+}
+var Yn = null;
+function cD(e) {
+    (Yn !== null &&
+        (e.defaultEncapsulation !== Yn.defaultEncapsulation ||
+            e.preserveWhitespaces !== Yn.preserveWhitespaces)) ||
+        (Yn = e);
+}
+var IM = (() => {
+    let t = class t {
+        log(r) {
+            console.log(r);
+        }
+        warn(r) {
+            console.warn(r);
+        }
+    };
+    (t.ɵfac = function (o) {
+        return new (o || t)();
+    }),
+        (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "platform" }));
+    let e = t;
+    return e;
+})();
+var lD = new T(""),
+    dD = new T(""),
+    wM = (() => {
+        let t = class t {
+            constructor(r, o, i) {
+                (this._ngZone = r),
+                    (this.registry = o),
+                    (this._pendingCount = 0),
+                    (this._isZoneStable = !0),
+                    (this._callbacks = []),
+                    (this.taskTrackingZone = null),
+                    Ms || (pD(i), i.addToWindow(o)),
+                    this._watchAngularEvents(),
+                    r.run(() => {
+                        this.taskTrackingZone =
+                            typeof Zone > "u"
+                                ? null
+                                : Zone.current.get("TaskTrackingZone");
+                    });
+            }
+            _watchAngularEvents() {
+                this._ngZone.onUnstable.subscribe({
+                    next: () => {
+                        this._isZoneStable = !1;
+                    },
+                }),
+                    this._ngZone.runOutsideAngular(() => {
+                        this._ngZone.onStable.subscribe({
+                            next: () => {
+                                q.assertNotInAngularZone(),
+                                    queueMicrotask(() => {
+                                        (this._isZoneStable = !0),
+                                            this._runCallbacksIfReady();
+                                    });
+                            },
+                        });
+                    });
+            }
+            increasePendingRequestCount() {
+                return (this._pendingCount += 1), this._pendingCount;
+            }
+            decreasePendingRequestCount() {
+                if (((this._pendingCount -= 1), this._pendingCount < 0))
+                    throw new Error("pending async requests below zero");
+                return this._runCallbacksIfReady(), this._pendingCount;
+            }
+            isStable() {
+                return (
+                    this._isZoneStable &&
+                    this._pendingCount === 0 &&
+                    !this._ngZone.hasPendingMacrotasks
+                );
+            }
+            _runCallbacksIfReady() {
+                if (this.isStable())
+                    queueMicrotask(() => {
+                        for (; this._callbacks.length !== 0; ) {
+                            let r = this._callbacks.pop();
+                            clearTimeout(r.timeoutId), r.doneCb();
+                        }
+                    });
+                else {
+                    let r = this.getPendingTasks();
+                    this._callbacks = this._callbacks.filter((o) =>
+                        o.updateCb && o.updateCb(r)
+                            ? (clearTimeout(o.timeoutId), !1)
+                            : !0
+                    );
+                }
+            }
+            getPendingTasks() {
+                return this.taskTrackingZone
+                    ? this.taskTrackingZone.macroTasks.map((r) => ({
+                          source: r.source,
+                          creationLocation: r.creationLocation,
+                          data: r.data,
+                      }))
+                    : [];
+            }
+            addCallback(r, o, i) {
+                let s = -1;
+                o &&
+                    o > 0 &&
+                    (s = setTimeout(() => {
+                        (this._callbacks = this._callbacks.filter(
+                            (a) => a.timeoutId !== s
+                        )),
+                            r();
+                    }, o)),
+                    this._callbacks.push({
+                        doneCb: r,
+                        timeoutId: s,
+                        updateCb: i,
+                    });
+            }
+            whenStable(r, o, i) {
+                if (i && !this.taskTrackingZone)
+                    throw new Error(
+                        'Task tracking zone is required when passing an update callback to whenStable(). Is "zone.js/plugins/task-tracking" loaded?'
+                    );
+                this.addCallback(r, o, i), this._runCallbacksIfReady();
+            }
+            getPendingRequestCount() {
+                return this._pendingCount;
+            }
+            registerApplication(r) {
+                this.registry.registerApplication(r, this);
+            }
+            unregisterApplication(r) {
+                this.registry.unregisterApplication(r);
+            }
+            findProviders(r, o, i) {
+                return [];
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)(R(q), R(fD), R(dD));
+        }),
+            (t.ɵprov = O({ token: t, factory: t.ɵfac }));
+        let e = t;
+        return e;
+    })(),
+    fD = (() => {
+        let t = class t {
+            constructor() {
+                this._applications = new Map();
+            }
+            registerApplication(r, o) {
+                this._applications.set(r, o);
+            }
+            unregisterApplication(r) {
+                this._applications.delete(r);
+            }
+            unregisterAllApplications() {
+                this._applications.clear();
+            }
+            getTestability(r) {
+                return this._applications.get(r) || null;
+            }
+            getAllTestabilities() {
+                return Array.from(this._applications.values());
+            }
+            getAllRootElements() {
+                return Array.from(this._applications.keys());
+            }
+            findTestabilityInTree(r, o = !0) {
+                return Ms?.findTestabilityInTree(this, r, o) ?? null;
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)();
+        }),
+            (t.ɵprov = O({
+                token: t,
+                factory: t.ɵfac,
+                providedIn: "platform",
+            }));
+        let e = t;
+        return e;
+    })();
+function pD(e) {
+    Ms = e;
+}
+var Ms;
+function xs(e) {
+    return !!e && typeof e.then == "function";
+}
+function Rl(e) {
+    return !!e && typeof e.subscribe == "function";
+}
+var hD = new T(""),
+    Pl = (() => {
+        let t = class t {
+            constructor() {
+                (this.initialized = !1),
+                    (this.done = !1),
+                    (this.donePromise = new Promise((r, o) => {
+                        (this.resolve = r), (this.reject = o);
+                    })),
+                    (this.appInits = S(hD, { optional: !0 }) ?? []);
+            }
+            runInitializers() {
+                if (this.initialized) return;
+                let r = [];
+                for (let i of this.appInits) {
+                    let s = i();
+                    if (xs(s)) r.push(s);
+                    else if (Rl(s)) {
+                        let a = new Promise((u, c) => {
+                            s.subscribe({ complete: u, error: c });
+                        });
+                        r.push(a);
+                    }
+                }
+                let o = () => {
+                    (this.done = !0), this.resolve();
+                };
+                Promise.all(r)
+                    .then(() => {
+                        o();
+                    })
+                    .catch((i) => {
+                        this.reject(i);
+                    }),
+                    r.length === 0 && o(),
+                    (this.initialized = !0);
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)();
+        }),
+            (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let e = t;
+        return e;
+    })(),
+    gD = new T("");
+function mD() {
+    zs(() => {
+        throw new _(600, !1);
+    });
+}
+function yD(e) {
+    return e.isBoundToModule;
+}
+function DD(e, t, n) {
+    try {
+        let r = n();
+        return xs(r)
+            ? r.catch((o) => {
+                  throw (t.runOutsideAngular(() => e.handleError(o)), o);
+              })
+            : r;
+    } catch (r) {
+        throw (t.runOutsideAngular(() => e.handleError(r)), r);
+    }
+}
+function kl(e, t) {
+    return Array.isArray(t) ? t.reduce(kl, e) : xe(xe({}, e), t);
+}
+var Ss = (() => {
+    let t = class t {
+        constructor() {
+            (this._bootstrapListeners = []),
+                (this._runningTick = !1),
+                (this._destroyed = !1),
+                (this._destroyListeners = []),
+                (this._views = []),
+                (this.internalErrorHandler = S(vc)),
+                (this.afterRenderEffectManager = S(Cs)),
+                (this.externalTestViews = new Set()),
+                (this.beforeRender = new ce()),
+                (this.afterTick = new ce()),
+                (this.componentTypes = []),
+                (this.components = []),
+                (this.isStable = S(_s).hasPendingTasks.pipe(De((r) => !r))),
+                (this._injector = S(Ae));
+        }
+        get destroyed() {
+            return this._destroyed;
+        }
+        get injector() {
+            return this._injector;
+        }
+        bootstrap(r, o) {
+            let i = r instanceof mr;
+            if (!this._injector.get(Pl).done) {
+                let p = !i && Xf(r),
+                    h = !1;
+                throw new _(405, h);
+            }
+            let a;
+            i
+                ? (a = r)
+                : (a = this._injector.get(Ur).resolveComponentFactory(r)),
+                this.componentTypes.push(a.componentType);
+            let u = yD(a) ? void 0 : this._injector.get(Pe),
+                c = o || a.selector,
+                l = a.create(Le.NULL, [], c, u),
+                d = l.location.nativeElement,
+                f = l.injector.get(lD, null);
+            return (
+                f?.registerApplication(d),
+                l.onDestroy(() => {
+                    this.detachView(l.hostView),
+                        tr(this.components, l),
+                        f?.unregisterApplication(d);
+                }),
+                this._loadComponent(l),
+                l
+            );
+        }
+        tick() {
+            this._tick(!0);
+        }
+        _tick(r) {
+            if (this._runningTick) throw new _(101, !1);
+            let o = M(null);
+            try {
+                (this._runningTick = !0), this.detectChangesInAttachedViews(r);
+            } catch (i) {
+                this.internalErrorHandler(i);
+            } finally {
+                this.afterTick.next(), (this._runningTick = !1), M(o);
+            }
+        }
+        detectChangesInAttachedViews(r) {
+            let o = 0,
+                i = this.afterRenderEffectManager;
+            for (;;) {
+                if (o === sl) throw new _(103, !1);
+                if (r) {
+                    let s = o === 0;
+                    this.beforeRender.next(s);
+                    for (let { _lView: a, notifyErrorHandler: u } of this
+                        ._views)
+                        vD(a, s, u);
+                }
+                if (
+                    (o++,
+                    i.executeInternalCallbacks(),
+                    ![...this.externalTestViews.keys(), ...this._views].some(
+                        ({ _lView: s }) => Oi(s)
+                    ) &&
+                        (i.execute(),
+                        ![
+                            ...this.externalTestViews.keys(),
+                            ...this._views,
+                        ].some(({ _lView: s }) => Oi(s))))
+                )
+                    break;
+            }
+        }
+        attachView(r) {
+            let o = r;
+            this._views.push(o), o.attachToAppRef(this);
+        }
+        detachView(r) {
+            let o = r;
+            tr(this._views, o), o.detachFromAppRef();
+        }
+        _loadComponent(r) {
+            this.attachView(r.hostView), this.tick(), this.components.push(r);
+            let o = this._injector.get(gD, []);
+            [...this._bootstrapListeners, ...o].forEach((i) => i(r));
+        }
+        ngOnDestroy() {
+            if (!this._destroyed)
+                try {
+                    this._destroyListeners.forEach((r) => r()),
+                        this._views.slice().forEach((r) => r.destroy());
+                } finally {
+                    (this._destroyed = !0),
+                        (this._views = []),
+                        (this._bootstrapListeners = []),
+                        (this._destroyListeners = []);
+                }
+        }
+        onDestroy(r) {
+            return (
+                this._destroyListeners.push(r),
+                () => tr(this._destroyListeners, r)
+            );
+        }
+        destroy() {
+            if (this._destroyed) throw new _(406, !1);
+            let r = this._injector;
+            r.destroy && !r.destroyed && r.destroy();
+        }
+        get viewCount() {
+            return this._views.length;
+        }
+        warnIfDestroyed() {}
+    };
+    (t.ɵfac = function (o) {
+        return new (o || t)();
+    }),
+        (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let e = t;
+    return e;
+})();
+function tr(e, t) {
+    let n = e.indexOf(t);
+    n > -1 && e.splice(n, 1);
+}
+function vD(e, t, n) {
+    (!t && !Oi(e)) || ID(e, n, t);
+}
+function Oi(e) {
+    return Xi(e);
+}
+function ID(e, t, n) {
+    let r;
+    n ? ((r = 0), (e[m] |= 1024)) : e[m] & 64 ? (r = 0) : (r = 1), al(e, t, r);
+}
+var Fi = class {
+        constructor(t, n) {
+            (this.ngModuleFactory = t), (this.componentFactories = n);
+        }
+    },
+    EM = (() => {
+        let t = class t {
+            compileModuleSync(r) {
+                return new Er(r);
+            }
+            compileModuleAsync(r) {
+                return Promise.resolve(this.compileModuleSync(r));
+            }
+            compileModuleAndAllComponentsSync(r) {
+                let o = this.compileModuleSync(r),
+                    i = Nu(r),
+                    s = Rc(i.declarations).reduce((a, u) => {
+                        let c = Ne(u);
+                        return c && a.push(new Rt(c)), a;
+                    }, []);
+                return new Fi(o, s);
+            }
+            compileModuleAndAllComponentsAsync(r) {
+                return Promise.resolve(
+                    this.compileModuleAndAllComponentsSync(r)
+                );
+            }
+            clearCache() {}
+            clearCacheFor(r) {}
+            getModuleId(r) {}
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)();
+        }),
+            (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let e = t;
+        return e;
+    })(),
+    wD = new T("");
+function ED(e, t, n) {
+    let r = new Er(n);
+    return Promise.resolve(r);
+}
+function au(e) {
+    for (let t = e.length - 1; t >= 0; t--) if (e[t] !== void 0) return e[t];
+}
+var CD = (() => {
+    let t = class t {
+        constructor() {
+            (this.zone = S(q)), (this.applicationRef = S(Ss));
+        }
+        initialize() {
+            this._onMicrotaskEmptySubscription ||
+                (this._onMicrotaskEmptySubscription =
+                    this.zone.onMicrotaskEmpty.subscribe({
+                        next: () => {
+                            this.zone.run(() => {
+                                this.applicationRef.tick();
+                            });
+                        },
+                    }));
+        }
+        ngOnDestroy() {
+            this._onMicrotaskEmptySubscription?.unsubscribe();
+        }
+    };
+    (t.ɵfac = function (o) {
+        return new (o || t)();
+    }),
+        (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let e = t;
+    return e;
+})();
+function bD(e) {
+    return [
+        { provide: q, useFactory: e },
+        {
+            provide: ir,
+            multi: !0,
+            useFactory: () => {
+                let t = S(CD, { optional: !0 });
+                return () => t.initialize();
+            },
+        },
+        {
+            provide: ir,
+            multi: !0,
+            useFactory: () => {
+                let t = S(xD);
+                return () => {
+                    t.initialize();
+                };
+            },
+        },
+        { provide: vc, useFactory: _D },
+    ];
+}
+function _D() {
+    let e = S(q),
+        t = S(Fe);
+    return (n) => e.runOutsideAngular(() => t.handleError(n));
+}
+function MD(e) {
+    return {
+        enableLongStackTrace: !1,
+        shouldCoalesceEventChangeDetection: e?.eventCoalescing ?? !1,
+        shouldCoalesceRunChangeDetection: e?.runCoalescing ?? !1,
+    };
+}
+var xD = (() => {
+    let t = class t {
+        constructor() {
+            (this.subscription = new L()),
+                (this.initialized = !1),
+                (this.zone = S(q)),
+                (this.pendingTasks = S(_s));
+        }
+        initialize() {
+            if (this.initialized) return;
+            this.initialized = !0;
+            let r = null;
+            !this.zone.isStable &&
+                !this.zone.hasPendingMacrotasks &&
+                !this.zone.hasPendingMicrotasks &&
+                (r = this.pendingTasks.add()),
+                this.zone.runOutsideAngular(() => {
+                    this.subscription.add(
+                        this.zone.onStable.subscribe(() => {
+                            q.assertNotInAngularZone(),
+                                queueMicrotask(() => {
+                                    r !== null &&
+                                        !this.zone.hasPendingMacrotasks &&
+                                        !this.zone.hasPendingMicrotasks &&
+                                        (this.pendingTasks.remove(r),
+                                        (r = null));
+                                });
+                        })
+                    );
+                }),
+                this.subscription.add(
+                    this.zone.onUnstable.subscribe(() => {
+                        q.assertInAngularZone(),
+                            (r ??= this.pendingTasks.add());
+                    })
+                );
+        }
+        ngOnDestroy() {
+            this.subscription.unsubscribe();
+        }
+    };
+    (t.ɵfac = function (o) {
+        return new (o || t)();
+    }),
+        (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let e = t;
+    return e;
+})();
+function SD() {
+    return (typeof $localize < "u" && $localize.locale) || br;
+}
+var Ts = new T("", {
+    providedIn: "root",
+    factory: () => S(Ts, b.Optional | b.SkipSelf) || SD(),
+});
+var Ll = new T(""),
+    jl = (() => {
+        let t = class t {
+            constructor(r) {
+                (this._injector = r),
+                    (this._modules = []),
+                    (this._destroyListeners = []),
+                    (this._destroyed = !1);
+            }
+            bootstrapModuleFactory(r, o) {
+                let i = gm(
+                    o?.ngZone,
+                    MD({
+                        eventCoalescing: o?.ngZoneEventCoalescing,
+                        runCoalescing: o?.ngZoneRunCoalescing,
+                    })
+                );
+                return i.run(() => {
+                    let s = oy(
+                            r.moduleType,
+                            this.injector,
+                            bD(() => i)
+                        ),
+                        a = s.injector.get(Fe, null);
+                    return (
+                        i.runOutsideAngular(() => {
+                            let u = i.onError.subscribe({
+                                next: (c) => {
+                                    a.handleError(c);
+                                },
+                            });
+                            s.onDestroy(() => {
+                                tr(this._modules, s), u.unsubscribe();
+                            });
+                        }),
+                        DD(a, i, () => {
+                            let u = s.injector.get(Pl);
+                            return (
+                                u.runInitializers(),
+                                u.donePromise.then(() => {
+                                    let c = s.injector.get(Ts, br);
+                                    return (
+                                        qy(c || br),
+                                        this._moduleDoBootstrap(s),
+                                        s
+                                    );
+                                })
+                            );
+                        })
+                    );
+                });
+            }
+            bootstrapModule(r, o = []) {
+                let i = kl({}, o);
+                return ED(this.injector, i, r).then((s) =>
+                    this.bootstrapModuleFactory(s, i)
+                );
+            }
+            _moduleDoBootstrap(r) {
+                let o = r.injector.get(Ss);
+                if (r._bootstrapComponents.length > 0)
+                    r._bootstrapComponents.forEach((i) => o.bootstrap(i));
+                else if (r.instance.ngDoBootstrap) r.instance.ngDoBootstrap(o);
+                else throw new _(-403, !1);
+                this._modules.push(r);
+            }
+            onDestroy(r) {
+                this._destroyListeners.push(r);
+            }
+            get injector() {
+                return this._injector;
+            }
+            destroy() {
+                if (this._destroyed) throw new _(404, !1);
+                this._modules.slice().forEach((o) => o.destroy()),
+                    this._destroyListeners.forEach((o) => o());
+                let r = this._injector.get(Ll, null);
+                r && (r.forEach((o) => o()), r.clear()), (this._destroyed = !0);
+            }
+            get destroyed() {
+                return this._destroyed;
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)(R(Le));
+        }),
+            (t.ɵprov = O({
+                token: t,
+                factory: t.ɵfac,
+                providedIn: "platform",
+            }));
+        let e = t;
+        return e;
+    })(),
+    qt = null,
+    Vl = new T("");
+function TD(e) {
+    if (qt && !qt.get(Vl, !1)) throw new _(400, !1);
+    mD(), (qt = e);
+    let t = e.get(jl);
+    return FD(e), t;
+}
+function ND(e, t, n = []) {
+    let r = `Platform: ${t}`,
+        o = new T(r);
+    return (i = []) => {
+        let s = Bl();
+        if (!s || s.injector.get(Vl, !1)) {
+            let a = [...n, ...i, { provide: o, useValue: !0 }];
+            e ? e(a) : TD(AD(a, r));
+        }
+        return OD(o);
+    };
+}
+function AD(e = [], t) {
+    return Le.create({
+        name: t,
+        providers: [
+            { provide: ku, useValue: "platform" },
+            { provide: Ll, useValue: new Set([() => (qt = null)]) },
+            ...e,
+        ],
+    });
+}
+function OD(e) {
+    let t = Bl();
+    if (!t) throw new _(401, !1);
+    return t;
+}
+function Bl() {
+    return qt?.get(jl) ?? null;
+}
+function FD(e) {
+    e.get(mh, null)?.forEach((n) => n());
+}
+var Ns = (() => {
+    let t = class t {};
+    t.__NG_ELEMENT_ID__ = RD;
+    let e = t;
+    return e;
+})();
+function RD(e) {
+    return PD(V(), E(), (e & 16) === 16);
+}
+function PD(e, t, n) {
+    if (Nr(e) && !n) {
+        let r = ke(e.index, t);
+        return new nt(r, r);
+    } else if (e.type & 47) {
+        let r = t[ue];
+        return new nt(r, t);
+    }
+    return null;
+}
+var Ri = class {
+        constructor() {}
+        supports(t) {
+            return Dl(t);
+        }
+        create(t) {
+            return new Pi(t);
+        }
+    },
+    kD = (e, t) => t,
+    Pi = class {
+        constructor(t) {
+            (this.length = 0),
+                (this._linkedRecords = null),
+                (this._unlinkedRecords = null),
+                (this._previousItHead = null),
+                (this._itHead = null),
+                (this._itTail = null),
+                (this._additionsHead = null),
+                (this._additionsTail = null),
+                (this._movesHead = null),
+                (this._movesTail = null),
+                (this._removalsHead = null),
+                (this._removalsTail = null),
+                (this._identityChangesHead = null),
+                (this._identityChangesTail = null),
+                (this._trackByFn = t || kD);
+        }
+        forEachItem(t) {
+            let n;
+            for (n = this._itHead; n !== null; n = n._next) t(n);
+        }
+        forEachOperation(t) {
+            let n = this._itHead,
+                r = this._removalsHead,
+                o = 0,
+                i = null;
+            for (; n || r; ) {
+                let s = !r || (n && n.currentIndex < uu(r, o, i)) ? n : r,
+                    a = uu(s, o, i),
+                    u = s.currentIndex;
+                if (s === r) o--, (r = r._nextRemoved);
+                else if (((n = n._next), s.previousIndex == null)) o++;
+                else {
+                    i || (i = []);
+                    let c = a - o,
+                        l = u - o;
+                    if (c != l) {
+                        for (let f = 0; f < c; f++) {
+                            let p = f < i.length ? i[f] : (i[f] = 0),
+                                h = p + f;
+                            l <= h && h < c && (i[f] = p + 1);
+                        }
+                        let d = s.previousIndex;
+                        i[d] = l - c;
+                    }
+                }
+                a !== u && t(s, a, u);
+            }
+        }
+        forEachPreviousItem(t) {
+            let n;
+            for (n = this._previousItHead; n !== null; n = n._nextPrevious)
+                t(n);
+        }
+        forEachAddedItem(t) {
+            let n;
+            for (n = this._additionsHead; n !== null; n = n._nextAdded) t(n);
+        }
+        forEachMovedItem(t) {
+            let n;
+            for (n = this._movesHead; n !== null; n = n._nextMoved) t(n);
+        }
+        forEachRemovedItem(t) {
+            let n;
+            for (n = this._removalsHead; n !== null; n = n._nextRemoved) t(n);
+        }
+        forEachIdentityChange(t) {
+            let n;
+            for (
+                n = this._identityChangesHead;
+                n !== null;
+                n = n._nextIdentityChange
+            )
+                t(n);
+        }
+        diff(t) {
+            if ((t == null && (t = []), !Dl(t))) throw new _(900, !1);
+            return this.check(t) ? this : null;
+        }
+        onDestroy() {}
+        check(t) {
+            this._reset();
+            let n = this._itHead,
+                r = !1,
+                o,
+                i,
+                s;
+            if (Array.isArray(t)) {
+                this.length = t.length;
+                for (let a = 0; a < this.length; a++)
+                    (i = t[a]),
+                        (s = this._trackByFn(a, i)),
+                        n === null || !Object.is(n.trackById, s)
+                            ? ((n = this._mismatch(n, i, s, a)), (r = !0))
+                            : (r && (n = this._verifyReinsertion(n, i, s, a)),
+                              Object.is(n.item, i) ||
+                                  this._addIdentityChange(n, i)),
+                        (n = n._next);
+            } else
+                (o = 0),
+                    sy(t, (a) => {
+                        (s = this._trackByFn(o, a)),
+                            n === null || !Object.is(n.trackById, s)
+                                ? ((n = this._mismatch(n, a, s, o)), (r = !0))
+                                : (r &&
+                                      (n = this._verifyReinsertion(n, a, s, o)),
+                                  Object.is(n.item, a) ||
+                                      this._addIdentityChange(n, a)),
+                            (n = n._next),
+                            o++;
+                    }),
+                    (this.length = o);
+            return this._truncate(n), (this.collection = t), this.isDirty;
+        }
+        get isDirty() {
+            return (
+                this._additionsHead !== null ||
+                this._movesHead !== null ||
+                this._removalsHead !== null ||
+                this._identityChangesHead !== null
+            );
+        }
+        _reset() {
+            if (this.isDirty) {
+                let t;
+                for (
+                    t = this._previousItHead = this._itHead;
+                    t !== null;
+                    t = t._next
+                )
+                    t._nextPrevious = t._next;
+                for (t = this._additionsHead; t !== null; t = t._nextAdded)
+                    t.previousIndex = t.currentIndex;
+                for (
+                    this._additionsHead = this._additionsTail = null,
+                        t = this._movesHead;
+                    t !== null;
+                    t = t._nextMoved
+                )
+                    t.previousIndex = t.currentIndex;
+                (this._movesHead = this._movesTail = null),
+                    (this._removalsHead = this._removalsTail = null),
+                    (this._identityChangesHead = this._identityChangesTail =
+                        null);
+            }
+        }
+        _mismatch(t, n, r, o) {
+            let i;
+            return (
+                t === null
+                    ? (i = this._itTail)
+                    : ((i = t._prev), this._remove(t)),
+                (t =
+                    this._unlinkedRecords === null
+                        ? null
+                        : this._unlinkedRecords.get(r, null)),
+                t !== null
+                    ? (Object.is(t.item, n) || this._addIdentityChange(t, n),
+                      this._reinsertAfter(t, i, o))
+                    : ((t =
+                          this._linkedRecords === null
+                              ? null
+                              : this._linkedRecords.get(r, o)),
+                      t !== null
+                          ? (Object.is(t.item, n) ||
+                                this._addIdentityChange(t, n),
+                            this._moveAfter(t, i, o))
+                          : (t = this._addAfter(new ki(n, r), i, o))),
+                t
+            );
+        }
+        _verifyReinsertion(t, n, r, o) {
+            let i =
+                this._unlinkedRecords === null
+                    ? null
+                    : this._unlinkedRecords.get(r, null);
+            return (
+                i !== null
+                    ? (t = this._reinsertAfter(i, t._prev, o))
+                    : t.currentIndex != o &&
+                      ((t.currentIndex = o), this._addToMoves(t, o)),
+                t
+            );
+        }
+        _truncate(t) {
+            for (; t !== null; ) {
+                let n = t._next;
+                this._addToRemovals(this._unlink(t)), (t = n);
+            }
+            this._unlinkedRecords !== null && this._unlinkedRecords.clear(),
+                this._additionsTail !== null &&
+                    (this._additionsTail._nextAdded = null),
+                this._movesTail !== null && (this._movesTail._nextMoved = null),
+                this._itTail !== null && (this._itTail._next = null),
+                this._removalsTail !== null &&
+                    (this._removalsTail._nextRemoved = null),
+                this._identityChangesTail !== null &&
+                    (this._identityChangesTail._nextIdentityChange = null);
+        }
+        _reinsertAfter(t, n, r) {
+            this._unlinkedRecords !== null && this._unlinkedRecords.remove(t);
+            let o = t._prevRemoved,
+                i = t._nextRemoved;
+            return (
+                o === null ? (this._removalsHead = i) : (o._nextRemoved = i),
+                i === null ? (this._removalsTail = o) : (i._prevRemoved = o),
+                this._insertAfter(t, n, r),
+                this._addToMoves(t, r),
+                t
+            );
+        }
+        _moveAfter(t, n, r) {
+            return (
+                this._unlink(t),
+                this._insertAfter(t, n, r),
+                this._addToMoves(t, r),
+                t
+            );
+        }
+        _addAfter(t, n, r) {
+            return (
+                this._insertAfter(t, n, r),
+                this._additionsTail === null
+                    ? (this._additionsTail = this._additionsHead = t)
+                    : (this._additionsTail = this._additionsTail._nextAdded =
+                          t),
+                t
+            );
+        }
+        _insertAfter(t, n, r) {
+            let o = n === null ? this._itHead : n._next;
+            return (
+                (t._next = o),
+                (t._prev = n),
+                o === null ? (this._itTail = t) : (o._prev = t),
+                n === null ? (this._itHead = t) : (n._next = t),
+                this._linkedRecords === null &&
+                    (this._linkedRecords = new _r()),
+                this._linkedRecords.put(t),
+                (t.currentIndex = r),
+                t
+            );
+        }
+        _remove(t) {
+            return this._addToRemovals(this._unlink(t));
+        }
+        _unlink(t) {
+            this._linkedRecords !== null && this._linkedRecords.remove(t);
+            let n = t._prev,
+                r = t._next;
+            return (
+                n === null ? (this._itHead = r) : (n._next = r),
+                r === null ? (this._itTail = n) : (r._prev = n),
+                t
+            );
+        }
+        _addToMoves(t, n) {
+            return (
+                t.previousIndex === n ||
+                    (this._movesTail === null
+                        ? (this._movesTail = this._movesHead = t)
+                        : (this._movesTail = this._movesTail._nextMoved = t)),
+                t
+            );
+        }
+        _addToRemovals(t) {
+            return (
+                this._unlinkedRecords === null &&
+                    (this._unlinkedRecords = new _r()),
+                this._unlinkedRecords.put(t),
+                (t.currentIndex = null),
+                (t._nextRemoved = null),
+                this._removalsTail === null
+                    ? ((this._removalsTail = this._removalsHead = t),
+                      (t._prevRemoved = null))
+                    : ((t._prevRemoved = this._removalsTail),
+                      (this._removalsTail = this._removalsTail._nextRemoved =
+                          t)),
+                t
+            );
+        }
+        _addIdentityChange(t, n) {
+            return (
+                (t.item = n),
+                this._identityChangesTail === null
+                    ? (this._identityChangesTail = this._identityChangesHead =
+                          t)
+                    : (this._identityChangesTail =
+                          this._identityChangesTail._nextIdentityChange =
+                              t),
+                t
+            );
+        }
+    },
+    ki = class {
+        constructor(t, n) {
+            (this.item = t),
+                (this.trackById = n),
+                (this.currentIndex = null),
+                (this.previousIndex = null),
+                (this._nextPrevious = null),
+                (this._prev = null),
+                (this._next = null),
+                (this._prevDup = null),
+                (this._nextDup = null),
+                (this._prevRemoved = null),
+                (this._nextRemoved = null),
+                (this._nextAdded = null),
+                (this._nextMoved = null),
+                (this._nextIdentityChange = null);
+        }
+    },
+    Li = class {
+        constructor() {
+            (this._head = null), (this._tail = null);
+        }
+        add(t) {
+            this._head === null
+                ? ((this._head = this._tail = t),
+                  (t._nextDup = null),
+                  (t._prevDup = null))
+                : ((this._tail._nextDup = t),
+                  (t._prevDup = this._tail),
+                  (t._nextDup = null),
+                  (this._tail = t));
+        }
+        get(t, n) {
+            let r;
+            for (r = this._head; r !== null; r = r._nextDup)
+                if (
+                    (n === null || n <= r.currentIndex) &&
+                    Object.is(r.trackById, t)
+                )
+                    return r;
+            return null;
+        }
+        remove(t) {
+            let n = t._prevDup,
+                r = t._nextDup;
+            return (
+                n === null ? (this._head = r) : (n._nextDup = r),
+                r === null ? (this._tail = n) : (r._prevDup = n),
+                this._head === null
+            );
+        }
+    },
+    _r = class {
+        constructor() {
+            this.map = new Map();
+        }
+        put(t) {
+            let n = t.trackById,
+                r = this.map.get(n);
+            r || ((r = new Li()), this.map.set(n, r)), r.add(t);
+        }
+        get(t, n) {
+            let r = t,
+                o = this.map.get(r);
+            return o ? o.get(t, n) : null;
+        }
+        remove(t) {
+            let n = t.trackById;
+            return this.map.get(n).remove(t) && this.map.delete(n), t;
+        }
+        get isEmpty() {
+            return this.map.size === 0;
+        }
+        clear() {
+            this.map.clear();
+        }
+    };
+function uu(e, t, n) {
+    let r = e.previousIndex;
+    if (r === null) return r;
+    let o = 0;
+    return n && r < n.length && (o = n[r]), r + t + o;
+}
+function cu() {
+    return new As([new Ri()]);
+}
+var As = (() => {
+    let t = class t {
+        constructor(r) {
+            this.factories = r;
+        }
+        static create(r, o) {
+            if (o != null) {
+                let i = o.factories.slice();
+                r = r.concat(i);
+            }
+            return new t(r);
+        }
+        static extend(r) {
+            return {
+                provide: t,
+                useFactory: (o) => t.create(r, o || cu()),
+                deps: [[t, new Of(), new Af()]],
+            };
+        }
+        find(r) {
+            let o = this.factories.find((i) => i.supports(r));
+            if (o != null) return o;
+            throw new _(901, !1);
+        }
+    };
+    t.ɵprov = O({ token: t, providedIn: "root", factory: cu });
+    let e = t;
+    return e;
+})();
+var CM = ND(null, "core", []),
+    bM = (() => {
+        let t = class t {
+            constructor(r) {}
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)(R(Ss));
+        }),
+            (t.ɵmod = zi({ type: t })),
+            (t.ɵinj = Bi({}));
+        let e = t;
+        return e;
+    })();
+function LD(e) {
+    return typeof e == "boolean" ? e : e != null && e !== "false";
+}
+function jD(e, t = NaN) {
+    return !isNaN(parseFloat(e)) && !isNaN(Number(e)) ? Number(e) : t;
+}
+var VD = new T("", { providedIn: "root", factory: () => S(BD) }),
+    BD = (() => {
+        let t = class t {};
+        t.ɵprov = O({ token: t, providedIn: "root", factory: () => new ji() });
+        let e = t;
+        return e;
+    })(),
+    ji = class {
+        constructor() {
+            (this.queuedEffectCount = 0),
+                (this.queues = new Map()),
+                (this.pendingTasks = S(_s)),
+                (this.taskId = null);
+        }
+        scheduleEffect(t) {
+            if ((this.enqueue(t), this.taskId === null)) {
+                let n = (this.taskId = this.pendingTasks.add());
+                queueMicrotask(() => {
+                    this.flush(),
+                        this.pendingTasks.remove(n),
+                        (this.taskId = null);
+                });
+            }
+        }
+        enqueue(t) {
+            let n = t.creationZone;
+            this.queues.has(n) || this.queues.set(n, new Set());
+            let r = this.queues.get(n);
+            r.has(t) || (this.queuedEffectCount++, r.add(t));
+        }
+        flush() {
+            for (; this.queuedEffectCount > 0; )
+                for (let [t, n] of this.queues)
+                    t === null
+                        ? this.flushQueue(n)
+                        : t.run(() => this.flushQueue(n));
+        }
+        flushQueue(t) {
+            for (let n of t) t.delete(n), this.queuedEffectCount--, n.run();
+        }
+    },
+    Vi = class {
+        constructor(t, n, r, o, i, s) {
+            (this.scheduler = t),
+                (this.effectFn = n),
+                (this.creationZone = r),
+                (this.injector = i),
+                (this.watcher = Ws(
+                    (a) => this.runEffect(a),
+                    () => this.schedule(),
+                    s
+                )),
+                (this.unregisterOnDestroy = o?.onDestroy(() => this.destroy()));
+        }
+        runEffect(t) {
+            try {
+                this.effectFn(t);
+            } catch (n) {
+                this.injector.get(Fe, null, { optional: !0 })?.handleError(n);
+            }
+        }
+        run() {
+            this.watcher.run();
+        }
+        schedule() {
+            this.scheduler.scheduleEffect(this);
+        }
+        destroy() {
+            this.watcher.destroy(), this.unregisterOnDestroy?.();
+        }
+    };
+function $D(e, t) {
+    dn("NgSignals"), !t?.injector && Vu($D);
+    let n = t?.injector ?? S(Le),
+        r = t?.manualCleanup !== !0 ? n.get(kr) : null,
+        o = new Vi(
+            n.get(VD),
+            e,
+            typeof Zone > "u" ? null : Zone.current,
+            r,
+            n,
+            t?.allowSignalWrites ?? !1
+        ),
+        i = n.get(Ns, null, { optional: !0 });
+    return (
+        !i || !(i._lView[m] & 8)
+            ? o.watcher.notify()
+            : (i._lView[Zn] ??= []).push(o.watcher.notify),
+        o
+    );
+}
+function _M(e) {
+    let t = Ne(e);
+    if (!t) return null;
+    let n = new Rt(t);
+    return {
+        get selector() {
+            return n.selector;
+        },
+        get type() {
+            return n.componentType;
+        },
+        get inputs() {
+            return n.inputs;
+        },
+        get outputs() {
+            return n.outputs;
+        },
+        get ngContentSelectors() {
+            return n.ngContentSelectors;
+        },
+        get isStandalone() {
+            return t.standalone;
+        },
+        get isSignal() {
+            return t.signals;
+        },
+    };
+}
+var ql = null;
+function Os() {
+    return ql;
+}
+function KM(e) {
+    ql ??= e;
+}
+var $l = class {};
+var Ls = new T(""),
+    js = (() => {
+        let t = class t {
+            historyGo(r) {
+                throw new Error("");
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)();
+        }),
+            (t.ɵprov = O({
+                token: t,
+                factory: () => S(UD),
+                providedIn: "platform",
+            }));
+        let e = t;
+        return e;
+    })(),
+    JM = new T(""),
+    UD = (() => {
+        let t = class t extends js {
+            constructor() {
+                super(),
+                    (this._doc = S(Ls)),
+                    (this._location = window.location),
+                    (this._history = window.history);
+            }
+            getBaseHrefFromDOM() {
+                return Os().getBaseHref(this._doc);
+            }
+            onPopState(r) {
+                let o = Os().getGlobalEventTarget(this._doc, "window");
+                return (
+                    o.addEventListener("popstate", r, !1),
+                    () => o.removeEventListener("popstate", r)
+                );
+            }
+            onHashChange(r) {
+                let o = Os().getGlobalEventTarget(this._doc, "window");
+                return (
+                    o.addEventListener("hashchange", r, !1),
+                    () => o.removeEventListener("hashchange", r)
+                );
+            }
+            get href() {
+                return this._location.href;
+            }
+            get protocol() {
+                return this._location.protocol;
+            }
+            get hostname() {
+                return this._location.hostname;
+            }
+            get port() {
+                return this._location.port;
+            }
+            get pathname() {
+                return this._location.pathname;
+            }
+            get search() {
+                return this._location.search;
+            }
+            get hash() {
+                return this._location.hash;
+            }
+            set pathname(r) {
+                this._location.pathname = r;
+            }
+            pushState(r, o, i) {
+                this._history.pushState(r, o, i);
+            }
+            replaceState(r, o, i) {
+                this._history.replaceState(r, o, i);
+            }
+            forward() {
+                this._history.forward();
+            }
+            back() {
+                this._history.back();
+            }
+            historyGo(r = 0) {
+                this._history.go(r);
+            }
+            getState() {
+                return this._history.state;
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)();
+        }),
+            (t.ɵprov = O({
+                token: t,
+                factory: () => new t(),
+                providedIn: "platform",
+            }));
+        let e = t;
+        return e;
+    })();
+function Vs(e, t) {
+    if (e.length == 0) return t;
+    if (t.length == 0) return e;
+    let n = 0;
+    return (
+        e.endsWith("/") && n++,
+        t.startsWith("/") && n++,
+        n == 2 ? e + t.substring(1) : n == 1 ? e + t : e + "/" + t
+    );
+}
+function Hl(e) {
+    let t = e.match(/#|\?|$/),
+        n = (t && t.index) || e.length,
+        r = n - (e[n - 1] === "/" ? 1 : 0);
+    return e.slice(0, r) + e.slice(n);
+}
+function Me(e) {
+    return e && e[0] !== "?" ? "?" + e : e;
+}
+var Gr = (() => {
+        let t = class t {
+            historyGo(r) {
+                throw new Error("");
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)();
+        }),
+            (t.ɵprov = O({
+                token: t,
+                factory: () => S(GD),
+                providedIn: "root",
+            }));
+        let e = t;
+        return e;
+    })(),
+    Yl = new T(""),
+    GD = (() => {
+        let t = class t extends Gr {
+            constructor(r, o) {
+                super(),
+                    (this._platformLocation = r),
+                    (this._removeListenerFns = []),
+                    (this._baseHref =
+                        o ??
+                        this._platformLocation.getBaseHrefFromDOM() ??
+                        S(Ls).location?.origin ??
+                        "");
+            }
+            ngOnDestroy() {
+                for (; this._removeListenerFns.length; )
+                    this._removeListenerFns.pop()();
+            }
+            onPopState(r) {
+                this._removeListenerFns.push(
+                    this._platformLocation.onPopState(r),
+                    this._platformLocation.onHashChange(r)
+                );
+            }
+            getBaseHref() {
+                return this._baseHref;
+            }
+            prepareExternalUrl(r) {
+                return Vs(this._baseHref, r);
+            }
+            path(r = !1) {
+                let o =
+                        this._platformLocation.pathname +
+                        Me(this._platformLocation.search),
+                    i = this._platformLocation.hash;
+                return i && r ? `${o}${i}` : o;
+            }
+            pushState(r, o, i, s) {
+                let a = this.prepareExternalUrl(i + Me(s));
+                this._platformLocation.pushState(r, o, a);
+            }
+            replaceState(r, o, i, s) {
+                let a = this.prepareExternalUrl(i + Me(s));
+                this._platformLocation.replaceState(r, o, a);
+            }
+            forward() {
+                this._platformLocation.forward();
+            }
+            back() {
+                this._platformLocation.back();
+            }
+            getState() {
+                return this._platformLocation.getState();
+            }
+            historyGo(r = 0) {
+                this._platformLocation.historyGo?.(r);
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)(R(js), R(Yl, 8));
+        }),
+            (t.ɵprov = O({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let e = t;
+        return e;
+    })(),
+    XM = (() => {
+        let t = class t extends Gr {
+            constructor(r, o) {
+                super(),
+                    (this._platformLocation = r),
+                    (this._baseHref = ""),
+                    (this._removeListenerFns = []),
+                    o != null && (this._baseHref = o);
+            }
+            ngOnDestroy() {
+                for (; this._removeListenerFns.length; )
+                    this._removeListenerFns.pop()();
+            }
+            onPopState(r) {
+                this._removeListenerFns.push(
+                    this._platformLocation.onPopState(r),
+                    this._platformLocation.onHashChange(r)
+                );
+            }
+            getBaseHref() {
+                return this._baseHref;
+            }
+            path(r = !1) {
+                let o = this._platformLocation.hash ?? "#";
+                return o.length > 0 ? o.substring(1) : o;
+            }
+            prepareExternalUrl(r) {
+                let o = Vs(this._baseHref, r);
+                return o.length > 0 ? "#" + o : o;
+            }
+            pushState(r, o, i, s) {
+                let a = this.prepareExternalUrl(i + Me(s));
+                a.length == 0 && (a = this._platformLocation.pathname),
+                    this._platformLocation.pushState(r, o, a);
+            }
+            replaceState(r, o, i, s) {
+                let a = this.prepareExternalUrl(i + Me(s));
+                a.length == 0 && (a = this._platformLocation.pathname),
+                    this._platformLocation.replaceState(r, o, a);
+            }
+            forward() {
+                this._platformLocation.forward();
+            }
+            back() {
+                this._platformLocation.back();
+            }
+            getState() {
+                return this._platformLocation.getState();
+            }
+            historyGo(r = 0) {
+                this._platformLocation.historyGo?.(r);
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)(R(js), R(Yl, 8));
+        }),
+            (t.ɵprov = O({ token: t, factory: t.ɵfac }));
+        let e = t;
+        return e;
+    })(),
+    zD = (() => {
+        let t = class t {
+            constructor(r) {
+                (this._subject = new ie()),
+                    (this._urlChangeListeners = []),
+                    (this._urlChangeSubscription = null),
+                    (this._locationStrategy = r);
+                let o = this._locationStrategy.getBaseHref();
+                (this._basePath = YD(Hl(Ul(o)))),
+                    this._locationStrategy.onPopState((i) => {
+                        this._subject.emit({
+                            url: this.path(!0),
+                            pop: !0,
+                            state: i.state,
+                            type: i.type,
+                        });
+                    });
+            }
+            ngOnDestroy() {
+                this._urlChangeSubscription?.unsubscribe(),
+                    (this._urlChangeListeners = []);
+            }
+            path(r = !1) {
+                return this.normalize(this._locationStrategy.path(r));
+            }
+            getState() {
+                return this._locationStrategy.getState();
+            }
+            isCurrentPathEqualTo(r, o = "") {
+                return this.path() == this.normalize(r + Me(o));
+            }
+            normalize(r) {
+                return t.stripTrailingSlash(qD(this._basePath, Ul(r)));
+            }
+            prepareExternalUrl(r) {
+                return (
+                    r && r[0] !== "/" && (r = "/" + r),
+                    this._locationStrategy.prepareExternalUrl(r)
+                );
+            }
+            go(r, o = "", i = null) {
+                this._locationStrategy.pushState(i, "", r, o),
+                    this._notifyUrlChangeListeners(
+                        this.prepareExternalUrl(r + Me(o)),
+                        i
+                    );
+            }
+            replaceState(r, o = "", i = null) {
+                this._locationStrategy.replaceState(i, "", r, o),
+                    this._notifyUrlChangeListeners(
+                        this.prepareExternalUrl(r + Me(o)),
+                        i
+                    );
+            }
+            forward() {
+                this._locationStrategy.forward();
+            }
+            back() {
+                this._locationStrategy.back();
+            }
+            historyGo(r = 0) {
+                this._locationStrategy.historyGo?.(r);
+            }
+            onUrlChange(r) {
+                return (
+                    this._urlChangeListeners.push(r),
+                    (this._urlChangeSubscription ??= this.subscribe((o) => {
+                        this._notifyUrlChangeListeners(o.url, o.state);
+                    })),
+                    () => {
+                        let o = this._urlChangeListeners.indexOf(r);
+                        this._urlChangeListeners.splice(o, 1),
+                            this._urlChangeListeners.length === 0 &&
+                                (this._urlChangeSubscription?.unsubscribe(),
+                                (this._urlChangeSubscription = null));
+                    }
+                );
+            }
+            _notifyUrlChangeListeners(r = "", o) {
+                this._urlChangeListeners.forEach((i) => i(r, o));
+            }
+            subscribe(r, o, i) {
+                return this._subject.subscribe({
+                    next: r,
+                    error: o,
+                    complete: i,
+                });
+            }
+        };
+        (t.normalizeQueryParams = Me),
+            (t.joinWithSlash = Vs),
+            (t.stripTrailingSlash = Hl),
+            (t.ɵfac = function (o) {
+                return new (o || t)(R(Gr));
+            }),
+            (t.ɵprov = O({
+                token: t,
+                factory: () => WD(),
+                providedIn: "root",
+            }));
+        let e = t;
+        return e;
+    })();
+function WD() {
+    return new zD(R(Gr));
+}
+function qD(e, t) {
+    if (!e || !t.startsWith(e)) return t;
+    let n = t.substring(e.length);
+    return n === "" || ["/", ";", "?", "#"].includes(n[0]) ? n : t;
+}
+function Ul(e) {
+    return e.replace(/\/index.html$/, "");
+}
+function YD(e) {
+    if (new RegExp("^(https?:)?//").test(e)) {
+        let [, n] = e.split(/\/\/[^\/]+/);
+        return n;
+    }
+    return e;
+}
+function ex(e, t) {
+    t = encodeURIComponent(t);
+    for (let n of e.split(";")) {
+        let r = n.indexOf("="),
+            [o, i] = r == -1 ? [n, ""] : [n.slice(0, r), n.slice(r + 1)];
+        if (o.trim() === t) return decodeURIComponent(i);
+    }
+    return null;
+}
+var Fs = class {
+        constructor(t, n, r, o) {
+            (this.$implicit = t),
+                (this.ngForOf = n),
+                (this.index = r),
+                (this.count = o);
+        }
+        get first() {
+            return this.index === 0;
+        }
+        get last() {
+            return this.index === this.count - 1;
+        }
+        get even() {
+            return this.index % 2 === 0;
+        }
+        get odd() {
+            return !this.even;
+        }
+    },
+    tx = (() => {
+        let t = class t {
+            set ngForOf(r) {
+                (this._ngForOf = r), (this._ngForOfDirty = !0);
+            }
+            set ngForTrackBy(r) {
+                this._trackByFn = r;
+            }
+            get ngForTrackBy() {
+                return this._trackByFn;
+            }
+            constructor(r, o, i) {
+                (this._viewContainer = r),
+                    (this._template = o),
+                    (this._differs = i),
+                    (this._ngForOf = null),
+                    (this._ngForOfDirty = !0),
+                    (this._differ = null);
+            }
+            set ngForTemplate(r) {
+                r && (this._template = r);
+            }
+            ngDoCheck() {
+                if (this._ngForOfDirty) {
+                    this._ngForOfDirty = !1;
+                    let r = this._ngForOf;
+                    if (!this._differ && r)
+                        if (0)
+                            try {
+                            } catch {}
+                        else
+                            this._differ = this._differs
+                                .find(r)
+                                .create(this.ngForTrackBy);
+                }
+                if (this._differ) {
+                    let r = this._differ.diff(this._ngForOf);
+                    r && this._applyChanges(r);
+                }
+            }
+            _applyChanges(r) {
+                let o = this._viewContainer;
+                r.forEachOperation((i, s, a) => {
+                    if (i.previousIndex == null)
+                        o.createEmbeddedView(
+                            this._template,
+                            new Fs(i.item, this._ngForOf, -1, -1),
+                            a === null ? void 0 : a
+                        );
+                    else if (a == null) o.remove(s === null ? void 0 : s);
+                    else if (s !== null) {
+                        let u = o.get(s);
+                        o.move(u, a), Gl(u, i);
+                    }
+                });
+                for (let i = 0, s = o.length; i < s; i++) {
+                    let u = o.get(i).context;
+                    (u.index = i), (u.count = s), (u.ngForOf = this._ngForOf);
+                }
+                r.forEachIdentityChange((i) => {
+                    let s = o.get(i.currentIndex);
+                    Gl(s, i);
+                });
+            }
+            static ngTemplateContextGuard(r, o) {
+                return !0;
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)(_e(Bt), _e(rt), _e(As));
+        }),
+            (t.ɵdir = Wi({
+                type: t,
+                selectors: [["", "ngFor", "", "ngForOf", ""]],
+                inputs: {
+                    ngForOf: "ngForOf",
+                    ngForTrackBy: "ngForTrackBy",
+                    ngForTemplate: "ngForTemplate",
+                },
+                standalone: !0,
+            }));
+        let e = t;
+        return e;
+    })();
+function Gl(e, t) {
+    e.context.$implicit = t.item;
+}
+var nx = (() => {
+        let t = class t {
+            constructor(r, o) {
+                (this._viewContainer = r),
+                    (this._context = new Rs()),
+                    (this._thenTemplateRef = null),
+                    (this._elseTemplateRef = null),
+                    (this._thenViewRef = null),
+                    (this._elseViewRef = null),
+                    (this._thenTemplateRef = o);
+            }
+            set ngIf(r) {
+                (this._context.$implicit = this._context.ngIf = r),
+                    this._updateView();
+            }
+            set ngIfThen(r) {
+                zl("ngIfThen", r),
+                    (this._thenTemplateRef = r),
+                    (this._thenViewRef = null),
+                    this._updateView();
+            }
+            set ngIfElse(r) {
+                zl("ngIfElse", r),
+                    (this._elseTemplateRef = r),
+                    (this._elseViewRef = null),
+                    this._updateView();
+            }
+            _updateView() {
+                this._context.$implicit
+                    ? this._thenViewRef ||
+                      (this._viewContainer.clear(),
+                      (this._elseViewRef = null),
+                      this._thenTemplateRef &&
+                          (this._thenViewRef =
+                              this._viewContainer.createEmbeddedView(
+                                  this._thenTemplateRef,
+                                  this._context
+                              )))
+                    : this._elseViewRef ||
+                      (this._viewContainer.clear(),
+                      (this._thenViewRef = null),
+                      this._elseTemplateRef &&
+                          (this._elseViewRef =
+                              this._viewContainer.createEmbeddedView(
+                                  this._elseTemplateRef,
+                                  this._context
+                              )));
+            }
+            static ngTemplateContextGuard(r, o) {
+                return !0;
+            }
+        };
+        (t.ɵfac = function (o) {
+            return new (o || t)(_e(Bt), _e(rt));
+        }),
+            (t.ɵdir = Wi({
+                type: t,
+                selectors: [["", "ngIf", ""]],
+                inputs: {
+                    ngIf: "ngIf",
+                    ngIfThen: "ngIfThen",
+                    ngIfElse: "ngIfElse",
+                },
+                standalone: !0,
+            }));
+        let e = t;
+        return e;
+    })(),
+    Rs = class {
+        constructor() {
+            (this.$implicit = null), (this.ngIf = null);
+        }
+    };
+function zl(e, t) {
+    if (!!!(!t || t.createEmbeddedView))
+        throw new Error(`${e} must be a TemplateRef, but received '${H(t)}'.`);
+}
+var rx = (() => {
+        let t = class t {};
+        (t.ɵfac = function (o) {
+            return new (o || t)();
+        }),
+            (t.ɵmod = zi({ type: t })),
+            (t.ɵinj = Bi({}));
+        let e = t;
+        return e;
+    })(),
+    QD = "browser",
+    ZD = "server";
+function KD(e) {
+    return e === QD;
+}
+function ox(e) {
+    return e === ZD;
+}
+var ix = (() => {
+        let t = class t {};
+        t.ɵprov = O({
+            token: t,
+            providedIn: "root",
+            factory: () => (KD(S(ss)) ? new Ps(S(Ls), window) : new ks()),
+        });
+        let e = t;
+        return e;
+    })(),
+    Ps = class {
+        constructor(t, n) {
+            (this.document = t),
+                (this.window = n),
+                (this.offset = () => [0, 0]);
+        }
+        setOffset(t) {
+            Array.isArray(t) ? (this.offset = () => t) : (this.offset = t);
+        }
+        getScrollPosition() {
+            return [this.window.scrollX, this.window.scrollY];
+        }
+        scrollToPosition(t) {
+            this.window.scrollTo(t[0], t[1]);
+        }
+        scrollToAnchor(t) {
+            let n = JD(this.document, t);
+            n && (this.scrollToElement(n), n.focus());
+        }
+        setHistoryScrollRestoration(t) {
+            this.window.history.scrollRestoration = t;
+        }
+        scrollToElement(t) {
+            let n = t.getBoundingClientRect(),
+                r = n.left + this.window.pageXOffset,
+                o = n.top + this.window.pageYOffset,
+                i = this.offset();
+            this.window.scrollTo(r - i[0], o - i[1]);
+        }
+    };
+function JD(e, t) {
+    let n = e.getElementById(t) || e.getElementsByName(t)[0];
+    if (n) return n;
+    if (
+        typeof e.createTreeWalker == "function" &&
+        e.body &&
+        typeof e.body.attachShadow == "function"
+    ) {
+        let r = e.createTreeWalker(e.body, NodeFilter.SHOW_ELEMENT),
+            o = r.currentNode;
+        for (; o; ) {
+            let i = o.shadowRoot;
+            if (i) {
+                let s = i.getElementById(t) || i.querySelector(`[name="${t}"]`);
+                if (s) return s;
+            }
+            o = r.nextNode();
+        }
+    }
+    return null;
+}
+var ks = class {
+        setOffset(t) {}
+        getScrollPosition() {
+            return [0, 0];
+        }
+        scrollToPosition(t) {}
+        scrollToAnchor(t) {}
+        setHistoryScrollRestoration(t) {}
+    },
+    Wl = class {};
+var at = (function (e) {
+        return (
+            (e[(e.State = 0)] = "State"),
+            (e[(e.Transition = 1)] = "Transition"),
+            (e[(e.Sequence = 2)] = "Sequence"),
+            (e[(e.Group = 3)] = "Group"),
+            (e[(e.Animate = 4)] = "Animate"),
+            (e[(e.Keyframes = 5)] = "Keyframes"),
+            (e[(e.Style = 6)] = "Style"),
+            (e[(e.Trigger = 7)] = "Trigger"),
+            (e[(e.Reference = 8)] = "Reference"),
+            (e[(e.AnimateChild = 9)] = "AnimateChild"),
+            (e[(e.AnimateRef = 10)] = "AnimateRef"),
+            (e[(e.Query = 11)] = "Query"),
+            (e[(e.Stagger = 12)] = "Stagger"),
+            e
+        );
+    })(at || {}),
+    ux = "*";
+function cx(e, t) {
+    return { type: at.Trigger, name: e, definitions: t, options: {} };
+}
+function lx(e, t = null) {
+    return { type: at.Animate, styles: t, timings: e };
+}
+function dx(e, t = null) {
+    return { type: at.Sequence, steps: e, options: t };
+}
+function fx(e) {
+    return { type: at.Style, styles: e, offset: null };
+}
+function px(e, t, n) {
+    return { type: at.State, name: e, styles: t, options: n };
+}
+function hx(e, t, n = null) {
+    return { type: at.Transition, expr: e, animation: t, options: n };
+}
+var Ql = class {
+        constructor(t = 0, n = 0) {
+            (this._onDoneFns = []),
+                (this._onStartFns = []),
+                (this._onDestroyFns = []),
+                (this._originalOnDoneFns = []),
+                (this._originalOnStartFns = []),
+                (this._started = !1),
+                (this._destroyed = !1),
+                (this._finished = !1),
+                (this._position = 0),
+                (this.parentPlayer = null),
+                (this.totalTime = t + n);
+        }
+        _onFinish() {
+            this._finished ||
+                ((this._finished = !0),
+                this._onDoneFns.forEach((t) => t()),
+                (this._onDoneFns = []));
+        }
+        onStart(t) {
+            this._originalOnStartFns.push(t), this._onStartFns.push(t);
+        }
+        onDone(t) {
+            this._originalOnDoneFns.push(t), this._onDoneFns.push(t);
+        }
+        onDestroy(t) {
+            this._onDestroyFns.push(t);
+        }
+        hasStarted() {
+            return this._started;
+        }
+        init() {}
+        play() {
+            this.hasStarted() || (this._onStart(), this.triggerMicrotask()),
+                (this._started = !0);
+        }
+        triggerMicrotask() {
+            queueMicrotask(() => this._onFinish());
+        }
+        _onStart() {
+            this._onStartFns.forEach((t) => t()), (this._onStartFns = []);
+        }
+        pause() {}
+        restart() {}
+        finish() {
+            this._onFinish();
+        }
+        destroy() {
+            this._destroyed ||
+                ((this._destroyed = !0),
+                this.hasStarted() || this._onStart(),
+                this.finish(),
+                this._onDestroyFns.forEach((t) => t()),
+                (this._onDestroyFns = []));
+        }
+        reset() {
+            (this._started = !1),
+                (this._finished = !1),
+                (this._onStartFns = this._originalOnStartFns),
+                (this._onDoneFns = this._originalOnDoneFns);
+        }
+        setPosition(t) {
+            this._position = this.totalTime ? t * this.totalTime : 1;
+        }
+        getPosition() {
+            return this.totalTime ? this._position / this.totalTime : 1;
+        }
+        triggerCallback(t) {
+            let n = t == "start" ? this._onStartFns : this._onDoneFns;
+            n.forEach((r) => r()), (n.length = 0);
+        }
+    },
+    Zl = class {
+        constructor(t) {
+            (this._onDoneFns = []),
+                (this._onStartFns = []),
+                (this._finished = !1),
+                (this._started = !1),
+                (this._destroyed = !1),
+                (this._onDestroyFns = []),
+                (this.parentPlayer = null),
+                (this.totalTime = 0),
+                (this.players = t);
+            let n = 0,
+                r = 0,
+                o = 0,
+                i = this.players.length;
+            i == 0
+                ? queueMicrotask(() => this._onFinish())
+                : this.players.forEach((s) => {
+                      s.onDone(() => {
+                          ++n == i && this._onFinish();
+                      }),
+                          s.onDestroy(() => {
+                              ++r == i && this._onDestroy();
+                          }),
+                          s.onStart(() => {
+                              ++o == i && this._onStart();
+                          });
+                  }),
+                (this.totalTime = this.players.reduce(
+                    (s, a) => Math.max(s, a.totalTime),
+                    0
+                ));
+        }
+        _onFinish() {
+            this._finished ||
+                ((this._finished = !0),
+                this._onDoneFns.forEach((t) => t()),
+                (this._onDoneFns = []));
+        }
+        init() {
+            this.players.forEach((t) => t.init());
+        }
+        onStart(t) {
+            this._onStartFns.push(t);
+        }
+        _onStart() {
+            this.hasStarted() ||
+                ((this._started = !0),
+                this._onStartFns.forEach((t) => t()),
+                (this._onStartFns = []));
+        }
+        onDone(t) {
+            this._onDoneFns.push(t);
+        }
+        onDestroy(t) {
+            this._onDestroyFns.push(t);
+        }
+        hasStarted() {
+            return this._started;
+        }
+        play() {
+            this.parentPlayer || this.init(),
+                this._onStart(),
+                this.players.forEach((t) => t.play());
+        }
+        pause() {
+            this.players.forEach((t) => t.pause());
+        }
+        restart() {
+            this.players.forEach((t) => t.restart());
+        }
+        finish() {
+            this._onFinish(), this.players.forEach((t) => t.finish());
+        }
+        destroy() {
+            this._onDestroy();
+        }
+        _onDestroy() {
+            this._destroyed ||
+                ((this._destroyed = !0),
+                this._onFinish(),
+                this.players.forEach((t) => t.destroy()),
+                this._onDestroyFns.forEach((t) => t()),
+                (this._onDestroyFns = []));
+        }
+        reset() {
+            this.players.forEach((t) => t.reset()),
+                (this._destroyed = !1),
+                (this._finished = !1),
+                (this._started = !1);
+        }
+        setPosition(t) {
+            let n = t * this.totalTime;
+            this.players.forEach((r) => {
+                let o = r.totalTime ? Math.min(1, n / r.totalTime) : 1;
+                r.setPosition(o);
+            });
+        }
+        getPosition() {
+            let t = this.players.reduce(
+                (n, r) => (n === null || r.totalTime > n.totalTime ? r : n),
+                null
+            );
+            return t != null ? t.getPosition() : 0;
+        }
+        beforeDestroy() {
+            this.players.forEach((t) => {
+                t.beforeDestroy && t.beforeDestroy();
+            });
+        }
+        triggerCallback(t) {
+            let n = t == "start" ? this._onStartFns : this._onDoneFns;
+            n.forEach((r) => r()), (n.length = 0);
+        }
+    },
+    gx = "!";
+export {
+    xe as a,
+    lt as b,
+    XD as c,
+    nd as d,
+    L as e,
+    pd as f,
+    C as g,
+    uo as h,
+    co as i,
+    ce as j,
+    $t as k,
+    vd as l,
+    Ge as m,
+    de as n,
+    xd as o,
+    Sd as p,
+    Td as q,
+    We as r,
+    De as s,
+    Ld as t,
+    ne as u,
+    Gt as v,
+    It as w,
+    Vd as x,
+    Bd as y,
+    go as z,
+    qd as A,
+    qe as B,
+    Yd as C,
+    wa as D,
+    Qd as E,
+    Zd as F,
+    zt as G,
+    wt as H,
+    mo as I,
+    Kd as J,
+    Jd as K,
+    tf as L,
+    ba as M,
+    Do as N,
+    nf as O,
+    rf as P,
+    of as Q,
+    sf as R,
+    af as S,
+    uf as T,
+    cf as U,
+    lf as V,
+    _ as W,
+    ve as X,
+    pu as Y,
+    O as Z,
+    Bi as _,
+    R_ as $,
+    T as aa,
+    b as ba,
+    R as ca,
+    S as da,
+    Af as ea,
+    Of as fa,
+    Qt as ga,
+    Ze as ha,
+    P_ as ia,
+    zi as ja,
+    Wi as ka,
+    k_ as la,
+    ku as ma,
+    Ae as na,
+    fp as oa,
+    Uu as pa,
+    L_ as qa,
+    j_ as ra,
+    V_ as sa,
+    B_ as ta,
+    oh as ua,
+    Le as va,
+    Fe as wa,
+    jt as xa,
+    ie as ya,
+    Qo as za,
+    $_ as Aa,
+    H_ as Ba,
+    mh as Ca,
+    ss as Da,
+    U_ as Ea,
+    G_ as Fa,
+    cn as Ga,
+    Mc as Ha,
+    z_ as Ia,
+    W_ as Ja,
+    q_ as Ka,
+    Y_ as La,
+    Q_ as Ma,
+    xc as Na,
+    Z_ as Oa,
+    us as Pa,
+    Bh as Qa,
+    K_ as Ra,
+    dr as Sa,
+    J_ as Ta,
+    _e as Ua,
+    X_ as Va,
+    rt as Wa,
+    gr as Xa,
+    Ur as Ya,
+    pi as Za,
+    dl as _a,
+    dn as $a,
+    q as ab,
+    ym as bb,
+    Bt as cb,
+    Um as db,
+    Km as eb,
+    ry as fb,
+    _i as gb,
+    iy as hb,
+    _s as ib,
+    dy as jb,
+    hy as kb,
+    _y as lb,
+    My as mb,
+    rM as nb,
+    oM as ob,
+    Ml as pb,
+    xl as qb,
+    $y as rb,
+    Sl as sb,
+    Tl as tb,
+    Gy as ub,
+    iM as vb,
+    Yy as wb,
+    sM as xb,
+    aM as yb,
+    uM as zb,
+    Ky as Ab,
+    cM as Bb,
+    lM as Cb,
+    dM as Db,
+    fM as Eb,
+    pM as Fb,
+    hM as Gb,
+    Xy as Hb,
+    Ol as Ib,
+    eD as Jb,
+    gM as Kb,
+    tD as Lb,
+    mM as Mb,
+    yM as Nb,
+    DM as Ob,
+    vM as Pb,
+    IM as Qb,
+    lD as Rb,
+    dD as Sb,
+    wM as Tb,
+    fD as Ub,
+    xs as Vb,
+    hD as Wb,
+    gD as Xb,
+    Ss as Yb,
+    EM as Zb,
+    ND as _b,
+    Ns as $b,
+    As as ac,
+    CM as bc,
+    bM as cc,
+    LD as dc,
+    jD as ec,
+    $D as fc,
+    _M as gc,
+    Os as hc,
+    KM as ic,
+    $l as jc,
+    Ls as kc,
+    JM as lc,
+    Gr as mc,
+    GD as nc,
+    XM as oc,
+    zD as pc,
+    ex as qc,
+    tx as rc,
+    nx as sc,
+    rx as tc,
+    QD as uc,
+    KD as vc,
+    ox as wc,
+    ix as xc,
+    Wl as yc,
+    at as zc,
+    ux as Ac,
+    cx as Bc,
+    lx as Cc,
+    dx as Dc,
+    fx as Ec,
+    px as Fc,
+    hx as Gc,
+    Ql as Hc,
+    Zl as Ic,
+    gx as Jc,
+};

--- a/angularDist/chunk-LWJOV7RA.js
+++ b/angularDist/chunk-LWJOV7RA.js
@@ -1,1 +1,3799 @@
-import{Ac as B,Dc as yt,Ec as Me,Hc as x,Ic as Ce,Jc as ue,W as E,Z as gt,a as he,c as pt,zc as S}from"./chunk-LPDIY7FO.js";function _t(n){return new E(3e3,!1)}function Ht(){return new E(3100,!1)}function Yt(){return new E(3101,!1)}function Xt(n){return new E(3001,!1)}function Zt(n){return new E(3003,!1)}function Jt(n){return new E(3004,!1)}function xt(n,e){return new E(3005,!1)}function es(){return new E(3006,!1)}function ts(){return new E(3007,!1)}function ss(n,e){return new E(3008,!1)}function is(n){return new E(3002,!1)}function ns(n,e,t,s,i){return new E(3010,!1)}function rs(){return new E(3011,!1)}function as(){return new E(3012,!1)}function os(){return new E(3200,!1)}function ls(){return new E(3202,!1)}function hs(){return new E(3013,!1)}function us(n){return new E(3014,!1)}function cs(n){return new E(3015,!1)}function fs(n){return new E(3016,!1)}function ds(n){return new E(3500,!1)}function ms(n){return new E(3501,!1)}function ps(n,e){return new E(3404,!1)}function gs(n){return new E(3502,!1)}function ys(n){return new E(3503,!1)}function _s(){return new E(3300,!1)}function Es(n){return new E(3504,!1)}function Ss(n){return new E(3301,!1)}function Ts(n,e){return new E(3302,!1)}function vs(n){return new E(3303,!1)}function ws(n,e){return new E(3400,!1)}function bs(n){return new E(3401,!1)}function As(n){return new E(3402,!1)}function Ps(n,e){return new E(3505,!1)}var Ns=new Set(["-moz-outline-radius","-moz-outline-radius-bottomleft","-moz-outline-radius-bottomright","-moz-outline-radius-topleft","-moz-outline-radius-topright","-ms-grid-columns","-ms-grid-rows","-webkit-line-clamp","-webkit-text-fill-color","-webkit-text-stroke","-webkit-text-stroke-color","accent-color","all","backdrop-filter","background","background-color","background-position","background-size","block-size","border","border-block-end","border-block-end-color","border-block-end-width","border-block-start","border-block-start-color","border-block-start-width","border-bottom","border-bottom-color","border-bottom-left-radius","border-bottom-right-radius","border-bottom-width","border-color","border-end-end-radius","border-end-start-radius","border-image-outset","border-image-slice","border-image-width","border-inline-end","border-inline-end-color","border-inline-end-width","border-inline-start","border-inline-start-color","border-inline-start-width","border-left","border-left-color","border-left-width","border-radius","border-right","border-right-color","border-right-width","border-start-end-radius","border-start-start-radius","border-top","border-top-color","border-top-left-radius","border-top-right-radius","border-top-width","border-width","bottom","box-shadow","caret-color","clip","clip-path","color","column-count","column-gap","column-rule","column-rule-color","column-rule-width","column-width","columns","filter","flex","flex-basis","flex-grow","flex-shrink","font","font-size","font-size-adjust","font-stretch","font-variation-settings","font-weight","gap","grid-column-gap","grid-gap","grid-row-gap","grid-template-columns","grid-template-rows","height","inline-size","input-security","inset","inset-block","inset-block-end","inset-block-start","inset-inline","inset-inline-end","inset-inline-start","left","letter-spacing","line-clamp","line-height","margin","margin-block-end","margin-block-start","margin-bottom","margin-inline-end","margin-inline-start","margin-left","margin-right","margin-top","mask","mask-border","mask-position","mask-size","max-block-size","max-height","max-inline-size","max-lines","max-width","min-block-size","min-height","min-inline-size","min-width","object-position","offset","offset-anchor","offset-distance","offset-path","offset-position","offset-rotate","opacity","order","outline","outline-color","outline-offset","outline-width","padding","padding-block-end","padding-block-start","padding-bottom","padding-inline-end","padding-inline-start","padding-left","padding-right","padding-top","perspective","perspective-origin","right","rotate","row-gap","scale","scroll-margin","scroll-margin-block","scroll-margin-block-end","scroll-margin-block-start","scroll-margin-bottom","scroll-margin-inline","scroll-margin-inline-end","scroll-margin-inline-start","scroll-margin-left","scroll-margin-right","scroll-margin-top","scroll-padding","scroll-padding-block","scroll-padding-block-end","scroll-padding-block-start","scroll-padding-bottom","scroll-padding-inline","scroll-padding-inline-end","scroll-padding-inline-start","scroll-padding-left","scroll-padding-right","scroll-padding-top","scroll-snap-coordinate","scroll-snap-destination","scrollbar-color","shape-image-threshold","shape-margin","shape-outside","tab-size","text-decoration","text-decoration-color","text-decoration-thickness","text-emphasis","text-emphasis-color","text-indent","text-shadow","text-underline-offset","top","transform","transform-origin","translate","vertical-align","visibility","width","word-spacing","z-index","zoom"]);function U(n){switch(n.length){case 0:return new x;case 1:return n[0];default:return new Ce(n)}}function It(n,e,t=new Map,s=new Map){let i=[],r=[],a=-1,o=null;if(e.forEach(l=>{let h=l.get("offset"),c=h==a,u=c&&o||new Map;l.forEach((_,y)=>{let d=y,g=_;if(y!=="offset")switch(d=n.normalizePropertyName(d,i),g){case ue:g=t.get(y);break;case B:g=s.get(y);break;default:g=n.normalizeStyleValue(y,d,g,i);break}u.set(d,g)}),c||r.push(u),o=u,a=h}),i.length)throw gs(i);return r}function tt(n,e,t,s){switch(e){case"start":n.onStart(()=>s(t&&ke(t,"start",n)));break;case"done":n.onDone(()=>s(t&&ke(t,"done",n)));break;case"destroy":n.onDestroy(()=>s(t&&ke(t,"destroy",n)));break}}function ke(n,e,t){let s=t.totalTime,i=!!t.disabled,r=st(n.element,n.triggerName,n.fromState,n.toState,e||n.phaseName,s??n.totalTime,i),a=n._data;return a!=null&&(r._data=a),r}function st(n,e,t,s,i="",r=0,a){return{element:n,triggerName:e,fromState:t,toState:s,phaseName:i,totalTime:r,disabled:!!a}}function L(n,e,t){let s=n.get(e);return s||n.set(e,s=t),s}function Et(n){let e=n.indexOf(":"),t=n.substring(1,e),s=n.slice(e+1);return[t,s]}var Ms=typeof document>"u"?null:document.documentElement;function it(n){let e=n.parentNode||n.host||null;return e===Ms?null:e}function Cs(n){return n.substring(1,6)=="ebkit"}var H=null,St=!1;function ks(n){H||(H=Ds()||{},St=H.style?"WebkitAppearance"in H.style:!1);let e=!0;return H.style&&!Cs(n)&&(e=n in H.style,!e&&St&&(e="Webkit"+n.charAt(0).toUpperCase()+n.slice(1)in H.style)),e}function Ai(n){return Ns.has(n)}function Ds(){return typeof document<"u"?document.body:null}function zt(n,e){for(;e;){if(e===n)return!0;e=it(e)}return!1}function Kt(n,e,t){if(t)return Array.from(n.querySelectorAll(e));let s=n.querySelector(e);return s?[s]:[]}var qt=(()=>{let e=class e{validateStyleProperty(s){return ks(s)}matchesElement(s,i){return!1}containsElement(s,i){return zt(s,i)}getParentElement(s){return it(s)}query(s,i,r){return Kt(s,i,r)}computeStyle(s,i,r){return r||""}animate(s,i,r,a,o,l=[],h){return new x(r,a)}};e.\u0275fac=function(i){return new(i||e)},e.\u0275prov=gt({token:e,factory:e.\u0275fac});let n=e;return n})(),ut=class ut{};ut.NOOP=new qt;var Tt=ut,Ie=class{},ze=class{normalizePropertyName(e,t){return e}normalizeStyleValue(e,t,s,i){return s}},Rs=1e3,Bt="{{",Os="}}",nt="ng-enter",ge="ng-leave",ce="ng-trigger",ye=".ng-trigger",vt="ng-animating",Ke=".ng-animating";function $(n){if(typeof n=="number")return n;let e=n.match(/^(-?[\.\d]+)(m?s)/);return!e||e.length<2?0:qe(parseFloat(e[1]),e[2])}function qe(n,e){switch(e){case"s":return n*Rs;default:return n}}function _e(n,e,t){return n.hasOwnProperty("duration")?n:Ls(n,e,t)}function Ls(n,e,t){let s=/^(-?[\.\d]+)(m?s)(?:\s+(-?[\.\d]+)(m?s))?(?:\s+([-a-z]+(?:\(.+?\))?))?$/i,i,r=0,a="";if(typeof n=="string"){let o=n.match(s);if(o===null)return e.push(_t(n)),{duration:0,delay:0,easing:""};i=qe(parseFloat(o[1]),o[2]);let l=o[3];l!=null&&(r=qe(parseFloat(l),o[4]));let h=o[5];h&&(a=h)}else i=n;if(!t){let o=!1,l=e.length;i<0&&(e.push(Ht()),o=!0),r<0&&(e.push(Yt()),o=!0),o&&e.splice(l,0,_t(n))}return{duration:i,delay:r,easing:a}}function Fs(n){return n.length?n[0]instanceof Map?n:n.map(e=>new Map(Object.entries(e))):[]}function wt(n){return Array.isArray(n)?new Map(...n):new Map(n)}function Q(n,e,t){e.forEach((s,i)=>{let r=rt(i);t&&!t.has(i)&&t.set(i,n.style[r]),n.style[r]=s})}function X(n,e){e.forEach((t,s)=>{let i=rt(s);n.style[i]=""})}function ie(n){return Array.isArray(n)?n.length==1?n[0]:yt(n):n}function Is(n,e,t){let s=e.params||{},i=Qt(n);i.length&&i.forEach(r=>{s.hasOwnProperty(r)||t.push(Xt(r))})}var Be=new RegExp(`${Bt}\\s*(.+?)\\s*${Os}`,"g");function Qt(n){let e=[];if(typeof n=="string"){let t;for(;t=Be.exec(n);)e.push(t[1]);Be.lastIndex=0}return e}function re(n,e,t){let s=`${n}`,i=s.replace(Be,(r,a)=>{let o=e[a];return o==null&&(t.push(Zt(a)),o=""),o.toString()});return i==s?n:i}var zs=/-+([a-z0-9])/g;function rt(n){return n.replace(zs,(...e)=>e[1].toUpperCase())}function Pi(n){return n.replace(/([a-z])([A-Z])/g,"$1-$2").toLowerCase()}function Ks(n,e){return n===0||e===0}function qs(n,e,t){if(t.size&&e.length){let s=e[0],i=[];if(t.forEach((r,a)=>{s.has(a)||i.push(a),s.set(a,r)}),i.length)for(let r=1;r<e.length;r++){let a=e[r];i.forEach(o=>a.set(o,at(n,o)))}}return e}function O(n,e,t){switch(e.type){case S.Trigger:return n.visitTrigger(e,t);case S.State:return n.visitState(e,t);case S.Transition:return n.visitTransition(e,t);case S.Sequence:return n.visitSequence(e,t);case S.Group:return n.visitGroup(e,t);case S.Animate:return n.visitAnimate(e,t);case S.Keyframes:return n.visitKeyframes(e,t);case S.Style:return n.visitStyle(e,t);case S.Reference:return n.visitReference(e,t);case S.AnimateChild:return n.visitAnimateChild(e,t);case S.AnimateRef:return n.visitAnimateRef(e,t);case S.Query:return n.visitQuery(e,t);case S.Stagger:return n.visitStagger(e,t);default:throw Jt(e.type)}}function at(n,e){return window.getComputedStyle(n)[e]}var Bs=new Set(["width","height","minWidth","minHeight","maxWidth","maxHeight","left","top","bottom","right","fontSize","outlineWidth","outlineOffset","paddingTop","paddingLeft","paddingBottom","paddingRight","marginTop","marginLeft","marginBottom","marginRight","borderRadius","borderWidth","borderTopWidth","borderLeftWidth","borderRightWidth","borderBottomWidth","textIndent","perspective"]),Qe=class extends Ie{normalizePropertyName(e,t){return rt(e)}normalizeStyleValue(e,t,s,i){let r="",a=s.toString().trim();if(Bs.has(t)&&s!==0&&s!=="0")if(typeof s=="number")r="px";else{let o=s.match(/^[+-]?[\d\.]+([a-z]*)$/);o&&o[1].length==0&&i.push(xt(e,s))}return a+r}};var Ee="*";function Qs(n,e){let t=[];return typeof n=="string"?n.split(/\s*,\s*/).forEach(s=>$s(s,t,e)):t.push(n),t}function $s(n,e,t){if(n[0]==":"){let l=Vs(n,t);if(typeof l=="function"){e.push(l);return}n=l}let s=n.match(/^(\*|[-\w]+)\s*(<?[=-]>)\s*(\*|[-\w]+)$/);if(s==null||s.length<4)return t.push(cs(n)),e;let i=s[1],r=s[2],a=s[3];e.push(bt(i,a));let o=i==Ee&&a==Ee;r[0]=="<"&&!o&&e.push(bt(a,i))}function Vs(n,e){switch(n){case":enter":return"void => *";case":leave":return"* => void";case":increment":return(t,s)=>parseFloat(s)>parseFloat(t);case":decrement":return(t,s)=>parseFloat(s)<parseFloat(t);default:return e.push(fs(n)),"* => *"}}var fe=new Set(["true","1"]),de=new Set(["false","0"]);function bt(n,e){let t=fe.has(n)||de.has(n),s=fe.has(e)||de.has(e);return(i,r)=>{let a=n==Ee||n==i,o=e==Ee||e==r;return!a&&t&&typeof i=="boolean"&&(a=i?fe.has(n):de.has(n)),!o&&s&&typeof r=="boolean"&&(o=r?fe.has(e):de.has(e)),a&&o}}var $t=":self",Us=new RegExp(`s*${$t}s*,?`,"g");function ot(n,e,t,s){return new $e(n).build(e,t,s)}var At="",$e=class{constructor(e){this._driver=e}build(e,t,s){let i=new Ve(t);return this._resetContextStyleTimingState(i),O(this,ie(e),i)}_resetContextStyleTimingState(e){e.currentQuerySelector=At,e.collectedStyles=new Map,e.collectedStyles.set(At,new Map),e.currentTime=0}visitTrigger(e,t){let s=t.queryCount=0,i=t.depCount=0,r=[],a=[];return e.name.charAt(0)=="@"&&t.errors.push(es()),e.definitions.forEach(o=>{if(this._resetContextStyleTimingState(t),o.type==S.State){let l=o,h=l.name;h.toString().split(/\s*,\s*/).forEach(c=>{l.name=c,r.push(this.visitState(l,t))}),l.name=h}else if(o.type==S.Transition){let l=this.visitTransition(o,t);s+=l.queryCount,i+=l.depCount,a.push(l)}else t.errors.push(ts())}),{type:S.Trigger,name:e.name,states:r,transitions:a,queryCount:s,depCount:i,options:null}}visitState(e,t){let s=this.visitStyle(e.styles,t),i=e.options&&e.options.params||null;if(s.containsDynamicStyles){let r=new Set,a=i||{};s.styles.forEach(o=>{o instanceof Map&&o.forEach(l=>{Qt(l).forEach(h=>{a.hasOwnProperty(h)||r.add(h)})})}),r.size&&t.errors.push(ss(e.name,[...r.values()]))}return{type:S.State,name:e.name,style:s,options:i?{params:i}:null}}visitTransition(e,t){t.queryCount=0,t.depCount=0;let s=O(this,ie(e.animation),t),i=Qs(e.expr,t.errors);return{type:S.Transition,matchers:i,animation:s,queryCount:t.queryCount,depCount:t.depCount,options:Y(e.options)}}visitSequence(e,t){return{type:S.Sequence,steps:e.steps.map(s=>O(this,s,t)),options:Y(e.options)}}visitGroup(e,t){let s=t.currentTime,i=0,r=e.steps.map(a=>{t.currentTime=s;let o=O(this,a,t);return i=Math.max(i,t.currentTime),o});return t.currentTime=i,{type:S.Group,steps:r,options:Y(e.options)}}visitAnimate(e,t){let s=Hs(e.timings,t.errors);t.currentAnimateTimings=s;let i,r=e.styles?e.styles:Me({});if(r.type==S.Keyframes)i=this.visitKeyframes(r,t);else{let a=e.styles,o=!1;if(!a){o=!0;let h={};s.easing&&(h.easing=s.easing),a=Me(h)}t.currentTime+=s.duration+s.delay;let l=this.visitStyle(a,t);l.isEmptyStep=o,i=l}return t.currentAnimateTimings=null,{type:S.Animate,timings:s,style:i,options:null}}visitStyle(e,t){let s=this._makeStyleAst(e,t);return this._validateStyleAst(s,t),s}_makeStyleAst(e,t){let s=[],i=Array.isArray(e.styles)?e.styles:[e.styles];for(let o of i)typeof o=="string"?o===B?s.push(o):t.errors.push(is(o)):s.push(new Map(Object.entries(o)));let r=!1,a=null;return s.forEach(o=>{if(o instanceof Map&&(o.has("easing")&&(a=o.get("easing"),o.delete("easing")),!r)){for(let l of o.values())if(l.toString().indexOf(Bt)>=0){r=!0;break}}}),{type:S.Style,styles:s,easing:a,offset:e.offset,containsDynamicStyles:r,options:null}}_validateStyleAst(e,t){let s=t.currentAnimateTimings,i=t.currentTime,r=t.currentTime;s&&r>0&&(r-=s.duration+s.delay),e.styles.forEach(a=>{typeof a!="string"&&a.forEach((o,l)=>{let h=t.collectedStyles.get(t.currentQuerySelector),c=h.get(l),u=!0;c&&(r!=i&&r>=c.startTime&&i<=c.endTime&&(t.errors.push(ns(l,c.startTime,c.endTime,r,i)),u=!1),r=c.startTime),u&&h.set(l,{startTime:r,endTime:i}),t.options&&Is(o,t.options,t.errors)})})}visitKeyframes(e,t){let s={type:S.Keyframes,styles:[],options:null};if(!t.currentAnimateTimings)return t.errors.push(rs()),s;let i=1,r=0,a=[],o=!1,l=!1,h=0,c=e.steps.map(b=>{let A=this._makeStyleAst(b,t),C=A.offset!=null?A.offset:Gs(A.styles),N=0;return C!=null&&(r++,N=A.offset=C),l=l||N<0||N>1,o=o||N<h,h=N,a.push(N),A});l&&t.errors.push(as()),o&&t.errors.push(os());let u=e.steps.length,_=0;r>0&&r<u?t.errors.push(ls()):r==0&&(_=i/(u-1));let y=u-1,d=t.currentTime,g=t.currentAnimateTimings,v=g.duration;return c.forEach((b,A)=>{let C=_>0?A==y?1:_*A:a[A],N=C*v;t.currentTime=d+g.delay+N,g.duration=N,this._validateStyleAst(b,t),b.offset=C,s.styles.push(b)}),s}visitReference(e,t){return{type:S.Reference,animation:O(this,ie(e.animation),t),options:Y(e.options)}}visitAnimateChild(e,t){return t.depCount++,{type:S.AnimateChild,options:Y(e.options)}}visitAnimateRef(e,t){return{type:S.AnimateRef,animation:this.visitReference(e.animation,t),options:Y(e.options)}}visitQuery(e,t){let s=t.currentQuerySelector,i=e.options||{};t.queryCount++,t.currentQuery=e;let[r,a]=js(e.selector);t.currentQuerySelector=s.length?s+" "+r:r,L(t.collectedStyles,t.currentQuerySelector,new Map);let o=O(this,ie(e.animation),t);return t.currentQuery=null,t.currentQuerySelector=s,{type:S.Query,selector:r,limit:i.limit||0,optional:!!i.optional,includeSelf:a,animation:o,originalSelector:e.selector,options:Y(e.options)}}visitStagger(e,t){t.currentQuery||t.errors.push(hs());let s=e.timings==="full"?{duration:0,delay:0,easing:"full"}:_e(e.timings,t.errors,!0);return{type:S.Stagger,animation:O(this,ie(e.animation),t),timings:s,options:null}}};function js(n){let e=!!n.split(/\s*,\s*/).find(t=>t==$t);return e&&(n=n.replace(Us,"")),n=n.replace(/@\*/g,ye).replace(/@\w+/g,t=>ye+"-"+t.slice(1)).replace(/:animating/g,Ke),[n,e]}function Ws(n){return n?he({},n):null}var Ve=class{constructor(e){this.errors=e,this.queryCount=0,this.depCount=0,this.currentTransition=null,this.currentQuery=null,this.currentQuerySelector=null,this.currentAnimateTimings=null,this.currentTime=0,this.collectedStyles=new Map,this.options=null,this.unsupportedCSSPropertiesFound=new Set}};function Gs(n){if(typeof n=="string")return null;let e=null;if(Array.isArray(n))n.forEach(t=>{if(t instanceof Map&&t.has("offset")){let s=t;e=parseFloat(s.get("offset")),s.delete("offset")}});else if(n instanceof Map&&n.has("offset")){let t=n;e=parseFloat(t.get("offset")),t.delete("offset")}return e}function Hs(n,e){if(n.hasOwnProperty("duration"))return n;if(typeof n=="number"){let r=_e(n,e).duration;return De(r,0,"")}let t=n;if(t.split(/\s+/).some(r=>r.charAt(0)=="{"&&r.charAt(1)=="{")){let r=De(0,0,"");return r.dynamic=!0,r.strValue=t,r}let i=_e(t,e);return De(i.duration,i.delay,i.easing)}function Y(n){return n?(n=he({},n),n.params&&(n.params=Ws(n.params))):n={},n}function De(n,e,t){return{duration:n,delay:e,easing:t}}function lt(n,e,t,s,i,r,a=null,o=!1){return{type:1,element:n,keyframes:e,preStyleProps:t,postStyleProps:s,duration:i,delay:r,totalTime:i+r,easing:a,subTimeline:o}}var se=class{constructor(){this._map=new Map}get(e){return this._map.get(e)||[]}append(e,t){let s=this._map.get(e);s||this._map.set(e,s=[]),s.push(...t)}has(e){return this._map.has(e)}clear(){this._map.clear()}},Ys=1,Xs=":enter",Zs=new RegExp(Xs,"g"),Js=":leave",xs=new RegExp(Js,"g");function ht(n,e,t,s,i,r=new Map,a=new Map,o,l,h=[]){return new Ue().buildKeyframes(n,e,t,s,i,r,a,o,l,h)}var Ue=class{buildKeyframes(e,t,s,i,r,a,o,l,h,c=[]){h=h||new se;let u=new je(e,t,h,i,r,c,[]);u.options=l;let _=l.delay?$(l.delay):0;u.currentTimeline.delayNextStep(_),u.currentTimeline.setStyles([a],null,u.errors,l),O(this,s,u);let y=u.timelines.filter(d=>d.containsAnimation());if(y.length&&o.size){let d;for(let g=y.length-1;g>=0;g--){let v=y[g];if(v.element===t){d=v;break}}d&&!d.allowOnlyTimelineStyles()&&d.setStyles([o],null,u.errors,l)}return y.length?y.map(d=>d.buildKeyframes()):[lt(t,[],[],[],0,_,"",!1)]}visitTrigger(e,t){}visitState(e,t){}visitTransition(e,t){}visitAnimateChild(e,t){let s=t.subInstructions.get(t.element);if(s){let i=t.createSubContext(e.options),r=t.currentTimeline.currentTime,a=this._visitSubInstructions(s,i,i.options);r!=a&&t.transformIntoNewTimeline(a)}t.previousNode=e}visitAnimateRef(e,t){let s=t.createSubContext(e.options);s.transformIntoNewTimeline(),this._applyAnimationRefDelays([e.options,e.animation.options],t,s),this.visitReference(e.animation,s),t.transformIntoNewTimeline(s.currentTimeline.currentTime),t.previousNode=e}_applyAnimationRefDelays(e,t,s){for(let i of e){let r=i?.delay;if(r){let a=typeof r=="number"?r:$(re(r,i?.params??{},t.errors));s.delayNextStep(a)}}}_visitSubInstructions(e,t,s){let r=t.currentTimeline.currentTime,a=s.duration!=null?$(s.duration):null,o=s.delay!=null?$(s.delay):null;return a!==0&&e.forEach(l=>{let h=t.appendInstructionToTimeline(l,a,o);r=Math.max(r,h.duration+h.delay)}),r}visitReference(e,t){t.updateOptions(e.options,!0),O(this,e.animation,t),t.previousNode=e}visitSequence(e,t){let s=t.subContextCount,i=t,r=e.options;if(r&&(r.params||r.delay)&&(i=t.createSubContext(r),i.transformIntoNewTimeline(),r.delay!=null)){i.previousNode.type==S.Style&&(i.currentTimeline.snapshotCurrentStyles(),i.previousNode=Se);let a=$(r.delay);i.delayNextStep(a)}e.steps.length&&(e.steps.forEach(a=>O(this,a,i)),i.currentTimeline.applyStylesToKeyframe(),i.subContextCount>s&&i.transformIntoNewTimeline()),t.previousNode=e}visitGroup(e,t){let s=[],i=t.currentTimeline.currentTime,r=e.options&&e.options.delay?$(e.options.delay):0;e.steps.forEach(a=>{let o=t.createSubContext(e.options);r&&o.delayNextStep(r),O(this,a,o),i=Math.max(i,o.currentTimeline.currentTime),s.push(o.currentTimeline)}),s.forEach(a=>t.currentTimeline.mergeTimelineCollectedStyles(a)),t.transformIntoNewTimeline(i),t.previousNode=e}_visitTiming(e,t){if(e.dynamic){let s=e.strValue,i=t.params?re(s,t.params,t.errors):s;return _e(i,t.errors)}else return{duration:e.duration,delay:e.delay,easing:e.easing}}visitAnimate(e,t){let s=t.currentAnimateTimings=this._visitTiming(e.timings,t),i=t.currentTimeline;s.delay&&(t.incrementTime(s.delay),i.snapshotCurrentStyles());let r=e.style;r.type==S.Keyframes?this.visitKeyframes(r,t):(t.incrementTime(s.duration),this.visitStyle(r,t),i.applyStylesToKeyframe()),t.currentAnimateTimings=null,t.previousNode=e}visitStyle(e,t){let s=t.currentTimeline,i=t.currentAnimateTimings;!i&&s.hasCurrentStyleProperties()&&s.forwardFrame();let r=i&&i.easing||e.easing;e.isEmptyStep?s.applyEmptyStep(r):s.setStyles(e.styles,r,t.errors,t.options),t.previousNode=e}visitKeyframes(e,t){let s=t.currentAnimateTimings,i=t.currentTimeline.duration,r=s.duration,o=t.createSubContext().currentTimeline;o.easing=s.easing,e.styles.forEach(l=>{let h=l.offset||0;o.forwardTime(h*r),o.setStyles(l.styles,l.easing,t.errors,t.options),o.applyStylesToKeyframe()}),t.currentTimeline.mergeTimelineCollectedStyles(o),t.transformIntoNewTimeline(i+r),t.previousNode=e}visitQuery(e,t){let s=t.currentTimeline.currentTime,i=e.options||{},r=i.delay?$(i.delay):0;r&&(t.previousNode.type===S.Style||s==0&&t.currentTimeline.hasCurrentStyleProperties())&&(t.currentTimeline.snapshotCurrentStyles(),t.previousNode=Se);let a=s,o=t.invokeQuery(e.selector,e.originalSelector,e.limit,e.includeSelf,!!i.optional,t.errors);t.currentQueryTotal=o.length;let l=null;o.forEach((h,c)=>{t.currentQueryIndex=c;let u=t.createSubContext(e.options,h);r&&u.delayNextStep(r),h===t.element&&(l=u.currentTimeline),O(this,e.animation,u),u.currentTimeline.applyStylesToKeyframe();let _=u.currentTimeline.currentTime;a=Math.max(a,_)}),t.currentQueryIndex=0,t.currentQueryTotal=0,t.transformIntoNewTimeline(a),l&&(t.currentTimeline.mergeTimelineCollectedStyles(l),t.currentTimeline.snapshotCurrentStyles()),t.previousNode=e}visitStagger(e,t){let s=t.parentContext,i=t.currentTimeline,r=e.timings,a=Math.abs(r.duration),o=a*(t.currentQueryTotal-1),l=a*t.currentQueryIndex;switch(r.duration<0?"reverse":r.easing){case"reverse":l=o-l;break;case"full":l=s.currentStaggerTime;break}let c=t.currentTimeline;l&&c.delayNextStep(l);let u=c.currentTime;O(this,e.animation,t),t.previousNode=e,s.currentStaggerTime=i.currentTime-u+(i.startTime-s.currentTimeline.startTime)}},Se={},je=class n{constructor(e,t,s,i,r,a,o,l){this._driver=e,this.element=t,this.subInstructions=s,this._enterClassName=i,this._leaveClassName=r,this.errors=a,this.timelines=o,this.parentContext=null,this.currentAnimateTimings=null,this.previousNode=Se,this.subContextCount=0,this.options={},this.currentQueryIndex=0,this.currentQueryTotal=0,this.currentStaggerTime=0,this.currentTimeline=l||new Te(this._driver,t,0),o.push(this.currentTimeline)}get params(){return this.options.params}updateOptions(e,t){if(!e)return;let s=e,i=this.options;s.duration!=null&&(i.duration=$(s.duration)),s.delay!=null&&(i.delay=$(s.delay));let r=s.params;if(r){let a=i.params;a||(a=this.options.params={}),Object.keys(r).forEach(o=>{(!t||!a.hasOwnProperty(o))&&(a[o]=re(r[o],a,this.errors))})}}_copyOptions(){let e={};if(this.options){let t=this.options.params;if(t){let s=e.params={};Object.keys(t).forEach(i=>{s[i]=t[i]})}}return e}createSubContext(e=null,t,s){let i=t||this.element,r=new n(this._driver,i,this.subInstructions,this._enterClassName,this._leaveClassName,this.errors,this.timelines,this.currentTimeline.fork(i,s||0));return r.previousNode=this.previousNode,r.currentAnimateTimings=this.currentAnimateTimings,r.options=this._copyOptions(),r.updateOptions(e),r.currentQueryIndex=this.currentQueryIndex,r.currentQueryTotal=this.currentQueryTotal,r.parentContext=this,this.subContextCount++,r}transformIntoNewTimeline(e){return this.previousNode=Se,this.currentTimeline=this.currentTimeline.fork(this.element,e),this.timelines.push(this.currentTimeline),this.currentTimeline}appendInstructionToTimeline(e,t,s){let i={duration:t??e.duration,delay:this.currentTimeline.currentTime+(s??0)+e.delay,easing:""},r=new We(this._driver,e.element,e.keyframes,e.preStyleProps,e.postStyleProps,i,e.stretchStartingKeyframe);return this.timelines.push(r),i}incrementTime(e){this.currentTimeline.forwardTime(this.currentTimeline.duration+e)}delayNextStep(e){e>0&&this.currentTimeline.delayNextStep(e)}invokeQuery(e,t,s,i,r,a){let o=[];if(i&&o.push(this.element),e.length>0){e=e.replace(Zs,"."+this._enterClassName),e=e.replace(xs,"."+this._leaveClassName);let l=s!=1,h=this._driver.query(this.element,e,l);s!==0&&(h=s<0?h.slice(h.length+s,h.length):h.slice(0,s)),o.push(...h)}return!r&&o.length==0&&a.push(us(t)),o}},Te=class n{constructor(e,t,s,i){this._driver=e,this.element=t,this.startTime=s,this._elementTimelineStylesLookup=i,this.duration=0,this.easing=null,this._previousKeyframe=new Map,this._currentKeyframe=new Map,this._keyframes=new Map,this._styleSummary=new Map,this._localTimelineStyles=new Map,this._pendingStyles=new Map,this._backFill=new Map,this._currentEmptyStepKeyframe=null,this._elementTimelineStylesLookup||(this._elementTimelineStylesLookup=new Map),this._globalTimelineStyles=this._elementTimelineStylesLookup.get(t),this._globalTimelineStyles||(this._globalTimelineStyles=this._localTimelineStyles,this._elementTimelineStylesLookup.set(t,this._localTimelineStyles)),this._loadKeyframe()}containsAnimation(){switch(this._keyframes.size){case 0:return!1;case 1:return this.hasCurrentStyleProperties();default:return!0}}hasCurrentStyleProperties(){return this._currentKeyframe.size>0}get currentTime(){return this.startTime+this.duration}delayNextStep(e){let t=this._keyframes.size===1&&this._pendingStyles.size;this.duration||t?(this.forwardTime(this.currentTime+e),t&&this.snapshotCurrentStyles()):this.startTime+=e}fork(e,t){return this.applyStylesToKeyframe(),new n(this._driver,e,t||this.currentTime,this._elementTimelineStylesLookup)}_loadKeyframe(){this._currentKeyframe&&(this._previousKeyframe=this._currentKeyframe),this._currentKeyframe=this._keyframes.get(this.duration),this._currentKeyframe||(this._currentKeyframe=new Map,this._keyframes.set(this.duration,this._currentKeyframe))}forwardFrame(){this.duration+=Ys,this._loadKeyframe()}forwardTime(e){this.applyStylesToKeyframe(),this.duration=e,this._loadKeyframe()}_updateStyle(e,t){this._localTimelineStyles.set(e,t),this._globalTimelineStyles.set(e,t),this._styleSummary.set(e,{time:this.currentTime,value:t})}allowOnlyTimelineStyles(){return this._currentEmptyStepKeyframe!==this._currentKeyframe}applyEmptyStep(e){e&&this._previousKeyframe.set("easing",e);for(let[t,s]of this._globalTimelineStyles)this._backFill.set(t,s||B),this._currentKeyframe.set(t,B);this._currentEmptyStepKeyframe=this._currentKeyframe}setStyles(e,t,s,i){t&&this._previousKeyframe.set("easing",t);let r=i&&i.params||{},a=ei(e,this._globalTimelineStyles);for(let[o,l]of a){let h=re(l,r,s);this._pendingStyles.set(o,h),this._localTimelineStyles.has(o)||this._backFill.set(o,this._globalTimelineStyles.get(o)??B),this._updateStyle(o,h)}}applyStylesToKeyframe(){this._pendingStyles.size!=0&&(this._pendingStyles.forEach((e,t)=>{this._currentKeyframe.set(t,e)}),this._pendingStyles.clear(),this._localTimelineStyles.forEach((e,t)=>{this._currentKeyframe.has(t)||this._currentKeyframe.set(t,e)}))}snapshotCurrentStyles(){for(let[e,t]of this._localTimelineStyles)this._pendingStyles.set(e,t),this._updateStyle(e,t)}getFinalKeyframe(){return this._keyframes.get(this.duration)}get properties(){let e=[];for(let t in this._currentKeyframe)e.push(t);return e}mergeTimelineCollectedStyles(e){e._styleSummary.forEach((t,s)=>{let i=this._styleSummary.get(s);(!i||t.time>i.time)&&this._updateStyle(s,t.value)})}buildKeyframes(){this.applyStylesToKeyframe();let e=new Set,t=new Set,s=this._keyframes.size===1&&this.duration===0,i=[];this._keyframes.forEach((o,l)=>{let h=new Map([...this._backFill,...o]);h.forEach((c,u)=>{c===ue?e.add(u):c===B&&t.add(u)}),s||h.set("offset",l/this.duration),i.push(h)});let r=[...e.values()],a=[...t.values()];if(s){let o=i[0],l=new Map(o);o.set("offset",0),l.set("offset",1),i=[o,l]}return lt(this.element,i,r,a,this.duration,this.startTime,this.easing,!1)}},We=class extends Te{constructor(e,t,s,i,r,a,o=!1){super(e,t,a.delay),this.keyframes=s,this.preStyleProps=i,this.postStyleProps=r,this._stretchStartingKeyframe=o,this.timings={duration:a.duration,delay:a.delay,easing:a.easing}}containsAnimation(){return this.keyframes.length>1}buildKeyframes(){let e=this.keyframes,{delay:t,duration:s,easing:i}=this.timings;if(this._stretchStartingKeyframe&&t){let r=[],a=s+t,o=t/a,l=new Map(e[0]);l.set("offset",0),r.push(l);let h=new Map(e[0]);h.set("offset",Pt(o)),r.push(h);let c=e.length-1;for(let u=1;u<=c;u++){let _=new Map(e[u]),y=_.get("offset"),d=t+y*s;_.set("offset",Pt(d/a)),r.push(_)}s=a,t=0,i="",e=r}return lt(this.element,e,this.preStyleProps,this.postStyleProps,s,t,i,!0)}};function Pt(n,e=3){let t=Math.pow(10,e-1);return Math.round(n*t)/t}function ei(n,e){let t=new Map,s;return n.forEach(i=>{if(i==="*"){s??=e.keys();for(let r of s)t.set(r,B)}else for(let[r,a]of i)t.set(r,a)}),t}function Nt(n,e,t,s,i,r,a,o,l,h,c,u,_){return{type:0,element:n,triggerName:e,isRemovalTransition:i,fromState:t,fromStyles:r,toState:s,toStyles:a,timelines:o,queriedElements:l,preStyleProps:h,postStyleProps:c,totalTime:u,errors:_}}var Re={},ve=class{constructor(e,t,s){this._triggerName=e,this.ast=t,this._stateStyles=s}match(e,t,s,i){return ti(this.ast.matchers,e,t,s,i)}buildStyles(e,t,s){let i=this._stateStyles.get("*");return e!==void 0&&(i=this._stateStyles.get(e?.toString())||i),i?i.buildStyles(t,s):new Map}build(e,t,s,i,r,a,o,l,h,c){let u=[],_=this.ast.options&&this.ast.options.params||Re,y=o&&o.params||Re,d=this.buildStyles(s,y,u),g=l&&l.params||Re,v=this.buildStyles(i,g,u),b=new Set,A=new Map,C=new Map,N=i==="void",Z={params:Vt(g,_),delay:this.ast.options?.delay},K=c?[]:ht(e,t,this.ast.animation,r,a,d,v,Z,h,u),k=0;return K.forEach(D=>{k=Math.max(D.duration+D.delay,k)}),u.length?Nt(t,this._triggerName,s,i,N,d,v,[],[],A,C,k,u):(K.forEach(D=>{let j=D.element,J=L(A,j,new Set);D.preStyleProps.forEach(W=>J.add(W));let ct=L(C,j,new Set);D.postStyleProps.forEach(W=>ct.add(W)),j!==t&&b.add(j)}),Nt(t,this._triggerName,s,i,N,d,v,K,[...b.values()],A,C,k))}};function ti(n,e,t,s,i){return n.some(r=>r(e,t,s,i))}function Vt(n,e){let t=he({},e);return Object.entries(n).forEach(([s,i])=>{i!=null&&(t[s]=i)}),t}var Ge=class{constructor(e,t,s){this.styles=e,this.defaultParams=t,this.normalizer=s}buildStyles(e,t){let s=new Map,i=Vt(e,this.defaultParams);return this.styles.styles.forEach(r=>{typeof r!="string"&&r.forEach((a,o)=>{a&&(a=re(a,i,t));let l=this.normalizer.normalizePropertyName(o,t);a=this.normalizer.normalizeStyleValue(o,l,a,t),s.set(o,a)})}),s}};function si(n,e,t){return new He(n,e,t)}var He=class{constructor(e,t,s){this.name=e,this.ast=t,this._normalizer=s,this.transitionFactories=[],this.states=new Map,t.states.forEach(i=>{let r=i.options&&i.options.params||{};this.states.set(i.name,new Ge(i.style,r,s))}),Mt(this.states,"true","1"),Mt(this.states,"false","0"),t.transitions.forEach(i=>{this.transitionFactories.push(new ve(e,i,this.states))}),this.fallbackTransition=ii(e,this.states,this._normalizer)}get containsQueries(){return this.ast.queryCount>0}matchTransition(e,t,s,i){return this.transitionFactories.find(a=>a.match(e,t,s,i))||null}matchStyles(e,t,s){return this.fallbackTransition.buildStyles(e,t,s)}};function ii(n,e,t){let s=[(a,o)=>!0],i={type:S.Sequence,steps:[],options:null},r={type:S.Transition,animation:i,matchers:s,options:null,queryCount:0,depCount:0};return new ve(n,r,e)}function Mt(n,e,t){n.has(e)?n.has(t)||n.set(t,n.get(e)):n.has(t)&&n.set(e,n.get(t))}var ni=new se,Ye=class{constructor(e,t,s){this.bodyNode=e,this._driver=t,this._normalizer=s,this._animations=new Map,this._playersById=new Map,this.players=[]}register(e,t){let s=[],i=[],r=ot(this._driver,t,s,i);if(s.length)throw ys(s);i.length&&void 0,this._animations.set(e,r)}_buildPlayer(e,t,s){let i=e.element,r=It(this._normalizer,e.keyframes,t,s);return this._driver.animate(i,r,e.duration,e.delay,e.easing,[],!0)}create(e,t,s={}){let i=[],r=this._animations.get(e),a,o=new Map;if(r?(a=ht(this._driver,t,r,nt,ge,new Map,new Map,s,ni,i),a.forEach(c=>{let u=L(o,c.element,new Map);c.postStyleProps.forEach(_=>u.set(_,null))})):(i.push(_s()),a=[]),i.length)throw Es(i);o.forEach((c,u)=>{c.forEach((_,y)=>{c.set(y,this._driver.computeStyle(u,y,B))})});let l=a.map(c=>{let u=o.get(c.element);return this._buildPlayer(c,new Map,u)}),h=U(l);return this._playersById.set(e,h),h.onDestroy(()=>this.destroy(e)),this.players.push(h),h}destroy(e){let t=this._getPlayer(e);t.destroy(),this._playersById.delete(e);let s=this.players.indexOf(t);s>=0&&this.players.splice(s,1)}_getPlayer(e){let t=this._playersById.get(e);if(!t)throw Ss(e);return t}listen(e,t,s,i){let r=st(t,"","","");return tt(this._getPlayer(e),s,r,i),()=>{}}command(e,t,s,i){if(s=="register"){this.register(e,i[0]);return}if(s=="create"){let a=i[0]||{};this.create(e,t,a);return}let r=this._getPlayer(e);switch(s){case"play":r.play();break;case"pause":r.pause();break;case"reset":r.reset();break;case"restart":r.restart();break;case"finish":r.finish();break;case"init":r.init();break;case"setPosition":r.setPosition(parseFloat(i[0]));break;case"destroy":this.destroy(e);break}}},Ct="ng-animate-queued",ri=".ng-animate-queued",Oe="ng-animate-disabled",ai=".ng-animate-disabled",oi="ng-star-inserted",li=".ng-star-inserted",hi=[],Ut={namespaceId:"",setForRemoval:!1,setForMove:!1,hasAnimation:!1,removedBeforeQueried:!1},ui={namespaceId:"",setForMove:!1,setForRemoval:!1,hasAnimation:!1,removedBeforeQueried:!0},z="__ng_removed",ae=class{get params(){return this.options.params}constructor(e,t=""){this.namespaceId=t;let s=e&&e.hasOwnProperty("value"),i=s?e.value:e;if(this.value=fi(i),s){let r=e,{value:a}=r,o=pt(r,["value"]);this.options=o}else this.options={};this.options.params||(this.options.params={})}absorbOptions(e){let t=e.params;if(t){let s=this.options.params;Object.keys(t).forEach(i=>{s[i]==null&&(s[i]=t[i])})}}},ne="void",Le=new ae(ne),Xe=class{constructor(e,t,s){this.id=e,this.hostElement=t,this._engine=s,this.players=[],this._triggers=new Map,this._queue=[],this._elementListeners=new Map,this._hostClassName="ng-tns-"+e,I(t,this._hostClassName)}listen(e,t,s,i){if(!this._triggers.has(t))throw Ts(s,t);if(s==null||s.length==0)throw vs(t);if(!di(s))throw ws(s,t);let r=L(this._elementListeners,e,[]),a={name:t,phase:s,callback:i};r.push(a);let o=L(this._engine.statesByElement,e,new Map);return o.has(t)||(I(e,ce),I(e,ce+"-"+t),o.set(t,Le)),()=>{this._engine.afterFlush(()=>{let l=r.indexOf(a);l>=0&&r.splice(l,1),this._triggers.has(t)||o.delete(t)})}}register(e,t){return this._triggers.has(e)?!1:(this._triggers.set(e,t),!0)}_getTrigger(e){let t=this._triggers.get(e);if(!t)throw bs(e);return t}trigger(e,t,s,i=!0){let r=this._getTrigger(t),a=new oe(this.id,t,e),o=this._engine.statesByElement.get(e);o||(I(e,ce),I(e,ce+"-"+t),this._engine.statesByElement.set(e,o=new Map));let l=o.get(t),h=new ae(s,this.id);if(!(s&&s.hasOwnProperty("value"))&&l&&h.absorbOptions(l.options),o.set(t,h),l||(l=Le),!(h.value===ne)&&l.value===h.value){if(!gi(l.params,h.params)){let g=[],v=r.matchStyles(l.value,l.params,g),b=r.matchStyles(h.value,h.params,g);g.length?this._engine.reportError(g):this._engine.afterFlush(()=>{X(e,v),Q(e,b)})}return}let _=L(this._engine.playersByElement,e,[]);_.forEach(g=>{g.namespaceId==this.id&&g.triggerName==t&&g.queued&&g.destroy()});let y=r.matchTransition(l.value,h.value,e,h.params),d=!1;if(!y){if(!i)return;y=r.fallbackTransition,d=!0}return this._engine.totalQueuedPlayers++,this._queue.push({element:e,triggerName:t,transition:y,fromState:l,toState:h,player:a,isFallbackTransition:d}),d||(I(e,Ct),a.onStart(()=>{ee(e,Ct)})),a.onDone(()=>{let g=this.players.indexOf(a);g>=0&&this.players.splice(g,1);let v=this._engine.playersByElement.get(e);if(v){let b=v.indexOf(a);b>=0&&v.splice(b,1)}}),this.players.push(a),_.push(a),a}deregister(e){this._triggers.delete(e),this._engine.statesByElement.forEach(t=>t.delete(e)),this._elementListeners.forEach((t,s)=>{this._elementListeners.set(s,t.filter(i=>i.name!=e))})}clearElementCache(e){this._engine.statesByElement.delete(e),this._elementListeners.delete(e);let t=this._engine.playersByElement.get(e);t&&(t.forEach(s=>s.destroy()),this._engine.playersByElement.delete(e))}_signalRemovalForInnerTriggers(e,t){let s=this._engine.driver.query(e,ye,!0);s.forEach(i=>{if(i[z])return;let r=this._engine.fetchNamespacesByElement(i);r.size?r.forEach(a=>a.triggerLeaveAnimation(i,t,!1,!0)):this.clearElementCache(i)}),this._engine.afterFlushAnimationsDone(()=>s.forEach(i=>this.clearElementCache(i)))}triggerLeaveAnimation(e,t,s,i){let r=this._engine.statesByElement.get(e),a=new Map;if(r){let o=[];if(r.forEach((l,h)=>{if(a.set(h,l.value),this._triggers.has(h)){let c=this.trigger(e,h,ne,i);c&&o.push(c)}}),o.length)return this._engine.markElementAsRemoved(this.id,e,!0,t,a),s&&U(o).onDone(()=>this._engine.processLeaveNode(e)),!0}return!1}prepareLeaveAnimationListeners(e){let t=this._elementListeners.get(e),s=this._engine.statesByElement.get(e);if(t&&s){let i=new Set;t.forEach(r=>{let a=r.name;if(i.has(a))return;i.add(a);let l=this._triggers.get(a).fallbackTransition,h=s.get(a)||Le,c=new ae(ne),u=new oe(this.id,a,e);this._engine.totalQueuedPlayers++,this._queue.push({element:e,triggerName:a,transition:l,fromState:h,toState:c,player:u,isFallbackTransition:!0})})}}removeNode(e,t){let s=this._engine;if(e.childElementCount&&this._signalRemovalForInnerTriggers(e,t),this.triggerLeaveAnimation(e,t,!0))return;let i=!1;if(s.totalAnimations){let r=s.players.length?s.playersByQueriedElement.get(e):[];if(r&&r.length)i=!0;else{let a=e;for(;a=a.parentNode;)if(s.statesByElement.get(a)){i=!0;break}}}if(this.prepareLeaveAnimationListeners(e),i)s.markElementAsRemoved(this.id,e,!1,t);else{let r=e[z];(!r||r===Ut)&&(s.afterFlush(()=>this.clearElementCache(e)),s.destroyInnerAnimations(e),s._onRemovalComplete(e,t))}}insertNode(e,t){I(e,this._hostClassName)}drainQueuedTransitions(e){let t=[];return this._queue.forEach(s=>{let i=s.player;if(i.destroyed)return;let r=s.element,a=this._elementListeners.get(r);a&&a.forEach(o=>{if(o.name==s.triggerName){let l=st(r,s.triggerName,s.fromState.value,s.toState.value);l._data=e,tt(s.player,o.phase,l,o.callback)}}),i.markedForDestroy?this._engine.afterFlush(()=>{i.destroy()}):t.push(s)}),this._queue=[],t.sort((s,i)=>{let r=s.transition.ast.depCount,a=i.transition.ast.depCount;return r==0||a==0?r-a:this._engine.driver.containsElement(s.element,i.element)?1:-1})}destroy(e){this.players.forEach(t=>t.destroy()),this._signalRemovalForInnerTriggers(this.hostElement,e)}},Ze=class{_onRemovalComplete(e,t){this.onRemovalComplete(e,t)}constructor(e,t,s,i){this.bodyNode=e,this.driver=t,this._normalizer=s,this.scheduler=i,this.players=[],this.newHostElements=new Map,this.playersByElement=new Map,this.playersByQueriedElement=new Map,this.statesByElement=new Map,this.disabledNodes=new Set,this.totalAnimations=0,this.totalQueuedPlayers=0,this._namespaceLookup={},this._namespaceList=[],this._flushFns=[],this._whenQuietFns=[],this.namespacesByHostElement=new Map,this.collectedEnterElements=[],this.collectedLeaveElements=[],this.onRemovalComplete=(r,a)=>{}}get queuedPlayers(){let e=[];return this._namespaceList.forEach(t=>{t.players.forEach(s=>{s.queued&&e.push(s)})}),e}createNamespace(e,t){let s=new Xe(e,t,this);return this.bodyNode&&this.driver.containsElement(this.bodyNode,t)?this._balanceNamespaceList(s,t):(this.newHostElements.set(t,s),this.collectEnterElement(t)),this._namespaceLookup[e]=s}_balanceNamespaceList(e,t){let s=this._namespaceList,i=this.namespacesByHostElement;if(s.length-1>=0){let a=!1,o=this.driver.getParentElement(t);for(;o;){let l=i.get(o);if(l){let h=s.indexOf(l);s.splice(h+1,0,e),a=!0;break}o=this.driver.getParentElement(o)}a||s.unshift(e)}else s.push(e);return i.set(t,e),e}register(e,t){let s=this._namespaceLookup[e];return s||(s=this.createNamespace(e,t)),s}registerTrigger(e,t,s){let i=this._namespaceLookup[e];i&&i.register(t,s)&&this.totalAnimations++}destroy(e,t){e&&(this.afterFlush(()=>{}),this.afterFlushAnimationsDone(()=>{let s=this._fetchNamespace(e);this.namespacesByHostElement.delete(s.hostElement);let i=this._namespaceList.indexOf(s);i>=0&&this._namespaceList.splice(i,1),s.destroy(t),delete this._namespaceLookup[e]}))}_fetchNamespace(e){return this._namespaceLookup[e]}fetchNamespacesByElement(e){let t=new Set,s=this.statesByElement.get(e);if(s){for(let i of s.values())if(i.namespaceId){let r=this._fetchNamespace(i.namespaceId);r&&t.add(r)}}return t}trigger(e,t,s,i){if(me(t)){let r=this._fetchNamespace(e);if(r)return r.trigger(t,s,i),!0}return!1}insertNode(e,t,s,i){if(!me(t))return;let r=t[z];if(r&&r.setForRemoval){r.setForRemoval=!1,r.setForMove=!0;let a=this.collectedLeaveElements.indexOf(t);a>=0&&this.collectedLeaveElements.splice(a,1)}if(e){let a=this._fetchNamespace(e);a&&a.insertNode(t,s)}i&&this.collectEnterElement(t)}collectEnterElement(e){this.collectedEnterElements.push(e)}markElementAsDisabled(e,t){t?this.disabledNodes.has(e)||(this.disabledNodes.add(e),I(e,Oe)):this.disabledNodes.has(e)&&(this.disabledNodes.delete(e),ee(e,Oe))}removeNode(e,t,s){if(me(t)){this.scheduler?.notify();let i=e?this._fetchNamespace(e):null;i?i.removeNode(t,s):this.markElementAsRemoved(e,t,!1,s);let r=this.namespacesByHostElement.get(t);r&&r.id!==e&&r.removeNode(t,s)}else this._onRemovalComplete(t,s)}markElementAsRemoved(e,t,s,i,r){this.collectedLeaveElements.push(t),t[z]={namespaceId:e,setForRemoval:i,hasAnimation:s,removedBeforeQueried:!1,previousTriggersValues:r}}listen(e,t,s,i,r){return me(t)?this._fetchNamespace(e).listen(t,s,i,r):()=>{}}_buildInstruction(e,t,s,i,r){return e.transition.build(this.driver,e.element,e.fromState.value,e.toState.value,s,i,e.fromState.options,e.toState.options,t,r)}destroyInnerAnimations(e){let t=this.driver.query(e,ye,!0);t.forEach(s=>this.destroyActiveAnimationsForElement(s)),this.playersByQueriedElement.size!=0&&(t=this.driver.query(e,Ke,!0),t.forEach(s=>this.finishActiveQueriedAnimationOnElement(s)))}destroyActiveAnimationsForElement(e){let t=this.playersByElement.get(e);t&&t.forEach(s=>{s.queued?s.markedForDestroy=!0:s.destroy()})}finishActiveQueriedAnimationOnElement(e){let t=this.playersByQueriedElement.get(e);t&&t.forEach(s=>s.finish())}whenRenderingDone(){return new Promise(e=>{if(this.players.length)return U(this.players).onDone(()=>e());e()})}processLeaveNode(e){let t=e[z];if(t&&t.setForRemoval){if(e[z]=Ut,t.namespaceId){this.destroyInnerAnimations(e);let s=this._fetchNamespace(t.namespaceId);s&&s.clearElementCache(e)}this._onRemovalComplete(e,t.setForRemoval)}e.classList?.contains(Oe)&&this.markElementAsDisabled(e,!1),this.driver.query(e,ai,!0).forEach(s=>{this.markElementAsDisabled(s,!1)})}flush(e=-1){let t=[];if(this.newHostElements.size&&(this.newHostElements.forEach((s,i)=>this._balanceNamespaceList(s,i)),this.newHostElements.clear()),this.totalAnimations&&this.collectedEnterElements.length)for(let s=0;s<this.collectedEnterElements.length;s++){let i=this.collectedEnterElements[s];I(i,oi)}if(this._namespaceList.length&&(this.totalQueuedPlayers||this.collectedLeaveElements.length)){let s=[];try{t=this._flushAnimations(s,e)}finally{for(let i=0;i<s.length;i++)s[i]()}}else for(let s=0;s<this.collectedLeaveElements.length;s++){let i=this.collectedLeaveElements[s];this.processLeaveNode(i)}if(this.totalQueuedPlayers=0,this.collectedEnterElements.length=0,this.collectedLeaveElements.length=0,this._flushFns.forEach(s=>s()),this._flushFns=[],this._whenQuietFns.length){let s=this._whenQuietFns;this._whenQuietFns=[],t.length?U(t).onDone(()=>{s.forEach(i=>i())}):s.forEach(i=>i())}}reportError(e){throw As(e)}_flushAnimations(e,t){let s=new se,i=[],r=new Map,a=[],o=new Map,l=new Map,h=new Map,c=new Set;this.disabledNodes.forEach(f=>{c.add(f);let m=this.driver.query(f,ri,!0);for(let p=0;p<m.length;p++)c.add(m[p])});let u=this.bodyNode,_=Array.from(this.statesByElement.keys()),y=Rt(_,this.collectedEnterElements),d=new Map,g=0;y.forEach((f,m)=>{let p=nt+g++;d.set(m,p),f.forEach(T=>I(T,p))});let v=[],b=new Set,A=new Set;for(let f=0;f<this.collectedLeaveElements.length;f++){let m=this.collectedLeaveElements[f],p=m[z];p&&p.setForRemoval&&(v.push(m),b.add(m),p.hasAnimation?this.driver.query(m,li,!0).forEach(T=>b.add(T)):A.add(m))}let C=new Map,N=Rt(_,Array.from(b));N.forEach((f,m)=>{let p=ge+g++;C.set(m,p),f.forEach(T=>I(T,p))}),e.push(()=>{y.forEach((f,m)=>{let p=d.get(m);f.forEach(T=>ee(T,p))}),N.forEach((f,m)=>{let p=C.get(m);f.forEach(T=>ee(T,p))}),v.forEach(f=>{this.processLeaveNode(f)})});let Z=[],K=[];for(let f=this._namespaceList.length-1;f>=0;f--)this._namespaceList[f].drainQueuedTransitions(t).forEach(p=>{let T=p.player,P=p.element;if(Z.push(T),this.collectedEnterElements.length){let M=P[z];if(M&&M.setForMove){if(M.previousTriggersValues&&M.previousTriggersValues.has(p.triggerName)){let G=M.previousTriggersValues.get(p.triggerName),F=this.statesByElement.get(p.element);if(F&&F.has(p.triggerName)){let le=F.get(p.triggerName);le.value=G,F.set(p.triggerName,le)}}T.destroy();return}}let q=!u||!this.driver.containsElement(u,P),R=C.get(P),V=d.get(P),w=this._buildInstruction(p,s,V,R,q);if(w.errors&&w.errors.length){K.push(w);return}if(q){T.onStart(()=>X(P,w.fromStyles)),T.onDestroy(()=>Q(P,w.toStyles)),i.push(T);return}if(p.isFallbackTransition){T.onStart(()=>X(P,w.fromStyles)),T.onDestroy(()=>Q(P,w.toStyles)),i.push(T);return}let mt=[];w.timelines.forEach(M=>{M.stretchStartingKeyframe=!0,this.disabledNodes.has(M.element)||mt.push(M)}),w.timelines=mt,s.append(P,w.timelines);let Gt={instruction:w,player:T,element:P};a.push(Gt),w.queriedElements.forEach(M=>L(o,M,[]).push(T)),w.preStyleProps.forEach((M,G)=>{if(M.size){let F=l.get(G);F||l.set(G,F=new Set),M.forEach((le,Ne)=>F.add(Ne))}}),w.postStyleProps.forEach((M,G)=>{let F=h.get(G);F||h.set(G,F=new Set),M.forEach((le,Ne)=>F.add(Ne))})});if(K.length){let f=[];K.forEach(m=>{f.push(Ps(m.triggerName,m.errors))}),Z.forEach(m=>m.destroy()),this.reportError(f)}let k=new Map,D=new Map;a.forEach(f=>{let m=f.element;s.has(m)&&(D.set(m,m),this._beforeAnimationBuild(f.player.namespaceId,f.instruction,k))}),i.forEach(f=>{let m=f.element;this._getPreviousPlayers(m,!1,f.namespaceId,f.triggerName,null).forEach(T=>{L(k,m,[]).push(T),T.destroy()})});let j=v.filter(f=>Ot(f,l,h)),J=new Map;Dt(J,this.driver,A,h,B).forEach(f=>{Ot(f,l,h)&&j.push(f)});let W=new Map;y.forEach((f,m)=>{Dt(W,this.driver,new Set(f),l,ue)}),j.forEach(f=>{let m=J.get(f),p=W.get(f);J.set(f,new Map([...m?.entries()??[],...p?.entries()??[]]))});let Pe=[],ft=[],dt={};a.forEach(f=>{let{element:m,player:p,instruction:T}=f;if(s.has(m)){if(c.has(m)){p.onDestroy(()=>Q(m,T.toStyles)),p.disabled=!0,p.overrideTotalTime(T.totalTime),i.push(p);return}let P=dt;if(D.size>1){let R=m,V=[];for(;R=R.parentNode;){let w=D.get(R);if(w){P=w;break}V.push(R)}V.forEach(w=>D.set(w,P))}let q=this._buildAnimation(p.namespaceId,T,k,r,W,J);if(p.setRealPlayer(q),P===dt)Pe.push(p);else{let R=this.playersByElement.get(P);R&&R.length&&(p.parentPlayer=U(R)),i.push(p)}}else X(m,T.fromStyles),p.onDestroy(()=>Q(m,T.toStyles)),ft.push(p),c.has(m)&&i.push(p)}),ft.forEach(f=>{let m=r.get(f.element);if(m&&m.length){let p=U(m);f.setRealPlayer(p)}}),i.forEach(f=>{f.parentPlayer?f.syncPlayerEvents(f.parentPlayer):f.destroy()});for(let f=0;f<v.length;f++){let m=v[f],p=m[z];if(ee(m,ge),p&&p.hasAnimation)continue;let T=[];if(o.size){let q=o.get(m);q&&q.length&&T.push(...q);let R=this.driver.query(m,Ke,!0);for(let V=0;V<R.length;V++){let w=o.get(R[V]);w&&w.length&&T.push(...w)}}let P=T.filter(q=>!q.destroyed);P.length?mi(this,m,P):this.processLeaveNode(m)}return v.length=0,Pe.forEach(f=>{this.players.push(f),f.onDone(()=>{f.destroy();let m=this.players.indexOf(f);this.players.splice(m,1)}),f.play()}),Pe}afterFlush(e){this._flushFns.push(e)}afterFlushAnimationsDone(e){this._whenQuietFns.push(e)}_getPreviousPlayers(e,t,s,i,r){let a=[];if(t){let o=this.playersByQueriedElement.get(e);o&&(a=o)}else{let o=this.playersByElement.get(e);if(o){let l=!r||r==ne;o.forEach(h=>{h.queued||!l&&h.triggerName!=i||a.push(h)})}}return(s||i)&&(a=a.filter(o=>!(s&&s!=o.namespaceId||i&&i!=o.triggerName))),a}_beforeAnimationBuild(e,t,s){let i=t.triggerName,r=t.element,a=t.isRemovalTransition?void 0:e,o=t.isRemovalTransition?void 0:i;for(let l of t.timelines){let h=l.element,c=h!==r,u=L(s,h,[]);this._getPreviousPlayers(h,c,a,o,t.toState).forEach(y=>{let d=y.getRealPlayer();d.beforeDestroy&&d.beforeDestroy(),y.destroy(),u.push(y)})}X(r,t.fromStyles)}_buildAnimation(e,t,s,i,r,a){let o=t.triggerName,l=t.element,h=[],c=new Set,u=new Set,_=t.timelines.map(d=>{let g=d.element;c.add(g);let v=g[z];if(v&&v.removedBeforeQueried)return new x(d.duration,d.delay);let b=g!==l,A=pi((s.get(g)||hi).map(k=>k.getRealPlayer())).filter(k=>{let D=k;return D.element?D.element===g:!1}),C=r.get(g),N=a.get(g),Z=It(this._normalizer,d.keyframes,C,N),K=this._buildPlayer(d,Z,A);if(d.subTimeline&&i&&u.add(g),b){let k=new oe(e,o,g);k.setRealPlayer(K),h.push(k)}return K});h.forEach(d=>{L(this.playersByQueriedElement,d.element,[]).push(d),d.onDone(()=>ci(this.playersByQueriedElement,d.element,d))}),c.forEach(d=>I(d,vt));let y=U(_);return y.onDestroy(()=>{c.forEach(d=>ee(d,vt)),Q(l,t.toStyles)}),u.forEach(d=>{L(i,d,[]).push(y)}),y}_buildPlayer(e,t,s){return t.length>0?this.driver.animate(e.element,t,e.duration,e.delay,e.easing,s):new x(e.duration,e.delay)}},oe=class{constructor(e,t,s){this.namespaceId=e,this.triggerName=t,this.element=s,this._player=new x,this._containsRealPlayer=!1,this._queuedCallbacks=new Map,this.destroyed=!1,this.parentPlayer=null,this.markedForDestroy=!1,this.disabled=!1,this.queued=!0,this.totalTime=0}setRealPlayer(e){this._containsRealPlayer||(this._player=e,this._queuedCallbacks.forEach((t,s)=>{t.forEach(i=>tt(e,s,void 0,i))}),this._queuedCallbacks.clear(),this._containsRealPlayer=!0,this.overrideTotalTime(e.totalTime),this.queued=!1)}getRealPlayer(){return this._player}overrideTotalTime(e){this.totalTime=e}syncPlayerEvents(e){let t=this._player;t.triggerCallback&&e.onStart(()=>t.triggerCallback("start")),e.onDone(()=>this.finish()),e.onDestroy(()=>this.destroy())}_queueEvent(e,t){L(this._queuedCallbacks,e,[]).push(t)}onDone(e){this.queued&&this._queueEvent("done",e),this._player.onDone(e)}onStart(e){this.queued&&this._queueEvent("start",e),this._player.onStart(e)}onDestroy(e){this.queued&&this._queueEvent("destroy",e),this._player.onDestroy(e)}init(){this._player.init()}hasStarted(){return this.queued?!1:this._player.hasStarted()}play(){!this.queued&&this._player.play()}pause(){!this.queued&&this._player.pause()}restart(){!this.queued&&this._player.restart()}finish(){this._player.finish()}destroy(){this.destroyed=!0,this._player.destroy()}reset(){!this.queued&&this._player.reset()}setPosition(e){this.queued||this._player.setPosition(e)}getPosition(){return this.queued?0:this._player.getPosition()}triggerCallback(e){let t=this._player;t.triggerCallback&&t.triggerCallback(e)}};function ci(n,e,t){let s=n.get(e);if(s){if(s.length){let i=s.indexOf(t);s.splice(i,1)}s.length==0&&n.delete(e)}return s}function fi(n){return n??null}function me(n){return n&&n.nodeType===1}function di(n){return n=="start"||n=="done"}function kt(n,e){let t=n.style.display;return n.style.display=e??"none",t}function Dt(n,e,t,s,i){let r=[];t.forEach(l=>r.push(kt(l)));let a=[];s.forEach((l,h)=>{let c=new Map;l.forEach(u=>{let _=e.computeStyle(h,u,i);c.set(u,_),(!_||_.length==0)&&(h[z]=ui,a.push(h))}),n.set(h,c)});let o=0;return t.forEach(l=>kt(l,r[o++])),a}function Rt(n,e){let t=new Map;if(n.forEach(o=>t.set(o,[])),e.length==0)return t;let s=1,i=new Set(e),r=new Map;function a(o){if(!o)return s;let l=r.get(o);if(l)return l;let h=o.parentNode;return t.has(h)?l=h:i.has(h)?l=s:l=a(h),r.set(o,l),l}return e.forEach(o=>{let l=a(o);l!==s&&t.get(l).push(o)}),t}function I(n,e){n.classList?.add(e)}function ee(n,e){n.classList?.remove(e)}function mi(n,e,t){U(t).onDone(()=>n.processLeaveNode(e))}function pi(n){let e=[];return jt(n,e),e}function jt(n,e){for(let t=0;t<n.length;t++){let s=n[t];s instanceof Ce?jt(s.players,e):e.push(s)}}function gi(n,e){let t=Object.keys(n),s=Object.keys(e);if(t.length!=s.length)return!1;for(let i=0;i<t.length;i++){let r=t[i];if(!e.hasOwnProperty(r)||n[r]!==e[r])return!1}return!0}function Ot(n,e,t){let s=t.get(n);if(!s)return!1;let i=e.get(n);return i?s.forEach(r=>i.add(r)):e.set(n,s),t.delete(n),!0}var we=class{constructor(e,t,s,i){this._driver=t,this._normalizer=s,this._triggerCache={},this.onRemovalComplete=(r,a)=>{},this._transitionEngine=new Ze(e.body,t,s,i),this._timelineEngine=new Ye(e.body,t,s),this._transitionEngine.onRemovalComplete=(r,a)=>this.onRemovalComplete(r,a)}registerTrigger(e,t,s,i,r){let a=e+"-"+i,o=this._triggerCache[a];if(!o){let l=[],h=[],c=ot(this._driver,r,l,h);if(l.length)throw ps(i,l);h.length&&void 0,o=si(i,c,this._normalizer),this._triggerCache[a]=o}this._transitionEngine.registerTrigger(t,i,o)}register(e,t){this._transitionEngine.register(e,t)}destroy(e,t){this._transitionEngine.destroy(e,t)}onInsert(e,t,s,i){this._transitionEngine.insertNode(e,t,s,i)}onRemove(e,t,s){this._transitionEngine.removeNode(e,t,s)}disableAnimations(e,t){this._transitionEngine.markElementAsDisabled(e,t)}process(e,t,s,i){if(s.charAt(0)=="@"){let[r,a]=Et(s),o=i;this._timelineEngine.command(r,t,a,o)}else this._transitionEngine.trigger(e,t,s,i)}listen(e,t,s,i,r){if(s.charAt(0)=="@"){let[a,o]=Et(s);return this._timelineEngine.listen(a,t,o,r)}return this._transitionEngine.listen(e,t,s,i,r)}flush(e=-1){this._transitionEngine.flush(e)}get players(){return[...this._transitionEngine.players,...this._timelineEngine.players]}whenRenderingDone(){return this._transitionEngine.whenRenderingDone()}afterFlushAnimationsDone(e){this._transitionEngine.afterFlushAnimationsDone(e)}};function yi(n,e){let t=null,s=null;return Array.isArray(e)&&e.length?(t=Fe(e[0]),e.length>1&&(s=Fe(e[e.length-1]))):e instanceof Map&&(t=Fe(e)),t||s?new Je(n,t,s):null}var te=class te{constructor(e,t,s){this._element=e,this._startStyles=t,this._endStyles=s,this._state=0;let i=te.initialStylesByElement.get(e);i||te.initialStylesByElement.set(e,i=new Map),this._initialStyles=i}start(){this._state<1&&(this._startStyles&&Q(this._element,this._startStyles,this._initialStyles),this._state=1)}finish(){this.start(),this._state<2&&(Q(this._element,this._initialStyles),this._endStyles&&(Q(this._element,this._endStyles),this._endStyles=null),this._state=1)}destroy(){this.finish(),this._state<3&&(te.initialStylesByElement.delete(this._element),this._startStyles&&(X(this._element,this._startStyles),this._endStyles=null),this._endStyles&&(X(this._element,this._endStyles),this._endStyles=null),Q(this._element,this._initialStyles),this._state=3)}};te.initialStylesByElement=new WeakMap;var Je=te;function Fe(n){let e=null;return n.forEach((t,s)=>{_i(s)&&(e=e||new Map,e.set(s,t))}),e}function _i(n){return n==="display"||n==="position"}var be=class{constructor(e,t,s,i){this.element=e,this.keyframes=t,this.options=s,this._specialStyles=i,this._onDoneFns=[],this._onStartFns=[],this._onDestroyFns=[],this._initialized=!1,this._finished=!1,this._started=!1,this._destroyed=!1,this._originalOnDoneFns=[],this._originalOnStartFns=[],this.time=0,this.parentPlayer=null,this.currentSnapshot=new Map,this._duration=s.duration,this._delay=s.delay||0,this.time=this._duration+this._delay}_onFinish(){this._finished||(this._finished=!0,this._onDoneFns.forEach(e=>e()),this._onDoneFns=[])}init(){this._buildPlayer(),this._preparePlayerBeforeStart()}_buildPlayer(){if(this._initialized)return;this._initialized=!0;let e=this.keyframes;this.domPlayer=this._triggerWebAnimation(this.element,e,this.options),this._finalKeyframe=e.length?e[e.length-1]:new Map;let t=()=>this._onFinish();this.domPlayer.addEventListener("finish",t),this.onDestroy(()=>{this.domPlayer.removeEventListener("finish",t)})}_preparePlayerBeforeStart(){this._delay?this._resetDomPlayerState():this.domPlayer.pause()}_convertKeyframesToObject(e){let t=[];return e.forEach(s=>{t.push(Object.fromEntries(s))}),t}_triggerWebAnimation(e,t,s){return e.animate(this._convertKeyframesToObject(t),s)}onStart(e){this._originalOnStartFns.push(e),this._onStartFns.push(e)}onDone(e){this._originalOnDoneFns.push(e),this._onDoneFns.push(e)}onDestroy(e){this._onDestroyFns.push(e)}play(){this._buildPlayer(),this.hasStarted()||(this._onStartFns.forEach(e=>e()),this._onStartFns=[],this._started=!0,this._specialStyles&&this._specialStyles.start()),this.domPlayer.play()}pause(){this.init(),this.domPlayer.pause()}finish(){this.init(),this._specialStyles&&this._specialStyles.finish(),this._onFinish(),this.domPlayer.finish()}reset(){this._resetDomPlayerState(),this._destroyed=!1,this._finished=!1,this._started=!1,this._onStartFns=this._originalOnStartFns,this._onDoneFns=this._originalOnDoneFns}_resetDomPlayerState(){this.domPlayer&&this.domPlayer.cancel()}restart(){this.reset(),this.play()}hasStarted(){return this._started}destroy(){this._destroyed||(this._destroyed=!0,this._resetDomPlayerState(),this._onFinish(),this._specialStyles&&this._specialStyles.destroy(),this._onDestroyFns.forEach(e=>e()),this._onDestroyFns=[])}setPosition(e){this.domPlayer===void 0&&this.init(),this.domPlayer.currentTime=e*this.time}getPosition(){return+(this.domPlayer.currentTime??0)/this.time}get totalTime(){return this._delay+this._duration}beforeDestroy(){let e=new Map;this.hasStarted()&&this._finalKeyframe.forEach((s,i)=>{i!=="offset"&&e.set(i,this._finished?s:at(this.element,i))}),this.currentSnapshot=e}triggerCallback(e){let t=e==="start"?this._onStartFns:this._onDoneFns;t.forEach(s=>s()),t.length=0}},xe=class{validateStyleProperty(e){return!0}validateAnimatableStyleProperty(e){return!0}matchesElement(e,t){return!1}containsElement(e,t){return zt(e,t)}getParentElement(e){return it(e)}query(e,t,s){return Kt(e,t,s)}computeStyle(e,t,s){return at(e,t)}animate(e,t,s,i,r,a=[]){let o=i==0?"both":"forwards",l={duration:s,delay:i,fill:o};r&&(l.easing=r);let h=new Map,c=a.filter(y=>y instanceof be);Ks(s,i)&&c.forEach(y=>{y.currentSnapshot.forEach((d,g)=>h.set(g,d))});let u=Fs(t).map(y=>new Map(y));u=qs(e,u,h);let _=yi(e,u);return new be(e,u,l,_)}};function Ni(n,e,t){return n==="noop"?new we(e,new qt,new ze,t):new we(e,new xe,new Qe,t)}var Lt=class{constructor(e,t){this._driver=e;let s=[],i=[],r=ot(e,t,s,i);if(s.length)throw ds(s);i.length&&void 0,this._animationAst=r}buildTimelines(e,t,s,i,r){let a=Array.isArray(t)?wt(t):t,o=Array.isArray(s)?wt(s):s,l=[];r=r||new se;let h=ht(this._driver,e,this._animationAst,nt,ge,a,o,i,r,l);if(l.length)throw ms(l);return h}},pe="@",Wt="@.disabled",Ae=class{constructor(e,t,s,i){this.namespaceId=e,this.delegate=t,this.engine=s,this._onDestroy=i,this.\u0275type=0}get data(){return this.delegate.data}destroyNode(e){this.delegate.destroyNode?.(e)}destroy(){this.engine.destroy(this.namespaceId,this.delegate),this.engine.afterFlushAnimationsDone(()=>{queueMicrotask(()=>{this.delegate.destroy()})}),this._onDestroy?.()}createElement(e,t){return this.delegate.createElement(e,t)}createComment(e){return this.delegate.createComment(e)}createText(e){return this.delegate.createText(e)}appendChild(e,t){this.delegate.appendChild(e,t),this.engine.onInsert(this.namespaceId,t,e,!1)}insertBefore(e,t,s,i=!0){this.delegate.insertBefore(e,t,s),this.engine.onInsert(this.namespaceId,t,e,i)}removeChild(e,t,s){this.engine.onRemove(this.namespaceId,t,this.delegate)}selectRootElement(e,t){return this.delegate.selectRootElement(e,t)}parentNode(e){return this.delegate.parentNode(e)}nextSibling(e){return this.delegate.nextSibling(e)}setAttribute(e,t,s,i){this.delegate.setAttribute(e,t,s,i)}removeAttribute(e,t,s){this.delegate.removeAttribute(e,t,s)}addClass(e,t){this.delegate.addClass(e,t)}removeClass(e,t){this.delegate.removeClass(e,t)}setStyle(e,t,s,i){this.delegate.setStyle(e,t,s,i)}removeStyle(e,t,s){this.delegate.removeStyle(e,t,s)}setProperty(e,t,s){t.charAt(0)==pe&&t==Wt?this.disableAnimations(e,!!s):this.delegate.setProperty(e,t,s)}setValue(e,t){this.delegate.setValue(e,t)}listen(e,t,s){return this.delegate.listen(e,t,s)}disableAnimations(e,t){this.engine.disableAnimations(e,t)}},et=class extends Ae{constructor(e,t,s,i,r){super(t,s,i,r),this.factory=e,this.namespaceId=t}setProperty(e,t,s){t.charAt(0)==pe?t.charAt(1)=="."&&t==Wt?(s=s===void 0?!0:!!s,this.disableAnimations(e,s)):this.engine.process(this.namespaceId,e,t.slice(1),s):this.delegate.setProperty(e,t,s)}listen(e,t,s){if(t.charAt(0)==pe){let i=Ei(e),r=t.slice(1),a="";return r.charAt(0)!=pe&&([r,a]=Si(r)),this.engine.listen(this.namespaceId,i,r,a,o=>{let l=o._data||-1;this.factory.scheduleListenerCallback(l,s,o)})}return this.delegate.listen(e,t,s)}};function Ei(n){switch(n){case"body":return document.body;case"document":return document;case"window":return window;default:return n}}function Si(n){let e=n.indexOf("."),t=n.substring(0,e),s=n.slice(e+1);return[t,s]}var Ft=class{constructor(e,t,s){this.delegate=e,this.engine=t,this._zone=s,this._currentId=0,this._microtaskId=1,this._animationCallbacksBuffer=[],this._rendererCache=new Map,this._cdRecurDepth=0,t.onRemovalComplete=(i,r)=>{let a=r?.parentNode(i);a&&r.removeChild(a,i)}}createRenderer(e,t){let s="",i=this.delegate.createRenderer(e,t);if(!e||!t?.data?.animation){let h=this._rendererCache,c=h.get(i);if(!c){let u=()=>h.delete(i);c=new Ae(s,i,this.engine,u),h.set(i,c)}return c}let r=t.id,a=t.id+"-"+this._currentId;this._currentId++,this.engine.register(a,e);let o=h=>{Array.isArray(h)?h.forEach(o):this.engine.registerTrigger(r,a,e,h.name,h)};return t.data.animation.forEach(o),new et(this,a,i,this.engine)}begin(){this._cdRecurDepth++,this.delegate.begin&&this.delegate.begin()}_scheduleCountTask(){queueMicrotask(()=>{this._microtaskId++})}scheduleListenerCallback(e,t,s){if(e>=0&&e<this._microtaskId){this._zone.run(()=>t(s));return}let i=this._animationCallbacksBuffer;i.length==0&&queueMicrotask(()=>{this._zone.run(()=>{i.forEach(r=>{let[a,o]=r;a(o)}),this._animationCallbacksBuffer=[]})}),i.push([t,s])}end(){this._cdRecurDepth--,this._cdRecurDepth==0&&this._zone.runOutsideAngular(()=>{this._scheduleCountTask(),this.engine.flush(this._microtaskId)}),this.delegate.end&&this.delegate.end()}whenRenderingDone(){return this.engine.whenRenderingDone()}};export{Tt as AnimationDriver,qt as NoopAnimationDriver,Lt as \u0275Animation,we as \u0275AnimationEngine,et as \u0275AnimationRenderer,Ft as \u0275AnimationRendererFactory,Ie as \u0275AnimationStyleNormalizer,Ae as \u0275BaseAnimationRenderer,ze as \u0275NoopAnimationStyleNormalizer,xe as \u0275WebAnimationsDriver,be as \u0275WebAnimationsPlayer,Qe as \u0275WebAnimationsStyleNormalizer,Ks as \u0275allowPreviousPlayerStylesMerge,Pi as \u0275camelCaseToDashCase,zt as \u0275containsElement,Ni as \u0275createEngine,it as \u0275getParentElement,Kt as \u0275invokeQuery,Fs as \u0275normalizeKeyframes,ks as \u0275validateStyleProperty,Ai as \u0275validateWebAnimatableStyleProperty};
+import {
+    Ac as B,
+    Dc as yt,
+    Ec as Me,
+    Hc as x,
+    Ic as Ce,
+    Jc as ue,
+    W as E,
+    Z as gt,
+    a as he,
+    c as pt,
+    zc as S,
+} from "./chunk-LPDIY7FO.js";
+function _t(n) {
+    return new E(3e3, !1);
+}
+function Ht() {
+    return new E(3100, !1);
+}
+function Yt() {
+    return new E(3101, !1);
+}
+function Xt(n) {
+    return new E(3001, !1);
+}
+function Zt(n) {
+    return new E(3003, !1);
+}
+function Jt(n) {
+    return new E(3004, !1);
+}
+function xt(n, e) {
+    return new E(3005, !1);
+}
+function es() {
+    return new E(3006, !1);
+}
+function ts() {
+    return new E(3007, !1);
+}
+function ss(n, e) {
+    return new E(3008, !1);
+}
+function is(n) {
+    return new E(3002, !1);
+}
+function ns(n, e, t, s, i) {
+    return new E(3010, !1);
+}
+function rs() {
+    return new E(3011, !1);
+}
+function as() {
+    return new E(3012, !1);
+}
+function os() {
+    return new E(3200, !1);
+}
+function ls() {
+    return new E(3202, !1);
+}
+function hs() {
+    return new E(3013, !1);
+}
+function us(n) {
+    return new E(3014, !1);
+}
+function cs(n) {
+    return new E(3015, !1);
+}
+function fs(n) {
+    return new E(3016, !1);
+}
+function ds(n) {
+    return new E(3500, !1);
+}
+function ms(n) {
+    return new E(3501, !1);
+}
+function ps(n, e) {
+    return new E(3404, !1);
+}
+function gs(n) {
+    return new E(3502, !1);
+}
+function ys(n) {
+    return new E(3503, !1);
+}
+function _s() {
+    return new E(3300, !1);
+}
+function Es(n) {
+    return new E(3504, !1);
+}
+function Ss(n) {
+    return new E(3301, !1);
+}
+function Ts(n, e) {
+    return new E(3302, !1);
+}
+function vs(n) {
+    return new E(3303, !1);
+}
+function ws(n, e) {
+    return new E(3400, !1);
+}
+function bs(n) {
+    return new E(3401, !1);
+}
+function As(n) {
+    return new E(3402, !1);
+}
+function Ps(n, e) {
+    return new E(3505, !1);
+}
+var Ns = new Set([
+    "-moz-outline-radius",
+    "-moz-outline-radius-bottomleft",
+    "-moz-outline-radius-bottomright",
+    "-moz-outline-radius-topleft",
+    "-moz-outline-radius-topright",
+    "-ms-grid-columns",
+    "-ms-grid-rows",
+    "-webkit-line-clamp",
+    "-webkit-text-fill-color",
+    "-webkit-text-stroke",
+    "-webkit-text-stroke-color",
+    "accent-color",
+    "all",
+    "backdrop-filter",
+    "background",
+    "background-color",
+    "background-position",
+    "background-size",
+    "block-size",
+    "border",
+    "border-block-end",
+    "border-block-end-color",
+    "border-block-end-width",
+    "border-block-start",
+    "border-block-start-color",
+    "border-block-start-width",
+    "border-bottom",
+    "border-bottom-color",
+    "border-bottom-left-radius",
+    "border-bottom-right-radius",
+    "border-bottom-width",
+    "border-color",
+    "border-end-end-radius",
+    "border-end-start-radius",
+    "border-image-outset",
+    "border-image-slice",
+    "border-image-width",
+    "border-inline-end",
+    "border-inline-end-color",
+    "border-inline-end-width",
+    "border-inline-start",
+    "border-inline-start-color",
+    "border-inline-start-width",
+    "border-left",
+    "border-left-color",
+    "border-left-width",
+    "border-radius",
+    "border-right",
+    "border-right-color",
+    "border-right-width",
+    "border-start-end-radius",
+    "border-start-start-radius",
+    "border-top",
+    "border-top-color",
+    "border-top-left-radius",
+    "border-top-right-radius",
+    "border-top-width",
+    "border-width",
+    "bottom",
+    "box-shadow",
+    "caret-color",
+    "clip",
+    "clip-path",
+    "color",
+    "column-count",
+    "column-gap",
+    "column-rule",
+    "column-rule-color",
+    "column-rule-width",
+    "column-width",
+    "columns",
+    "filter",
+    "flex",
+    "flex-basis",
+    "flex-grow",
+    "flex-shrink",
+    "font",
+    "font-size",
+    "font-size-adjust",
+    "font-stretch",
+    "font-variation-settings",
+    "font-weight",
+    "gap",
+    "grid-column-gap",
+    "grid-gap",
+    "grid-row-gap",
+    "grid-template-columns",
+    "grid-template-rows",
+    "height",
+    "inline-size",
+    "input-security",
+    "inset",
+    "inset-block",
+    "inset-block-end",
+    "inset-block-start",
+    "inset-inline",
+    "inset-inline-end",
+    "inset-inline-start",
+    "left",
+    "letter-spacing",
+    "line-clamp",
+    "line-height",
+    "margin",
+    "margin-block-end",
+    "margin-block-start",
+    "margin-bottom",
+    "margin-inline-end",
+    "margin-inline-start",
+    "margin-left",
+    "margin-right",
+    "margin-top",
+    "mask",
+    "mask-border",
+    "mask-position",
+    "mask-size",
+    "max-block-size",
+    "max-height",
+    "max-inline-size",
+    "max-lines",
+    "max-width",
+    "min-block-size",
+    "min-height",
+    "min-inline-size",
+    "min-width",
+    "object-position",
+    "offset",
+    "offset-anchor",
+    "offset-distance",
+    "offset-path",
+    "offset-position",
+    "offset-rotate",
+    "opacity",
+    "order",
+    "outline",
+    "outline-color",
+    "outline-offset",
+    "outline-width",
+    "padding",
+    "padding-block-end",
+    "padding-block-start",
+    "padding-bottom",
+    "padding-inline-end",
+    "padding-inline-start",
+    "padding-left",
+    "padding-right",
+    "padding-top",
+    "perspective",
+    "perspective-origin",
+    "right",
+    "rotate",
+    "row-gap",
+    "scale",
+    "scroll-margin",
+    "scroll-margin-block",
+    "scroll-margin-block-end",
+    "scroll-margin-block-start",
+    "scroll-margin-bottom",
+    "scroll-margin-inline",
+    "scroll-margin-inline-end",
+    "scroll-margin-inline-start",
+    "scroll-margin-left",
+    "scroll-margin-right",
+    "scroll-margin-top",
+    "scroll-padding",
+    "scroll-padding-block",
+    "scroll-padding-block-end",
+    "scroll-padding-block-start",
+    "scroll-padding-bottom",
+    "scroll-padding-inline",
+    "scroll-padding-inline-end",
+    "scroll-padding-inline-start",
+    "scroll-padding-left",
+    "scroll-padding-right",
+    "scroll-padding-top",
+    "scroll-snap-coordinate",
+    "scroll-snap-destination",
+    "scrollbar-color",
+    "shape-image-threshold",
+    "shape-margin",
+    "shape-outside",
+    "tab-size",
+    "text-decoration",
+    "text-decoration-color",
+    "text-decoration-thickness",
+    "text-emphasis",
+    "text-emphasis-color",
+    "text-indent",
+    "text-shadow",
+    "text-underline-offset",
+    "top",
+    "transform",
+    "transform-origin",
+    "translate",
+    "vertical-align",
+    "visibility",
+    "width",
+    "word-spacing",
+    "z-index",
+    "zoom",
+]);
+function U(n) {
+    switch (n.length) {
+        case 0:
+            return new x();
+        case 1:
+            return n[0];
+        default:
+            return new Ce(n);
+    }
+}
+function It(n, e, t = new Map(), s = new Map()) {
+    let i = [],
+        r = [],
+        a = -1,
+        o = null;
+    if (
+        (e.forEach((l) => {
+            let h = l.get("offset"),
+                c = h == a,
+                u = (c && o) || new Map();
+            l.forEach((_, y) => {
+                let d = y,
+                    g = _;
+                if (y !== "offset")
+                    switch (((d = n.normalizePropertyName(d, i)), g)) {
+                        case ue:
+                            g = t.get(y);
+                            break;
+                        case B:
+                            g = s.get(y);
+                            break;
+                        default:
+                            g = n.normalizeStyleValue(y, d, g, i);
+                            break;
+                    }
+                u.set(d, g);
+            }),
+                c || r.push(u),
+                (o = u),
+                (a = h);
+        }),
+        i.length)
+    )
+        throw gs(i);
+    return r;
+}
+function tt(n, e, t, s) {
+    switch (e) {
+        case "start":
+            n.onStart(() => s(t && ke(t, "start", n)));
+            break;
+        case "done":
+            n.onDone(() => s(t && ke(t, "done", n)));
+            break;
+        case "destroy":
+            n.onDestroy(() => s(t && ke(t, "destroy", n)));
+            break;
+    }
+}
+function ke(n, e, t) {
+    let s = t.totalTime,
+        i = !!t.disabled,
+        r = st(
+            n.element,
+            n.triggerName,
+            n.fromState,
+            n.toState,
+            e || n.phaseName,
+            s ?? n.totalTime,
+            i
+        ),
+        a = n._data;
+    return a != null && (r._data = a), r;
+}
+function st(n, e, t, s, i = "", r = 0, a) {
+    return {
+        element: n,
+        triggerName: e,
+        fromState: t,
+        toState: s,
+        phaseName: i,
+        totalTime: r,
+        disabled: !!a,
+    };
+}
+function L(n, e, t) {
+    let s = n.get(e);
+    return s || n.set(e, (s = t)), s;
+}
+function Et(n) {
+    let e = n.indexOf(":"),
+        t = n.substring(1, e),
+        s = n.slice(e + 1);
+    return [t, s];
+}
+var Ms = typeof document > "u" ? null : document.documentElement;
+function it(n) {
+    let e = n.parentNode || n.host || null;
+    return e === Ms ? null : e;
+}
+function Cs(n) {
+    return n.substring(1, 6) == "ebkit";
+}
+var H = null,
+    St = !1;
+function ks(n) {
+    H ||
+        ((H = Ds() || {}), (St = H.style ? "WebkitAppearance" in H.style : !1));
+    let e = !0;
+    return (
+        H.style &&
+            !Cs(n) &&
+            ((e = n in H.style),
+            !e &&
+                St &&
+                (e =
+                    "Webkit" + n.charAt(0).toUpperCase() + n.slice(1) in
+                    H.style)),
+        e
+    );
+}
+function Ai(n) {
+    return Ns.has(n);
+}
+function Ds() {
+    return typeof document < "u" ? document.body : null;
+}
+function zt(n, e) {
+    for (; e; ) {
+        if (e === n) return !0;
+        e = it(e);
+    }
+    return !1;
+}
+function Kt(n, e, t) {
+    if (t) return Array.from(n.querySelectorAll(e));
+    let s = n.querySelector(e);
+    return s ? [s] : [];
+}
+var qt = (() => {
+        let e = class e {
+            validateStyleProperty(s) {
+                return ks(s);
+            }
+            matchesElement(s, i) {
+                return !1;
+            }
+            containsElement(s, i) {
+                return zt(s, i);
+            }
+            getParentElement(s) {
+                return it(s);
+            }
+            query(s, i, r) {
+                return Kt(s, i, r);
+            }
+            computeStyle(s, i, r) {
+                return r || "";
+            }
+            animate(s, i, r, a, o, l = [], h) {
+                return new x(r, a);
+            }
+        };
+        (e.ɵfac = function (i) {
+            return new (i || e)();
+        }),
+            (e.ɵprov = gt({ token: e, factory: e.ɵfac }));
+        let n = e;
+        return n;
+    })(),
+    ut = class ut {};
+ut.NOOP = new qt();
+var Tt = ut,
+    Ie = class {},
+    ze = class {
+        normalizePropertyName(e, t) {
+            return e;
+        }
+        normalizeStyleValue(e, t, s, i) {
+            return s;
+        }
+    },
+    Rs = 1e3,
+    Bt = "{{",
+    Os = "}}",
+    nt = "ng-enter",
+    ge = "ng-leave",
+    ce = "ng-trigger",
+    ye = ".ng-trigger",
+    vt = "ng-animating",
+    Ke = ".ng-animating";
+function $(n) {
+    if (typeof n == "number") return n;
+    let e = n.match(/^(-?[\.\d]+)(m?s)/);
+    return !e || e.length < 2 ? 0 : qe(parseFloat(e[1]), e[2]);
+}
+function qe(n, e) {
+    switch (e) {
+        case "s":
+            return n * Rs;
+        default:
+            return n;
+    }
+}
+function _e(n, e, t) {
+    return n.hasOwnProperty("duration") ? n : Ls(n, e, t);
+}
+function Ls(n, e, t) {
+    let s =
+            /^(-?[\.\d]+)(m?s)(?:\s+(-?[\.\d]+)(m?s))?(?:\s+([-a-z]+(?:\(.+?\))?))?$/i,
+        i,
+        r = 0,
+        a = "";
+    if (typeof n == "string") {
+        let o = n.match(s);
+        if (o === null)
+            return e.push(_t(n)), { duration: 0, delay: 0, easing: "" };
+        i = qe(parseFloat(o[1]), o[2]);
+        let l = o[3];
+        l != null && (r = qe(parseFloat(l), o[4]));
+        let h = o[5];
+        h && (a = h);
+    } else i = n;
+    if (!t) {
+        let o = !1,
+            l = e.length;
+        i < 0 && (e.push(Ht()), (o = !0)),
+            r < 0 && (e.push(Yt()), (o = !0)),
+            o && e.splice(l, 0, _t(n));
+    }
+    return { duration: i, delay: r, easing: a };
+}
+function Fs(n) {
+    return n.length
+        ? n[0] instanceof Map
+            ? n
+            : n.map((e) => new Map(Object.entries(e)))
+        : [];
+}
+function wt(n) {
+    return Array.isArray(n) ? new Map(...n) : new Map(n);
+}
+function Q(n, e, t) {
+    e.forEach((s, i) => {
+        let r = rt(i);
+        t && !t.has(i) && t.set(i, n.style[r]), (n.style[r] = s);
+    });
+}
+function X(n, e) {
+    e.forEach((t, s) => {
+        let i = rt(s);
+        n.style[i] = "";
+    });
+}
+function ie(n) {
+    return Array.isArray(n) ? (n.length == 1 ? n[0] : yt(n)) : n;
+}
+function Is(n, e, t) {
+    let s = e.params || {},
+        i = Qt(n);
+    i.length &&
+        i.forEach((r) => {
+            s.hasOwnProperty(r) || t.push(Xt(r));
+        });
+}
+var Be = new RegExp(`${Bt}\\s*(.+?)\\s*${Os}`, "g");
+function Qt(n) {
+    let e = [];
+    if (typeof n == "string") {
+        let t;
+        for (; (t = Be.exec(n)); ) e.push(t[1]);
+        Be.lastIndex = 0;
+    }
+    return e;
+}
+function re(n, e, t) {
+    let s = `${n}`,
+        i = s.replace(Be, (r, a) => {
+            let o = e[a];
+            return o == null && (t.push(Zt(a)), (o = "")), o.toString();
+        });
+    return i == s ? n : i;
+}
+var zs = /-+([a-z0-9])/g;
+function rt(n) {
+    return n.replace(zs, (...e) => e[1].toUpperCase());
+}
+function Pi(n) {
+    return n.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+}
+function Ks(n, e) {
+    return n === 0 || e === 0;
+}
+function qs(n, e, t) {
+    if (t.size && e.length) {
+        let s = e[0],
+            i = [];
+        if (
+            (t.forEach((r, a) => {
+                s.has(a) || i.push(a), s.set(a, r);
+            }),
+            i.length)
+        )
+            for (let r = 1; r < e.length; r++) {
+                let a = e[r];
+                i.forEach((o) => a.set(o, at(n, o)));
+            }
+    }
+    return e;
+}
+function O(n, e, t) {
+    switch (e.type) {
+        case S.Trigger:
+            return n.visitTrigger(e, t);
+        case S.State:
+            return n.visitState(e, t);
+        case S.Transition:
+            return n.visitTransition(e, t);
+        case S.Sequence:
+            return n.visitSequence(e, t);
+        case S.Group:
+            return n.visitGroup(e, t);
+        case S.Animate:
+            return n.visitAnimate(e, t);
+        case S.Keyframes:
+            return n.visitKeyframes(e, t);
+        case S.Style:
+            return n.visitStyle(e, t);
+        case S.Reference:
+            return n.visitReference(e, t);
+        case S.AnimateChild:
+            return n.visitAnimateChild(e, t);
+        case S.AnimateRef:
+            return n.visitAnimateRef(e, t);
+        case S.Query:
+            return n.visitQuery(e, t);
+        case S.Stagger:
+            return n.visitStagger(e, t);
+        default:
+            throw Jt(e.type);
+    }
+}
+function at(n, e) {
+    return window.getComputedStyle(n)[e];
+}
+var Bs = new Set([
+        "width",
+        "height",
+        "minWidth",
+        "minHeight",
+        "maxWidth",
+        "maxHeight",
+        "left",
+        "top",
+        "bottom",
+        "right",
+        "fontSize",
+        "outlineWidth",
+        "outlineOffset",
+        "paddingTop",
+        "paddingLeft",
+        "paddingBottom",
+        "paddingRight",
+        "marginTop",
+        "marginLeft",
+        "marginBottom",
+        "marginRight",
+        "borderRadius",
+        "borderWidth",
+        "borderTopWidth",
+        "borderLeftWidth",
+        "borderRightWidth",
+        "borderBottomWidth",
+        "textIndent",
+        "perspective",
+    ]),
+    Qe = class extends Ie {
+        normalizePropertyName(e, t) {
+            return rt(e);
+        }
+        normalizeStyleValue(e, t, s, i) {
+            let r = "",
+                a = s.toString().trim();
+            if (Bs.has(t) && s !== 0 && s !== "0")
+                if (typeof s == "number") r = "px";
+                else {
+                    let o = s.match(/^[+-]?[\d\.]+([a-z]*)$/);
+                    o && o[1].length == 0 && i.push(xt(e, s));
+                }
+            return a + r;
+        }
+    };
+var Ee = "*";
+function Qs(n, e) {
+    let t = [];
+    return (
+        typeof n == "string"
+            ? n.split(/\s*,\s*/).forEach((s) => $s(s, t, e))
+            : t.push(n),
+        t
+    );
+}
+function $s(n, e, t) {
+    if (n[0] == ":") {
+        let l = Vs(n, t);
+        if (typeof l == "function") {
+            e.push(l);
+            return;
+        }
+        n = l;
+    }
+    let s = n.match(/^(\*|[-\w]+)\s*(<?[=-]>)\s*(\*|[-\w]+)$/);
+    if (s == null || s.length < 4) return t.push(cs(n)), e;
+    let i = s[1],
+        r = s[2],
+        a = s[3];
+    e.push(bt(i, a));
+    let o = i == Ee && a == Ee;
+    r[0] == "<" && !o && e.push(bt(a, i));
+}
+function Vs(n, e) {
+    switch (n) {
+        case ":enter":
+            return "void => *";
+        case ":leave":
+            return "* => void";
+        case ":increment":
+            return (t, s) => parseFloat(s) > parseFloat(t);
+        case ":decrement":
+            return (t, s) => parseFloat(s) < parseFloat(t);
+        default:
+            return e.push(fs(n)), "* => *";
+    }
+}
+var fe = new Set(["true", "1"]),
+    de = new Set(["false", "0"]);
+function bt(n, e) {
+    let t = fe.has(n) || de.has(n),
+        s = fe.has(e) || de.has(e);
+    return (i, r) => {
+        let a = n == Ee || n == i,
+            o = e == Ee || e == r;
+        return (
+            !a && t && typeof i == "boolean" && (a = i ? fe.has(n) : de.has(n)),
+            !o && s && typeof r == "boolean" && (o = r ? fe.has(e) : de.has(e)),
+            a && o
+        );
+    };
+}
+var $t = ":self",
+    Us = new RegExp(`s*${$t}s*,?`, "g");
+function ot(n, e, t, s) {
+    return new $e(n).build(e, t, s);
+}
+var At = "",
+    $e = class {
+        constructor(e) {
+            this._driver = e;
+        }
+        build(e, t, s) {
+            let i = new Ve(t);
+            return this._resetContextStyleTimingState(i), O(this, ie(e), i);
+        }
+        _resetContextStyleTimingState(e) {
+            (e.currentQuerySelector = At),
+                (e.collectedStyles = new Map()),
+                e.collectedStyles.set(At, new Map()),
+                (e.currentTime = 0);
+        }
+        visitTrigger(e, t) {
+            let s = (t.queryCount = 0),
+                i = (t.depCount = 0),
+                r = [],
+                a = [];
+            return (
+                e.name.charAt(0) == "@" && t.errors.push(es()),
+                e.definitions.forEach((o) => {
+                    if (
+                        (this._resetContextStyleTimingState(t),
+                        o.type == S.State)
+                    ) {
+                        let l = o,
+                            h = l.name;
+                        h
+                            .toString()
+                            .split(/\s*,\s*/)
+                            .forEach((c) => {
+                                (l.name = c), r.push(this.visitState(l, t));
+                            }),
+                            (l.name = h);
+                    } else if (o.type == S.Transition) {
+                        let l = this.visitTransition(o, t);
+                        (s += l.queryCount), (i += l.depCount), a.push(l);
+                    } else t.errors.push(ts());
+                }),
+                {
+                    type: S.Trigger,
+                    name: e.name,
+                    states: r,
+                    transitions: a,
+                    queryCount: s,
+                    depCount: i,
+                    options: null,
+                }
+            );
+        }
+        visitState(e, t) {
+            let s = this.visitStyle(e.styles, t),
+                i = (e.options && e.options.params) || null;
+            if (s.containsDynamicStyles) {
+                let r = new Set(),
+                    a = i || {};
+                s.styles.forEach((o) => {
+                    o instanceof Map &&
+                        o.forEach((l) => {
+                            Qt(l).forEach((h) => {
+                                a.hasOwnProperty(h) || r.add(h);
+                            });
+                        });
+                }),
+                    r.size && t.errors.push(ss(e.name, [...r.values()]));
+            }
+            return {
+                type: S.State,
+                name: e.name,
+                style: s,
+                options: i ? { params: i } : null,
+            };
+        }
+        visitTransition(e, t) {
+            (t.queryCount = 0), (t.depCount = 0);
+            let s = O(this, ie(e.animation), t),
+                i = Qs(e.expr, t.errors);
+            return {
+                type: S.Transition,
+                matchers: i,
+                animation: s,
+                queryCount: t.queryCount,
+                depCount: t.depCount,
+                options: Y(e.options),
+            };
+        }
+        visitSequence(e, t) {
+            return {
+                type: S.Sequence,
+                steps: e.steps.map((s) => O(this, s, t)),
+                options: Y(e.options),
+            };
+        }
+        visitGroup(e, t) {
+            let s = t.currentTime,
+                i = 0,
+                r = e.steps.map((a) => {
+                    t.currentTime = s;
+                    let o = O(this, a, t);
+                    return (i = Math.max(i, t.currentTime)), o;
+                });
+            return (
+                (t.currentTime = i),
+                { type: S.Group, steps: r, options: Y(e.options) }
+            );
+        }
+        visitAnimate(e, t) {
+            let s = Hs(e.timings, t.errors);
+            t.currentAnimateTimings = s;
+            let i,
+                r = e.styles ? e.styles : Me({});
+            if (r.type == S.Keyframes) i = this.visitKeyframes(r, t);
+            else {
+                let a = e.styles,
+                    o = !1;
+                if (!a) {
+                    o = !0;
+                    let h = {};
+                    s.easing && (h.easing = s.easing), (a = Me(h));
+                }
+                t.currentTime += s.duration + s.delay;
+                let l = this.visitStyle(a, t);
+                (l.isEmptyStep = o), (i = l);
+            }
+            return (
+                (t.currentAnimateTimings = null),
+                { type: S.Animate, timings: s, style: i, options: null }
+            );
+        }
+        visitStyle(e, t) {
+            let s = this._makeStyleAst(e, t);
+            return this._validateStyleAst(s, t), s;
+        }
+        _makeStyleAst(e, t) {
+            let s = [],
+                i = Array.isArray(e.styles) ? e.styles : [e.styles];
+            for (let o of i)
+                typeof o == "string"
+                    ? o === B
+                        ? s.push(o)
+                        : t.errors.push(is(o))
+                    : s.push(new Map(Object.entries(o)));
+            let r = !1,
+                a = null;
+            return (
+                s.forEach((o) => {
+                    if (
+                        o instanceof Map &&
+                        (o.has("easing") &&
+                            ((a = o.get("easing")), o.delete("easing")),
+                        !r)
+                    ) {
+                        for (let l of o.values())
+                            if (l.toString().indexOf(Bt) >= 0) {
+                                r = !0;
+                                break;
+                            }
+                    }
+                }),
+                {
+                    type: S.Style,
+                    styles: s,
+                    easing: a,
+                    offset: e.offset,
+                    containsDynamicStyles: r,
+                    options: null,
+                }
+            );
+        }
+        _validateStyleAst(e, t) {
+            let s = t.currentAnimateTimings,
+                i = t.currentTime,
+                r = t.currentTime;
+            s && r > 0 && (r -= s.duration + s.delay),
+                e.styles.forEach((a) => {
+                    typeof a != "string" &&
+                        a.forEach((o, l) => {
+                            let h = t.collectedStyles.get(
+                                    t.currentQuerySelector
+                                ),
+                                c = h.get(l),
+                                u = !0;
+                            c &&
+                                (r != i &&
+                                    r >= c.startTime &&
+                                    i <= c.endTime &&
+                                    (t.errors.push(
+                                        ns(l, c.startTime, c.endTime, r, i)
+                                    ),
+                                    (u = !1)),
+                                (r = c.startTime)),
+                                u && h.set(l, { startTime: r, endTime: i }),
+                                t.options && Is(o, t.options, t.errors);
+                        });
+                });
+        }
+        visitKeyframes(e, t) {
+            let s = { type: S.Keyframes, styles: [], options: null };
+            if (!t.currentAnimateTimings) return t.errors.push(rs()), s;
+            let i = 1,
+                r = 0,
+                a = [],
+                o = !1,
+                l = !1,
+                h = 0,
+                c = e.steps.map((b) => {
+                    let A = this._makeStyleAst(b, t),
+                        C = A.offset != null ? A.offset : Gs(A.styles),
+                        N = 0;
+                    return (
+                        C != null && (r++, (N = A.offset = C)),
+                        (l = l || N < 0 || N > 1),
+                        (o = o || N < h),
+                        (h = N),
+                        a.push(N),
+                        A
+                    );
+                });
+            l && t.errors.push(as()), o && t.errors.push(os());
+            let u = e.steps.length,
+                _ = 0;
+            r > 0 && r < u ? t.errors.push(ls()) : r == 0 && (_ = i / (u - 1));
+            let y = u - 1,
+                d = t.currentTime,
+                g = t.currentAnimateTimings,
+                v = g.duration;
+            return (
+                c.forEach((b, A) => {
+                    let C = _ > 0 ? (A == y ? 1 : _ * A) : a[A],
+                        N = C * v;
+                    (t.currentTime = d + g.delay + N),
+                        (g.duration = N),
+                        this._validateStyleAst(b, t),
+                        (b.offset = C),
+                        s.styles.push(b);
+                }),
+                s
+            );
+        }
+        visitReference(e, t) {
+            return {
+                type: S.Reference,
+                animation: O(this, ie(e.animation), t),
+                options: Y(e.options),
+            };
+        }
+        visitAnimateChild(e, t) {
+            return (
+                t.depCount++, { type: S.AnimateChild, options: Y(e.options) }
+            );
+        }
+        visitAnimateRef(e, t) {
+            return {
+                type: S.AnimateRef,
+                animation: this.visitReference(e.animation, t),
+                options: Y(e.options),
+            };
+        }
+        visitQuery(e, t) {
+            let s = t.currentQuerySelector,
+                i = e.options || {};
+            t.queryCount++, (t.currentQuery = e);
+            let [r, a] = js(e.selector);
+            (t.currentQuerySelector = s.length ? s + " " + r : r),
+                L(t.collectedStyles, t.currentQuerySelector, new Map());
+            let o = O(this, ie(e.animation), t);
+            return (
+                (t.currentQuery = null),
+                (t.currentQuerySelector = s),
+                {
+                    type: S.Query,
+                    selector: r,
+                    limit: i.limit || 0,
+                    optional: !!i.optional,
+                    includeSelf: a,
+                    animation: o,
+                    originalSelector: e.selector,
+                    options: Y(e.options),
+                }
+            );
+        }
+        visitStagger(e, t) {
+            t.currentQuery || t.errors.push(hs());
+            let s =
+                e.timings === "full"
+                    ? { duration: 0, delay: 0, easing: "full" }
+                    : _e(e.timings, t.errors, !0);
+            return {
+                type: S.Stagger,
+                animation: O(this, ie(e.animation), t),
+                timings: s,
+                options: null,
+            };
+        }
+    };
+function js(n) {
+    let e = !!n.split(/\s*,\s*/).find((t) => t == $t);
+    return (
+        e && (n = n.replace(Us, "")),
+        (n = n
+            .replace(/@\*/g, ye)
+            .replace(/@\w+/g, (t) => ye + "-" + t.slice(1))
+            .replace(/:animating/g, Ke)),
+        [n, e]
+    );
+}
+function Ws(n) {
+    return n ? he({}, n) : null;
+}
+var Ve = class {
+    constructor(e) {
+        (this.errors = e),
+            (this.queryCount = 0),
+            (this.depCount = 0),
+            (this.currentTransition = null),
+            (this.currentQuery = null),
+            (this.currentQuerySelector = null),
+            (this.currentAnimateTimings = null),
+            (this.currentTime = 0),
+            (this.collectedStyles = new Map()),
+            (this.options = null),
+            (this.unsupportedCSSPropertiesFound = new Set());
+    }
+};
+function Gs(n) {
+    if (typeof n == "string") return null;
+    let e = null;
+    if (Array.isArray(n))
+        n.forEach((t) => {
+            if (t instanceof Map && t.has("offset")) {
+                let s = t;
+                (e = parseFloat(s.get("offset"))), s.delete("offset");
+            }
+        });
+    else if (n instanceof Map && n.has("offset")) {
+        let t = n;
+        (e = parseFloat(t.get("offset"))), t.delete("offset");
+    }
+    return e;
+}
+function Hs(n, e) {
+    if (n.hasOwnProperty("duration")) return n;
+    if (typeof n == "number") {
+        let r = _e(n, e).duration;
+        return De(r, 0, "");
+    }
+    let t = n;
+    if (t.split(/\s+/).some((r) => r.charAt(0) == "{" && r.charAt(1) == "{")) {
+        let r = De(0, 0, "");
+        return (r.dynamic = !0), (r.strValue = t), r;
+    }
+    let i = _e(t, e);
+    return De(i.duration, i.delay, i.easing);
+}
+function Y(n) {
+    return (
+        n ? ((n = he({}, n)), n.params && (n.params = Ws(n.params))) : (n = {}),
+        n
+    );
+}
+function De(n, e, t) {
+    return { duration: n, delay: e, easing: t };
+}
+function lt(n, e, t, s, i, r, a = null, o = !1) {
+    return {
+        type: 1,
+        element: n,
+        keyframes: e,
+        preStyleProps: t,
+        postStyleProps: s,
+        duration: i,
+        delay: r,
+        totalTime: i + r,
+        easing: a,
+        subTimeline: o,
+    };
+}
+var se = class {
+        constructor() {
+            this._map = new Map();
+        }
+        get(e) {
+            return this._map.get(e) || [];
+        }
+        append(e, t) {
+            let s = this._map.get(e);
+            s || this._map.set(e, (s = [])), s.push(...t);
+        }
+        has(e) {
+            return this._map.has(e);
+        }
+        clear() {
+            this._map.clear();
+        }
+    },
+    Ys = 1,
+    Xs = ":enter",
+    Zs = new RegExp(Xs, "g"),
+    Js = ":leave",
+    xs = new RegExp(Js, "g");
+function ht(n, e, t, s, i, r = new Map(), a = new Map(), o, l, h = []) {
+    return new Ue().buildKeyframes(n, e, t, s, i, r, a, o, l, h);
+}
+var Ue = class {
+        buildKeyframes(e, t, s, i, r, a, o, l, h, c = []) {
+            h = h || new se();
+            let u = new je(e, t, h, i, r, c, []);
+            u.options = l;
+            let _ = l.delay ? $(l.delay) : 0;
+            u.currentTimeline.delayNextStep(_),
+                u.currentTimeline.setStyles([a], null, u.errors, l),
+                O(this, s, u);
+            let y = u.timelines.filter((d) => d.containsAnimation());
+            if (y.length && o.size) {
+                let d;
+                for (let g = y.length - 1; g >= 0; g--) {
+                    let v = y[g];
+                    if (v.element === t) {
+                        d = v;
+                        break;
+                    }
+                }
+                d &&
+                    !d.allowOnlyTimelineStyles() &&
+                    d.setStyles([o], null, u.errors, l);
+            }
+            return y.length
+                ? y.map((d) => d.buildKeyframes())
+                : [lt(t, [], [], [], 0, _, "", !1)];
+        }
+        visitTrigger(e, t) {}
+        visitState(e, t) {}
+        visitTransition(e, t) {}
+        visitAnimateChild(e, t) {
+            let s = t.subInstructions.get(t.element);
+            if (s) {
+                let i = t.createSubContext(e.options),
+                    r = t.currentTimeline.currentTime,
+                    a = this._visitSubInstructions(s, i, i.options);
+                r != a && t.transformIntoNewTimeline(a);
+            }
+            t.previousNode = e;
+        }
+        visitAnimateRef(e, t) {
+            let s = t.createSubContext(e.options);
+            s.transformIntoNewTimeline(),
+                this._applyAnimationRefDelays(
+                    [e.options, e.animation.options],
+                    t,
+                    s
+                ),
+                this.visitReference(e.animation, s),
+                t.transformIntoNewTimeline(s.currentTimeline.currentTime),
+                (t.previousNode = e);
+        }
+        _applyAnimationRefDelays(e, t, s) {
+            for (let i of e) {
+                let r = i?.delay;
+                if (r) {
+                    let a =
+                        typeof r == "number"
+                            ? r
+                            : $(re(r, i?.params ?? {}, t.errors));
+                    s.delayNextStep(a);
+                }
+            }
+        }
+        _visitSubInstructions(e, t, s) {
+            let r = t.currentTimeline.currentTime,
+                a = s.duration != null ? $(s.duration) : null,
+                o = s.delay != null ? $(s.delay) : null;
+            return (
+                a !== 0 &&
+                    e.forEach((l) => {
+                        let h = t.appendInstructionToTimeline(l, a, o);
+                        r = Math.max(r, h.duration + h.delay);
+                    }),
+                r
+            );
+        }
+        visitReference(e, t) {
+            t.updateOptions(e.options, !0),
+                O(this, e.animation, t),
+                (t.previousNode = e);
+        }
+        visitSequence(e, t) {
+            let s = t.subContextCount,
+                i = t,
+                r = e.options;
+            if (
+                r &&
+                (r.params || r.delay) &&
+                ((i = t.createSubContext(r)),
+                i.transformIntoNewTimeline(),
+                r.delay != null)
+            ) {
+                i.previousNode.type == S.Style &&
+                    (i.currentTimeline.snapshotCurrentStyles(),
+                    (i.previousNode = Se));
+                let a = $(r.delay);
+                i.delayNextStep(a);
+            }
+            e.steps.length &&
+                (e.steps.forEach((a) => O(this, a, i)),
+                i.currentTimeline.applyStylesToKeyframe(),
+                i.subContextCount > s && i.transformIntoNewTimeline()),
+                (t.previousNode = e);
+        }
+        visitGroup(e, t) {
+            let s = [],
+                i = t.currentTimeline.currentTime,
+                r = e.options && e.options.delay ? $(e.options.delay) : 0;
+            e.steps.forEach((a) => {
+                let o = t.createSubContext(e.options);
+                r && o.delayNextStep(r),
+                    O(this, a, o),
+                    (i = Math.max(i, o.currentTimeline.currentTime)),
+                    s.push(o.currentTimeline);
+            }),
+                s.forEach((a) =>
+                    t.currentTimeline.mergeTimelineCollectedStyles(a)
+                ),
+                t.transformIntoNewTimeline(i),
+                (t.previousNode = e);
+        }
+        _visitTiming(e, t) {
+            if (e.dynamic) {
+                let s = e.strValue,
+                    i = t.params ? re(s, t.params, t.errors) : s;
+                return _e(i, t.errors);
+            } else
+                return {
+                    duration: e.duration,
+                    delay: e.delay,
+                    easing: e.easing,
+                };
+        }
+        visitAnimate(e, t) {
+            let s = (t.currentAnimateTimings = this._visitTiming(e.timings, t)),
+                i = t.currentTimeline;
+            s.delay && (t.incrementTime(s.delay), i.snapshotCurrentStyles());
+            let r = e.style;
+            r.type == S.Keyframes
+                ? this.visitKeyframes(r, t)
+                : (t.incrementTime(s.duration),
+                  this.visitStyle(r, t),
+                  i.applyStylesToKeyframe()),
+                (t.currentAnimateTimings = null),
+                (t.previousNode = e);
+        }
+        visitStyle(e, t) {
+            let s = t.currentTimeline,
+                i = t.currentAnimateTimings;
+            !i && s.hasCurrentStyleProperties() && s.forwardFrame();
+            let r = (i && i.easing) || e.easing;
+            e.isEmptyStep
+                ? s.applyEmptyStep(r)
+                : s.setStyles(e.styles, r, t.errors, t.options),
+                (t.previousNode = e);
+        }
+        visitKeyframes(e, t) {
+            let s = t.currentAnimateTimings,
+                i = t.currentTimeline.duration,
+                r = s.duration,
+                o = t.createSubContext().currentTimeline;
+            (o.easing = s.easing),
+                e.styles.forEach((l) => {
+                    let h = l.offset || 0;
+                    o.forwardTime(h * r),
+                        o.setStyles(l.styles, l.easing, t.errors, t.options),
+                        o.applyStylesToKeyframe();
+                }),
+                t.currentTimeline.mergeTimelineCollectedStyles(o),
+                t.transformIntoNewTimeline(i + r),
+                (t.previousNode = e);
+        }
+        visitQuery(e, t) {
+            let s = t.currentTimeline.currentTime,
+                i = e.options || {},
+                r = i.delay ? $(i.delay) : 0;
+            r &&
+                (t.previousNode.type === S.Style ||
+                    (s == 0 &&
+                        t.currentTimeline.hasCurrentStyleProperties())) &&
+                (t.currentTimeline.snapshotCurrentStyles(),
+                (t.previousNode = Se));
+            let a = s,
+                o = t.invokeQuery(
+                    e.selector,
+                    e.originalSelector,
+                    e.limit,
+                    e.includeSelf,
+                    !!i.optional,
+                    t.errors
+                );
+            t.currentQueryTotal = o.length;
+            let l = null;
+            o.forEach((h, c) => {
+                t.currentQueryIndex = c;
+                let u = t.createSubContext(e.options, h);
+                r && u.delayNextStep(r),
+                    h === t.element && (l = u.currentTimeline),
+                    O(this, e.animation, u),
+                    u.currentTimeline.applyStylesToKeyframe();
+                let _ = u.currentTimeline.currentTime;
+                a = Math.max(a, _);
+            }),
+                (t.currentQueryIndex = 0),
+                (t.currentQueryTotal = 0),
+                t.transformIntoNewTimeline(a),
+                l &&
+                    (t.currentTimeline.mergeTimelineCollectedStyles(l),
+                    t.currentTimeline.snapshotCurrentStyles()),
+                (t.previousNode = e);
+        }
+        visitStagger(e, t) {
+            let s = t.parentContext,
+                i = t.currentTimeline,
+                r = e.timings,
+                a = Math.abs(r.duration),
+                o = a * (t.currentQueryTotal - 1),
+                l = a * t.currentQueryIndex;
+            switch (r.duration < 0 ? "reverse" : r.easing) {
+                case "reverse":
+                    l = o - l;
+                    break;
+                case "full":
+                    l = s.currentStaggerTime;
+                    break;
+            }
+            let c = t.currentTimeline;
+            l && c.delayNextStep(l);
+            let u = c.currentTime;
+            O(this, e.animation, t),
+                (t.previousNode = e),
+                (s.currentStaggerTime =
+                    i.currentTime -
+                    u +
+                    (i.startTime - s.currentTimeline.startTime));
+        }
+    },
+    Se = {},
+    je = class n {
+        constructor(e, t, s, i, r, a, o, l) {
+            (this._driver = e),
+                (this.element = t),
+                (this.subInstructions = s),
+                (this._enterClassName = i),
+                (this._leaveClassName = r),
+                (this.errors = a),
+                (this.timelines = o),
+                (this.parentContext = null),
+                (this.currentAnimateTimings = null),
+                (this.previousNode = Se),
+                (this.subContextCount = 0),
+                (this.options = {}),
+                (this.currentQueryIndex = 0),
+                (this.currentQueryTotal = 0),
+                (this.currentStaggerTime = 0),
+                (this.currentTimeline = l || new Te(this._driver, t, 0)),
+                o.push(this.currentTimeline);
+        }
+        get params() {
+            return this.options.params;
+        }
+        updateOptions(e, t) {
+            if (!e) return;
+            let s = e,
+                i = this.options;
+            s.duration != null && (i.duration = $(s.duration)),
+                s.delay != null && (i.delay = $(s.delay));
+            let r = s.params;
+            if (r) {
+                let a = i.params;
+                a || (a = this.options.params = {}),
+                    Object.keys(r).forEach((o) => {
+                        (!t || !a.hasOwnProperty(o)) &&
+                            (a[o] = re(r[o], a, this.errors));
+                    });
+            }
+        }
+        _copyOptions() {
+            let e = {};
+            if (this.options) {
+                let t = this.options.params;
+                if (t) {
+                    let s = (e.params = {});
+                    Object.keys(t).forEach((i) => {
+                        s[i] = t[i];
+                    });
+                }
+            }
+            return e;
+        }
+        createSubContext(e = null, t, s) {
+            let i = t || this.element,
+                r = new n(
+                    this._driver,
+                    i,
+                    this.subInstructions,
+                    this._enterClassName,
+                    this._leaveClassName,
+                    this.errors,
+                    this.timelines,
+                    this.currentTimeline.fork(i, s || 0)
+                );
+            return (
+                (r.previousNode = this.previousNode),
+                (r.currentAnimateTimings = this.currentAnimateTimings),
+                (r.options = this._copyOptions()),
+                r.updateOptions(e),
+                (r.currentQueryIndex = this.currentQueryIndex),
+                (r.currentQueryTotal = this.currentQueryTotal),
+                (r.parentContext = this),
+                this.subContextCount++,
+                r
+            );
+        }
+        transformIntoNewTimeline(e) {
+            return (
+                (this.previousNode = Se),
+                (this.currentTimeline = this.currentTimeline.fork(
+                    this.element,
+                    e
+                )),
+                this.timelines.push(this.currentTimeline),
+                this.currentTimeline
+            );
+        }
+        appendInstructionToTimeline(e, t, s) {
+            let i = {
+                    duration: t ?? e.duration,
+                    delay:
+                        this.currentTimeline.currentTime + (s ?? 0) + e.delay,
+                    easing: "",
+                },
+                r = new We(
+                    this._driver,
+                    e.element,
+                    e.keyframes,
+                    e.preStyleProps,
+                    e.postStyleProps,
+                    i,
+                    e.stretchStartingKeyframe
+                );
+            return this.timelines.push(r), i;
+        }
+        incrementTime(e) {
+            this.currentTimeline.forwardTime(this.currentTimeline.duration + e);
+        }
+        delayNextStep(e) {
+            e > 0 && this.currentTimeline.delayNextStep(e);
+        }
+        invokeQuery(e, t, s, i, r, a) {
+            let o = [];
+            if ((i && o.push(this.element), e.length > 0)) {
+                (e = e.replace(Zs, "." + this._enterClassName)),
+                    (e = e.replace(xs, "." + this._leaveClassName));
+                let l = s != 1,
+                    h = this._driver.query(this.element, e, l);
+                s !== 0 &&
+                    (h =
+                        s < 0
+                            ? h.slice(h.length + s, h.length)
+                            : h.slice(0, s)),
+                    o.push(...h);
+            }
+            return !r && o.length == 0 && a.push(us(t)), o;
+        }
+    },
+    Te = class n {
+        constructor(e, t, s, i) {
+            (this._driver = e),
+                (this.element = t),
+                (this.startTime = s),
+                (this._elementTimelineStylesLookup = i),
+                (this.duration = 0),
+                (this.easing = null),
+                (this._previousKeyframe = new Map()),
+                (this._currentKeyframe = new Map()),
+                (this._keyframes = new Map()),
+                (this._styleSummary = new Map()),
+                (this._localTimelineStyles = new Map()),
+                (this._pendingStyles = new Map()),
+                (this._backFill = new Map()),
+                (this._currentEmptyStepKeyframe = null),
+                this._elementTimelineStylesLookup ||
+                    (this._elementTimelineStylesLookup = new Map()),
+                (this._globalTimelineStyles =
+                    this._elementTimelineStylesLookup.get(t)),
+                this._globalTimelineStyles ||
+                    ((this._globalTimelineStyles = this._localTimelineStyles),
+                    this._elementTimelineStylesLookup.set(
+                        t,
+                        this._localTimelineStyles
+                    )),
+                this._loadKeyframe();
+        }
+        containsAnimation() {
+            switch (this._keyframes.size) {
+                case 0:
+                    return !1;
+                case 1:
+                    return this.hasCurrentStyleProperties();
+                default:
+                    return !0;
+            }
+        }
+        hasCurrentStyleProperties() {
+            return this._currentKeyframe.size > 0;
+        }
+        get currentTime() {
+            return this.startTime + this.duration;
+        }
+        delayNextStep(e) {
+            let t = this._keyframes.size === 1 && this._pendingStyles.size;
+            this.duration || t
+                ? (this.forwardTime(this.currentTime + e),
+                  t && this.snapshotCurrentStyles())
+                : (this.startTime += e);
+        }
+        fork(e, t) {
+            return (
+                this.applyStylesToKeyframe(),
+                new n(
+                    this._driver,
+                    e,
+                    t || this.currentTime,
+                    this._elementTimelineStylesLookup
+                )
+            );
+        }
+        _loadKeyframe() {
+            this._currentKeyframe &&
+                (this._previousKeyframe = this._currentKeyframe),
+                (this._currentKeyframe = this._keyframes.get(this.duration)),
+                this._currentKeyframe ||
+                    ((this._currentKeyframe = new Map()),
+                    this._keyframes.set(this.duration, this._currentKeyframe));
+        }
+        forwardFrame() {
+            (this.duration += Ys), this._loadKeyframe();
+        }
+        forwardTime(e) {
+            this.applyStylesToKeyframe(),
+                (this.duration = e),
+                this._loadKeyframe();
+        }
+        _updateStyle(e, t) {
+            this._localTimelineStyles.set(e, t),
+                this._globalTimelineStyles.set(e, t),
+                this._styleSummary.set(e, { time: this.currentTime, value: t });
+        }
+        allowOnlyTimelineStyles() {
+            return this._currentEmptyStepKeyframe !== this._currentKeyframe;
+        }
+        applyEmptyStep(e) {
+            e && this._previousKeyframe.set("easing", e);
+            for (let [t, s] of this._globalTimelineStyles)
+                this._backFill.set(t, s || B), this._currentKeyframe.set(t, B);
+            this._currentEmptyStepKeyframe = this._currentKeyframe;
+        }
+        setStyles(e, t, s, i) {
+            t && this._previousKeyframe.set("easing", t);
+            let r = (i && i.params) || {},
+                a = ei(e, this._globalTimelineStyles);
+            for (let [o, l] of a) {
+                let h = re(l, r, s);
+                this._pendingStyles.set(o, h),
+                    this._localTimelineStyles.has(o) ||
+                        this._backFill.set(
+                            o,
+                            this._globalTimelineStyles.get(o) ?? B
+                        ),
+                    this._updateStyle(o, h);
+            }
+        }
+        applyStylesToKeyframe() {
+            this._pendingStyles.size != 0 &&
+                (this._pendingStyles.forEach((e, t) => {
+                    this._currentKeyframe.set(t, e);
+                }),
+                this._pendingStyles.clear(),
+                this._localTimelineStyles.forEach((e, t) => {
+                    this._currentKeyframe.has(t) ||
+                        this._currentKeyframe.set(t, e);
+                }));
+        }
+        snapshotCurrentStyles() {
+            for (let [e, t] of this._localTimelineStyles)
+                this._pendingStyles.set(e, t), this._updateStyle(e, t);
+        }
+        getFinalKeyframe() {
+            return this._keyframes.get(this.duration);
+        }
+        get properties() {
+            let e = [];
+            for (let t in this._currentKeyframe) e.push(t);
+            return e;
+        }
+        mergeTimelineCollectedStyles(e) {
+            e._styleSummary.forEach((t, s) => {
+                let i = this._styleSummary.get(s);
+                (!i || t.time > i.time) && this._updateStyle(s, t.value);
+            });
+        }
+        buildKeyframes() {
+            this.applyStylesToKeyframe();
+            let e = new Set(),
+                t = new Set(),
+                s = this._keyframes.size === 1 && this.duration === 0,
+                i = [];
+            this._keyframes.forEach((o, l) => {
+                let h = new Map([...this._backFill, ...o]);
+                h.forEach((c, u) => {
+                    c === ue ? e.add(u) : c === B && t.add(u);
+                }),
+                    s || h.set("offset", l / this.duration),
+                    i.push(h);
+            });
+            let r = [...e.values()],
+                a = [...t.values()];
+            if (s) {
+                let o = i[0],
+                    l = new Map(o);
+                o.set("offset", 0), l.set("offset", 1), (i = [o, l]);
+            }
+            return lt(
+                this.element,
+                i,
+                r,
+                a,
+                this.duration,
+                this.startTime,
+                this.easing,
+                !1
+            );
+        }
+    },
+    We = class extends Te {
+        constructor(e, t, s, i, r, a, o = !1) {
+            super(e, t, a.delay),
+                (this.keyframes = s),
+                (this.preStyleProps = i),
+                (this.postStyleProps = r),
+                (this._stretchStartingKeyframe = o),
+                (this.timings = {
+                    duration: a.duration,
+                    delay: a.delay,
+                    easing: a.easing,
+                });
+        }
+        containsAnimation() {
+            return this.keyframes.length > 1;
+        }
+        buildKeyframes() {
+            let e = this.keyframes,
+                { delay: t, duration: s, easing: i } = this.timings;
+            if (this._stretchStartingKeyframe && t) {
+                let r = [],
+                    a = s + t,
+                    o = t / a,
+                    l = new Map(e[0]);
+                l.set("offset", 0), r.push(l);
+                let h = new Map(e[0]);
+                h.set("offset", Pt(o)), r.push(h);
+                let c = e.length - 1;
+                for (let u = 1; u <= c; u++) {
+                    let _ = new Map(e[u]),
+                        y = _.get("offset"),
+                        d = t + y * s;
+                    _.set("offset", Pt(d / a)), r.push(_);
+                }
+                (s = a), (t = 0), (i = ""), (e = r);
+            }
+            return lt(
+                this.element,
+                e,
+                this.preStyleProps,
+                this.postStyleProps,
+                s,
+                t,
+                i,
+                !0
+            );
+        }
+    };
+function Pt(n, e = 3) {
+    let t = Math.pow(10, e - 1);
+    return Math.round(n * t) / t;
+}
+function ei(n, e) {
+    let t = new Map(),
+        s;
+    return (
+        n.forEach((i) => {
+            if (i === "*") {
+                s ??= e.keys();
+                for (let r of s) t.set(r, B);
+            } else for (let [r, a] of i) t.set(r, a);
+        }),
+        t
+    );
+}
+function Nt(n, e, t, s, i, r, a, o, l, h, c, u, _) {
+    return {
+        type: 0,
+        element: n,
+        triggerName: e,
+        isRemovalTransition: i,
+        fromState: t,
+        fromStyles: r,
+        toState: s,
+        toStyles: a,
+        timelines: o,
+        queriedElements: l,
+        preStyleProps: h,
+        postStyleProps: c,
+        totalTime: u,
+        errors: _,
+    };
+}
+var Re = {},
+    ve = class {
+        constructor(e, t, s) {
+            (this._triggerName = e), (this.ast = t), (this._stateStyles = s);
+        }
+        match(e, t, s, i) {
+            return ti(this.ast.matchers, e, t, s, i);
+        }
+        buildStyles(e, t, s) {
+            let i = this._stateStyles.get("*");
+            return (
+                e !== void 0 && (i = this._stateStyles.get(e?.toString()) || i),
+                i ? i.buildStyles(t, s) : new Map()
+            );
+        }
+        build(e, t, s, i, r, a, o, l, h, c) {
+            let u = [],
+                _ = (this.ast.options && this.ast.options.params) || Re,
+                y = (o && o.params) || Re,
+                d = this.buildStyles(s, y, u),
+                g = (l && l.params) || Re,
+                v = this.buildStyles(i, g, u),
+                b = new Set(),
+                A = new Map(),
+                C = new Map(),
+                N = i === "void",
+                Z = { params: Vt(g, _), delay: this.ast.options?.delay },
+                K = c ? [] : ht(e, t, this.ast.animation, r, a, d, v, Z, h, u),
+                k = 0;
+            return (
+                K.forEach((D) => {
+                    k = Math.max(D.duration + D.delay, k);
+                }),
+                u.length
+                    ? Nt(
+                          t,
+                          this._triggerName,
+                          s,
+                          i,
+                          N,
+                          d,
+                          v,
+                          [],
+                          [],
+                          A,
+                          C,
+                          k,
+                          u
+                      )
+                    : (K.forEach((D) => {
+                          let j = D.element,
+                              J = L(A, j, new Set());
+                          D.preStyleProps.forEach((W) => J.add(W));
+                          let ct = L(C, j, new Set());
+                          D.postStyleProps.forEach((W) => ct.add(W)),
+                              j !== t && b.add(j);
+                      }),
+                      Nt(
+                          t,
+                          this._triggerName,
+                          s,
+                          i,
+                          N,
+                          d,
+                          v,
+                          K,
+                          [...b.values()],
+                          A,
+                          C,
+                          k
+                      ))
+            );
+        }
+    };
+function ti(n, e, t, s, i) {
+    return n.some((r) => r(e, t, s, i));
+}
+function Vt(n, e) {
+    let t = he({}, e);
+    return (
+        Object.entries(n).forEach(([s, i]) => {
+            i != null && (t[s] = i);
+        }),
+        t
+    );
+}
+var Ge = class {
+    constructor(e, t, s) {
+        (this.styles = e), (this.defaultParams = t), (this.normalizer = s);
+    }
+    buildStyles(e, t) {
+        let s = new Map(),
+            i = Vt(e, this.defaultParams);
+        return (
+            this.styles.styles.forEach((r) => {
+                typeof r != "string" &&
+                    r.forEach((a, o) => {
+                        a && (a = re(a, i, t));
+                        let l = this.normalizer.normalizePropertyName(o, t);
+                        (a = this.normalizer.normalizeStyleValue(o, l, a, t)),
+                            s.set(o, a);
+                    });
+            }),
+            s
+        );
+    }
+};
+function si(n, e, t) {
+    return new He(n, e, t);
+}
+var He = class {
+    constructor(e, t, s) {
+        (this.name = e),
+            (this.ast = t),
+            (this._normalizer = s),
+            (this.transitionFactories = []),
+            (this.states = new Map()),
+            t.states.forEach((i) => {
+                let r = (i.options && i.options.params) || {};
+                this.states.set(i.name, new Ge(i.style, r, s));
+            }),
+            Mt(this.states, "true", "1"),
+            Mt(this.states, "false", "0"),
+            t.transitions.forEach((i) => {
+                this.transitionFactories.push(new ve(e, i, this.states));
+            }),
+            (this.fallbackTransition = ii(e, this.states, this._normalizer));
+    }
+    get containsQueries() {
+        return this.ast.queryCount > 0;
+    }
+    matchTransition(e, t, s, i) {
+        return (
+            this.transitionFactories.find((a) => a.match(e, t, s, i)) || null
+        );
+    }
+    matchStyles(e, t, s) {
+        return this.fallbackTransition.buildStyles(e, t, s);
+    }
+};
+function ii(n, e, t) {
+    let s = [(a, o) => !0],
+        i = { type: S.Sequence, steps: [], options: null },
+        r = {
+            type: S.Transition,
+            animation: i,
+            matchers: s,
+            options: null,
+            queryCount: 0,
+            depCount: 0,
+        };
+    return new ve(n, r, e);
+}
+function Mt(n, e, t) {
+    n.has(e) ? n.has(t) || n.set(t, n.get(e)) : n.has(t) && n.set(e, n.get(t));
+}
+var ni = new se(),
+    Ye = class {
+        constructor(e, t, s) {
+            (this.bodyNode = e),
+                (this._driver = t),
+                (this._normalizer = s),
+                (this._animations = new Map()),
+                (this._playersById = new Map()),
+                (this.players = []);
+        }
+        register(e, t) {
+            let s = [],
+                i = [],
+                r = ot(this._driver, t, s, i);
+            if (s.length) throw ys(s);
+            i.length && void 0, this._animations.set(e, r);
+        }
+        _buildPlayer(e, t, s) {
+            let i = e.element,
+                r = It(this._normalizer, e.keyframes, t, s);
+            return this._driver.animate(
+                i,
+                r,
+                e.duration,
+                e.delay,
+                e.easing,
+                [],
+                !0
+            );
+        }
+        create(e, t, s = {}) {
+            let i = [],
+                r = this._animations.get(e),
+                a,
+                o = new Map();
+            if (
+                (r
+                    ? ((a = ht(
+                          this._driver,
+                          t,
+                          r,
+                          nt,
+                          ge,
+                          new Map(),
+                          new Map(),
+                          s,
+                          ni,
+                          i
+                      )),
+                      a.forEach((c) => {
+                          let u = L(o, c.element, new Map());
+                          c.postStyleProps.forEach((_) => u.set(_, null));
+                      }))
+                    : (i.push(_s()), (a = [])),
+                i.length)
+            )
+                throw Es(i);
+            o.forEach((c, u) => {
+                c.forEach((_, y) => {
+                    c.set(y, this._driver.computeStyle(u, y, B));
+                });
+            });
+            let l = a.map((c) => {
+                    let u = o.get(c.element);
+                    return this._buildPlayer(c, new Map(), u);
+                }),
+                h = U(l);
+            return (
+                this._playersById.set(e, h),
+                h.onDestroy(() => this.destroy(e)),
+                this.players.push(h),
+                h
+            );
+        }
+        destroy(e) {
+            let t = this._getPlayer(e);
+            t.destroy(), this._playersById.delete(e);
+            let s = this.players.indexOf(t);
+            s >= 0 && this.players.splice(s, 1);
+        }
+        _getPlayer(e) {
+            let t = this._playersById.get(e);
+            if (!t) throw Ss(e);
+            return t;
+        }
+        listen(e, t, s, i) {
+            let r = st(t, "", "", "");
+            return tt(this._getPlayer(e), s, r, i), () => {};
+        }
+        command(e, t, s, i) {
+            if (s == "register") {
+                this.register(e, i[0]);
+                return;
+            }
+            if (s == "create") {
+                let a = i[0] || {};
+                this.create(e, t, a);
+                return;
+            }
+            let r = this._getPlayer(e);
+            switch (s) {
+                case "play":
+                    r.play();
+                    break;
+                case "pause":
+                    r.pause();
+                    break;
+                case "reset":
+                    r.reset();
+                    break;
+                case "restart":
+                    r.restart();
+                    break;
+                case "finish":
+                    r.finish();
+                    break;
+                case "init":
+                    r.init();
+                    break;
+                case "setPosition":
+                    r.setPosition(parseFloat(i[0]));
+                    break;
+                case "destroy":
+                    this.destroy(e);
+                    break;
+            }
+        }
+    },
+    Ct = "ng-animate-queued",
+    ri = ".ng-animate-queued",
+    Oe = "ng-animate-disabled",
+    ai = ".ng-animate-disabled",
+    oi = "ng-star-inserted",
+    li = ".ng-star-inserted",
+    hi = [],
+    Ut = {
+        namespaceId: "",
+        setForRemoval: !1,
+        setForMove: !1,
+        hasAnimation: !1,
+        removedBeforeQueried: !1,
+    },
+    ui = {
+        namespaceId: "",
+        setForMove: !1,
+        setForRemoval: !1,
+        hasAnimation: !1,
+        removedBeforeQueried: !0,
+    },
+    z = "__ng_removed",
+    ae = class {
+        get params() {
+            return this.options.params;
+        }
+        constructor(e, t = "") {
+            this.namespaceId = t;
+            let s = e && e.hasOwnProperty("value"),
+                i = s ? e.value : e;
+            if (((this.value = fi(i)), s)) {
+                let r = e,
+                    { value: a } = r,
+                    o = pt(r, ["value"]);
+                this.options = o;
+            } else this.options = {};
+            this.options.params || (this.options.params = {});
+        }
+        absorbOptions(e) {
+            let t = e.params;
+            if (t) {
+                let s = this.options.params;
+                Object.keys(t).forEach((i) => {
+                    s[i] == null && (s[i] = t[i]);
+                });
+            }
+        }
+    },
+    ne = "void",
+    Le = new ae(ne),
+    Xe = class {
+        constructor(e, t, s) {
+            (this.id = e),
+                (this.hostElement = t),
+                (this._engine = s),
+                (this.players = []),
+                (this._triggers = new Map()),
+                (this._queue = []),
+                (this._elementListeners = new Map()),
+                (this._hostClassName = "ng-tns-" + e),
+                I(t, this._hostClassName);
+        }
+        listen(e, t, s, i) {
+            if (!this._triggers.has(t)) throw Ts(s, t);
+            if (s == null || s.length == 0) throw vs(t);
+            if (!di(s)) throw ws(s, t);
+            let r = L(this._elementListeners, e, []),
+                a = { name: t, phase: s, callback: i };
+            r.push(a);
+            let o = L(this._engine.statesByElement, e, new Map());
+            return (
+                o.has(t) || (I(e, ce), I(e, ce + "-" + t), o.set(t, Le)),
+                () => {
+                    this._engine.afterFlush(() => {
+                        let l = r.indexOf(a);
+                        l >= 0 && r.splice(l, 1),
+                            this._triggers.has(t) || o.delete(t);
+                    });
+                }
+            );
+        }
+        register(e, t) {
+            return this._triggers.has(e) ? !1 : (this._triggers.set(e, t), !0);
+        }
+        _getTrigger(e) {
+            let t = this._triggers.get(e);
+            if (!t) throw bs(e);
+            return t;
+        }
+        trigger(e, t, s, i = !0) {
+            let r = this._getTrigger(t),
+                a = new oe(this.id, t, e),
+                o = this._engine.statesByElement.get(e);
+            o ||
+                (I(e, ce),
+                I(e, ce + "-" + t),
+                this._engine.statesByElement.set(e, (o = new Map())));
+            let l = o.get(t),
+                h = new ae(s, this.id);
+            if (
+                (!(s && s.hasOwnProperty("value")) &&
+                    l &&
+                    h.absorbOptions(l.options),
+                o.set(t, h),
+                l || (l = Le),
+                !(h.value === ne) && l.value === h.value)
+            ) {
+                if (!gi(l.params, h.params)) {
+                    let g = [],
+                        v = r.matchStyles(l.value, l.params, g),
+                        b = r.matchStyles(h.value, h.params, g);
+                    g.length
+                        ? this._engine.reportError(g)
+                        : this._engine.afterFlush(() => {
+                              X(e, v), Q(e, b);
+                          });
+                }
+                return;
+            }
+            let _ = L(this._engine.playersByElement, e, []);
+            _.forEach((g) => {
+                g.namespaceId == this.id &&
+                    g.triggerName == t &&
+                    g.queued &&
+                    g.destroy();
+            });
+            let y = r.matchTransition(l.value, h.value, e, h.params),
+                d = !1;
+            if (!y) {
+                if (!i) return;
+                (y = r.fallbackTransition), (d = !0);
+            }
+            return (
+                this._engine.totalQueuedPlayers++,
+                this._queue.push({
+                    element: e,
+                    triggerName: t,
+                    transition: y,
+                    fromState: l,
+                    toState: h,
+                    player: a,
+                    isFallbackTransition: d,
+                }),
+                d ||
+                    (I(e, Ct),
+                    a.onStart(() => {
+                        ee(e, Ct);
+                    })),
+                a.onDone(() => {
+                    let g = this.players.indexOf(a);
+                    g >= 0 && this.players.splice(g, 1);
+                    let v = this._engine.playersByElement.get(e);
+                    if (v) {
+                        let b = v.indexOf(a);
+                        b >= 0 && v.splice(b, 1);
+                    }
+                }),
+                this.players.push(a),
+                _.push(a),
+                a
+            );
+        }
+        deregister(e) {
+            this._triggers.delete(e),
+                this._engine.statesByElement.forEach((t) => t.delete(e)),
+                this._elementListeners.forEach((t, s) => {
+                    this._elementListeners.set(
+                        s,
+                        t.filter((i) => i.name != e)
+                    );
+                });
+        }
+        clearElementCache(e) {
+            this._engine.statesByElement.delete(e),
+                this._elementListeners.delete(e);
+            let t = this._engine.playersByElement.get(e);
+            t &&
+                (t.forEach((s) => s.destroy()),
+                this._engine.playersByElement.delete(e));
+        }
+        _signalRemovalForInnerTriggers(e, t) {
+            let s = this._engine.driver.query(e, ye, !0);
+            s.forEach((i) => {
+                if (i[z]) return;
+                let r = this._engine.fetchNamespacesByElement(i);
+                r.size
+                    ? r.forEach((a) => a.triggerLeaveAnimation(i, t, !1, !0))
+                    : this.clearElementCache(i);
+            }),
+                this._engine.afterFlushAnimationsDone(() =>
+                    s.forEach((i) => this.clearElementCache(i))
+                );
+        }
+        triggerLeaveAnimation(e, t, s, i) {
+            let r = this._engine.statesByElement.get(e),
+                a = new Map();
+            if (r) {
+                let o = [];
+                if (
+                    (r.forEach((l, h) => {
+                        if ((a.set(h, l.value), this._triggers.has(h))) {
+                            let c = this.trigger(e, h, ne, i);
+                            c && o.push(c);
+                        }
+                    }),
+                    o.length)
+                )
+                    return (
+                        this._engine.markElementAsRemoved(this.id, e, !0, t, a),
+                        s &&
+                            U(o).onDone(() => this._engine.processLeaveNode(e)),
+                        !0
+                    );
+            }
+            return !1;
+        }
+        prepareLeaveAnimationListeners(e) {
+            let t = this._elementListeners.get(e),
+                s = this._engine.statesByElement.get(e);
+            if (t && s) {
+                let i = new Set();
+                t.forEach((r) => {
+                    let a = r.name;
+                    if (i.has(a)) return;
+                    i.add(a);
+                    let l = this._triggers.get(a).fallbackTransition,
+                        h = s.get(a) || Le,
+                        c = new ae(ne),
+                        u = new oe(this.id, a, e);
+                    this._engine.totalQueuedPlayers++,
+                        this._queue.push({
+                            element: e,
+                            triggerName: a,
+                            transition: l,
+                            fromState: h,
+                            toState: c,
+                            player: u,
+                            isFallbackTransition: !0,
+                        });
+                });
+            }
+        }
+        removeNode(e, t) {
+            let s = this._engine;
+            if (
+                (e.childElementCount &&
+                    this._signalRemovalForInnerTriggers(e, t),
+                this.triggerLeaveAnimation(e, t, !0))
+            )
+                return;
+            let i = !1;
+            if (s.totalAnimations) {
+                let r = s.players.length
+                    ? s.playersByQueriedElement.get(e)
+                    : [];
+                if (r && r.length) i = !0;
+                else {
+                    let a = e;
+                    for (; (a = a.parentNode); )
+                        if (s.statesByElement.get(a)) {
+                            i = !0;
+                            break;
+                        }
+                }
+            }
+            if ((this.prepareLeaveAnimationListeners(e), i))
+                s.markElementAsRemoved(this.id, e, !1, t);
+            else {
+                let r = e[z];
+                (!r || r === Ut) &&
+                    (s.afterFlush(() => this.clearElementCache(e)),
+                    s.destroyInnerAnimations(e),
+                    s._onRemovalComplete(e, t));
+            }
+        }
+        insertNode(e, t) {
+            I(e, this._hostClassName);
+        }
+        drainQueuedTransitions(e) {
+            let t = [];
+            return (
+                this._queue.forEach((s) => {
+                    let i = s.player;
+                    if (i.destroyed) return;
+                    let r = s.element,
+                        a = this._elementListeners.get(r);
+                    a &&
+                        a.forEach((o) => {
+                            if (o.name == s.triggerName) {
+                                let l = st(
+                                    r,
+                                    s.triggerName,
+                                    s.fromState.value,
+                                    s.toState.value
+                                );
+                                (l._data = e),
+                                    tt(s.player, o.phase, l, o.callback);
+                            }
+                        }),
+                        i.markedForDestroy
+                            ? this._engine.afterFlush(() => {
+                                  i.destroy();
+                              })
+                            : t.push(s);
+                }),
+                (this._queue = []),
+                t.sort((s, i) => {
+                    let r = s.transition.ast.depCount,
+                        a = i.transition.ast.depCount;
+                    return r == 0 || a == 0
+                        ? r - a
+                        : this._engine.driver.containsElement(
+                                s.element,
+                                i.element
+                            )
+                          ? 1
+                          : -1;
+                })
+            );
+        }
+        destroy(e) {
+            this.players.forEach((t) => t.destroy()),
+                this._signalRemovalForInnerTriggers(this.hostElement, e);
+        }
+    },
+    Ze = class {
+        _onRemovalComplete(e, t) {
+            this.onRemovalComplete(e, t);
+        }
+        constructor(e, t, s, i) {
+            (this.bodyNode = e),
+                (this.driver = t),
+                (this._normalizer = s),
+                (this.scheduler = i),
+                (this.players = []),
+                (this.newHostElements = new Map()),
+                (this.playersByElement = new Map()),
+                (this.playersByQueriedElement = new Map()),
+                (this.statesByElement = new Map()),
+                (this.disabledNodes = new Set()),
+                (this.totalAnimations = 0),
+                (this.totalQueuedPlayers = 0),
+                (this._namespaceLookup = {}),
+                (this._namespaceList = []),
+                (this._flushFns = []),
+                (this._whenQuietFns = []),
+                (this.namespacesByHostElement = new Map()),
+                (this.collectedEnterElements = []),
+                (this.collectedLeaveElements = []),
+                (this.onRemovalComplete = (r, a) => {});
+        }
+        get queuedPlayers() {
+            let e = [];
+            return (
+                this._namespaceList.forEach((t) => {
+                    t.players.forEach((s) => {
+                        s.queued && e.push(s);
+                    });
+                }),
+                e
+            );
+        }
+        createNamespace(e, t) {
+            let s = new Xe(e, t, this);
+            return (
+                this.bodyNode && this.driver.containsElement(this.bodyNode, t)
+                    ? this._balanceNamespaceList(s, t)
+                    : (this.newHostElements.set(t, s),
+                      this.collectEnterElement(t)),
+                (this._namespaceLookup[e] = s)
+            );
+        }
+        _balanceNamespaceList(e, t) {
+            let s = this._namespaceList,
+                i = this.namespacesByHostElement;
+            if (s.length - 1 >= 0) {
+                let a = !1,
+                    o = this.driver.getParentElement(t);
+                for (; o; ) {
+                    let l = i.get(o);
+                    if (l) {
+                        let h = s.indexOf(l);
+                        s.splice(h + 1, 0, e), (a = !0);
+                        break;
+                    }
+                    o = this.driver.getParentElement(o);
+                }
+                a || s.unshift(e);
+            } else s.push(e);
+            return i.set(t, e), e;
+        }
+        register(e, t) {
+            let s = this._namespaceLookup[e];
+            return s || (s = this.createNamespace(e, t)), s;
+        }
+        registerTrigger(e, t, s) {
+            let i = this._namespaceLookup[e];
+            i && i.register(t, s) && this.totalAnimations++;
+        }
+        destroy(e, t) {
+            e &&
+                (this.afterFlush(() => {}),
+                this.afterFlushAnimationsDone(() => {
+                    let s = this._fetchNamespace(e);
+                    this.namespacesByHostElement.delete(s.hostElement);
+                    let i = this._namespaceList.indexOf(s);
+                    i >= 0 && this._namespaceList.splice(i, 1),
+                        s.destroy(t),
+                        delete this._namespaceLookup[e];
+                }));
+        }
+        _fetchNamespace(e) {
+            return this._namespaceLookup[e];
+        }
+        fetchNamespacesByElement(e) {
+            let t = new Set(),
+                s = this.statesByElement.get(e);
+            if (s) {
+                for (let i of s.values())
+                    if (i.namespaceId) {
+                        let r = this._fetchNamespace(i.namespaceId);
+                        r && t.add(r);
+                    }
+            }
+            return t;
+        }
+        trigger(e, t, s, i) {
+            if (me(t)) {
+                let r = this._fetchNamespace(e);
+                if (r) return r.trigger(t, s, i), !0;
+            }
+            return !1;
+        }
+        insertNode(e, t, s, i) {
+            if (!me(t)) return;
+            let r = t[z];
+            if (r && r.setForRemoval) {
+                (r.setForRemoval = !1), (r.setForMove = !0);
+                let a = this.collectedLeaveElements.indexOf(t);
+                a >= 0 && this.collectedLeaveElements.splice(a, 1);
+            }
+            if (e) {
+                let a = this._fetchNamespace(e);
+                a && a.insertNode(t, s);
+            }
+            i && this.collectEnterElement(t);
+        }
+        collectEnterElement(e) {
+            this.collectedEnterElements.push(e);
+        }
+        markElementAsDisabled(e, t) {
+            t
+                ? this.disabledNodes.has(e) ||
+                  (this.disabledNodes.add(e), I(e, Oe))
+                : this.disabledNodes.has(e) &&
+                  (this.disabledNodes.delete(e), ee(e, Oe));
+        }
+        removeNode(e, t, s) {
+            if (me(t)) {
+                this.scheduler?.notify();
+                let i = e ? this._fetchNamespace(e) : null;
+                i ? i.removeNode(t, s) : this.markElementAsRemoved(e, t, !1, s);
+                let r = this.namespacesByHostElement.get(t);
+                r && r.id !== e && r.removeNode(t, s);
+            } else this._onRemovalComplete(t, s);
+        }
+        markElementAsRemoved(e, t, s, i, r) {
+            this.collectedLeaveElements.push(t),
+                (t[z] = {
+                    namespaceId: e,
+                    setForRemoval: i,
+                    hasAnimation: s,
+                    removedBeforeQueried: !1,
+                    previousTriggersValues: r,
+                });
+        }
+        listen(e, t, s, i, r) {
+            return me(t)
+                ? this._fetchNamespace(e).listen(t, s, i, r)
+                : () => {};
+        }
+        _buildInstruction(e, t, s, i, r) {
+            return e.transition.build(
+                this.driver,
+                e.element,
+                e.fromState.value,
+                e.toState.value,
+                s,
+                i,
+                e.fromState.options,
+                e.toState.options,
+                t,
+                r
+            );
+        }
+        destroyInnerAnimations(e) {
+            let t = this.driver.query(e, ye, !0);
+            t.forEach((s) => this.destroyActiveAnimationsForElement(s)),
+                this.playersByQueriedElement.size != 0 &&
+                    ((t = this.driver.query(e, Ke, !0)),
+                    t.forEach((s) =>
+                        this.finishActiveQueriedAnimationOnElement(s)
+                    ));
+        }
+        destroyActiveAnimationsForElement(e) {
+            let t = this.playersByElement.get(e);
+            t &&
+                t.forEach((s) => {
+                    s.queued ? (s.markedForDestroy = !0) : s.destroy();
+                });
+        }
+        finishActiveQueriedAnimationOnElement(e) {
+            let t = this.playersByQueriedElement.get(e);
+            t && t.forEach((s) => s.finish());
+        }
+        whenRenderingDone() {
+            return new Promise((e) => {
+                if (this.players.length)
+                    return U(this.players).onDone(() => e());
+                e();
+            });
+        }
+        processLeaveNode(e) {
+            let t = e[z];
+            if (t && t.setForRemoval) {
+                if (((e[z] = Ut), t.namespaceId)) {
+                    this.destroyInnerAnimations(e);
+                    let s = this._fetchNamespace(t.namespaceId);
+                    s && s.clearElementCache(e);
+                }
+                this._onRemovalComplete(e, t.setForRemoval);
+            }
+            e.classList?.contains(Oe) && this.markElementAsDisabled(e, !1),
+                this.driver.query(e, ai, !0).forEach((s) => {
+                    this.markElementAsDisabled(s, !1);
+                });
+        }
+        flush(e = -1) {
+            let t = [];
+            if (
+                (this.newHostElements.size &&
+                    (this.newHostElements.forEach((s, i) =>
+                        this._balanceNamespaceList(s, i)
+                    ),
+                    this.newHostElements.clear()),
+                this.totalAnimations && this.collectedEnterElements.length)
+            )
+                for (let s = 0; s < this.collectedEnterElements.length; s++) {
+                    let i = this.collectedEnterElements[s];
+                    I(i, oi);
+                }
+            if (
+                this._namespaceList.length &&
+                (this.totalQueuedPlayers || this.collectedLeaveElements.length)
+            ) {
+                let s = [];
+                try {
+                    t = this._flushAnimations(s, e);
+                } finally {
+                    for (let i = 0; i < s.length; i++) s[i]();
+                }
+            } else
+                for (let s = 0; s < this.collectedLeaveElements.length; s++) {
+                    let i = this.collectedLeaveElements[s];
+                    this.processLeaveNode(i);
+                }
+            if (
+                ((this.totalQueuedPlayers = 0),
+                (this.collectedEnterElements.length = 0),
+                (this.collectedLeaveElements.length = 0),
+                this._flushFns.forEach((s) => s()),
+                (this._flushFns = []),
+                this._whenQuietFns.length)
+            ) {
+                let s = this._whenQuietFns;
+                (this._whenQuietFns = []),
+                    t.length
+                        ? U(t).onDone(() => {
+                              s.forEach((i) => i());
+                          })
+                        : s.forEach((i) => i());
+            }
+        }
+        reportError(e) {
+            throw As(e);
+        }
+        _flushAnimations(e, t) {
+            let s = new se(),
+                i = [],
+                r = new Map(),
+                a = [],
+                o = new Map(),
+                l = new Map(),
+                h = new Map(),
+                c = new Set();
+            this.disabledNodes.forEach((f) => {
+                c.add(f);
+                let m = this.driver.query(f, ri, !0);
+                for (let p = 0; p < m.length; p++) c.add(m[p]);
+            });
+            let u = this.bodyNode,
+                _ = Array.from(this.statesByElement.keys()),
+                y = Rt(_, this.collectedEnterElements),
+                d = new Map(),
+                g = 0;
+            y.forEach((f, m) => {
+                let p = nt + g++;
+                d.set(m, p), f.forEach((T) => I(T, p));
+            });
+            let v = [],
+                b = new Set(),
+                A = new Set();
+            for (let f = 0; f < this.collectedLeaveElements.length; f++) {
+                let m = this.collectedLeaveElements[f],
+                    p = m[z];
+                p &&
+                    p.setForRemoval &&
+                    (v.push(m),
+                    b.add(m),
+                    p.hasAnimation
+                        ? this.driver.query(m, li, !0).forEach((T) => b.add(T))
+                        : A.add(m));
+            }
+            let C = new Map(),
+                N = Rt(_, Array.from(b));
+            N.forEach((f, m) => {
+                let p = ge + g++;
+                C.set(m, p), f.forEach((T) => I(T, p));
+            }),
+                e.push(() => {
+                    y.forEach((f, m) => {
+                        let p = d.get(m);
+                        f.forEach((T) => ee(T, p));
+                    }),
+                        N.forEach((f, m) => {
+                            let p = C.get(m);
+                            f.forEach((T) => ee(T, p));
+                        }),
+                        v.forEach((f) => {
+                            this.processLeaveNode(f);
+                        });
+                });
+            let Z = [],
+                K = [];
+            for (let f = this._namespaceList.length - 1; f >= 0; f--)
+                this._namespaceList[f]
+                    .drainQueuedTransitions(t)
+                    .forEach((p) => {
+                        let T = p.player,
+                            P = p.element;
+                        if ((Z.push(T), this.collectedEnterElements.length)) {
+                            let M = P[z];
+                            if (M && M.setForMove) {
+                                if (
+                                    M.previousTriggersValues &&
+                                    M.previousTriggersValues.has(p.triggerName)
+                                ) {
+                                    let G = M.previousTriggersValues.get(
+                                            p.triggerName
+                                        ),
+                                        F = this.statesByElement.get(p.element);
+                                    if (F && F.has(p.triggerName)) {
+                                        let le = F.get(p.triggerName);
+                                        (le.value = G),
+                                            F.set(p.triggerName, le);
+                                    }
+                                }
+                                T.destroy();
+                                return;
+                            }
+                        }
+                        let q = !u || !this.driver.containsElement(u, P),
+                            R = C.get(P),
+                            V = d.get(P),
+                            w = this._buildInstruction(p, s, V, R, q);
+                        if (w.errors && w.errors.length) {
+                            K.push(w);
+                            return;
+                        }
+                        if (q) {
+                            T.onStart(() => X(P, w.fromStyles)),
+                                T.onDestroy(() => Q(P, w.toStyles)),
+                                i.push(T);
+                            return;
+                        }
+                        if (p.isFallbackTransition) {
+                            T.onStart(() => X(P, w.fromStyles)),
+                                T.onDestroy(() => Q(P, w.toStyles)),
+                                i.push(T);
+                            return;
+                        }
+                        let mt = [];
+                        w.timelines.forEach((M) => {
+                            (M.stretchStartingKeyframe = !0),
+                                this.disabledNodes.has(M.element) || mt.push(M);
+                        }),
+                            (w.timelines = mt),
+                            s.append(P, w.timelines);
+                        let Gt = { instruction: w, player: T, element: P };
+                        a.push(Gt),
+                            w.queriedElements.forEach((M) =>
+                                L(o, M, []).push(T)
+                            ),
+                            w.preStyleProps.forEach((M, G) => {
+                                if (M.size) {
+                                    let F = l.get(G);
+                                    F || l.set(G, (F = new Set())),
+                                        M.forEach((le, Ne) => F.add(Ne));
+                                }
+                            }),
+                            w.postStyleProps.forEach((M, G) => {
+                                let F = h.get(G);
+                                F || h.set(G, (F = new Set())),
+                                    M.forEach((le, Ne) => F.add(Ne));
+                            });
+                    });
+            if (K.length) {
+                let f = [];
+                K.forEach((m) => {
+                    f.push(Ps(m.triggerName, m.errors));
+                }),
+                    Z.forEach((m) => m.destroy()),
+                    this.reportError(f);
+            }
+            let k = new Map(),
+                D = new Map();
+            a.forEach((f) => {
+                let m = f.element;
+                s.has(m) &&
+                    (D.set(m, m),
+                    this._beforeAnimationBuild(
+                        f.player.namespaceId,
+                        f.instruction,
+                        k
+                    ));
+            }),
+                i.forEach((f) => {
+                    let m = f.element;
+                    this._getPreviousPlayers(
+                        m,
+                        !1,
+                        f.namespaceId,
+                        f.triggerName,
+                        null
+                    ).forEach((T) => {
+                        L(k, m, []).push(T), T.destroy();
+                    });
+                });
+            let j = v.filter((f) => Ot(f, l, h)),
+                J = new Map();
+            Dt(J, this.driver, A, h, B).forEach((f) => {
+                Ot(f, l, h) && j.push(f);
+            });
+            let W = new Map();
+            y.forEach((f, m) => {
+                Dt(W, this.driver, new Set(f), l, ue);
+            }),
+                j.forEach((f) => {
+                    let m = J.get(f),
+                        p = W.get(f);
+                    J.set(
+                        f,
+                        new Map([
+                            ...(m?.entries() ?? []),
+                            ...(p?.entries() ?? []),
+                        ])
+                    );
+                });
+            let Pe = [],
+                ft = [],
+                dt = {};
+            a.forEach((f) => {
+                let { element: m, player: p, instruction: T } = f;
+                if (s.has(m)) {
+                    if (c.has(m)) {
+                        p.onDestroy(() => Q(m, T.toStyles)),
+                            (p.disabled = !0),
+                            p.overrideTotalTime(T.totalTime),
+                            i.push(p);
+                        return;
+                    }
+                    let P = dt;
+                    if (D.size > 1) {
+                        let R = m,
+                            V = [];
+                        for (; (R = R.parentNode); ) {
+                            let w = D.get(R);
+                            if (w) {
+                                P = w;
+                                break;
+                            }
+                            V.push(R);
+                        }
+                        V.forEach((w) => D.set(w, P));
+                    }
+                    let q = this._buildAnimation(p.namespaceId, T, k, r, W, J);
+                    if ((p.setRealPlayer(q), P === dt)) Pe.push(p);
+                    else {
+                        let R = this.playersByElement.get(P);
+                        R && R.length && (p.parentPlayer = U(R)), i.push(p);
+                    }
+                } else
+                    X(m, T.fromStyles),
+                        p.onDestroy(() => Q(m, T.toStyles)),
+                        ft.push(p),
+                        c.has(m) && i.push(p);
+            }),
+                ft.forEach((f) => {
+                    let m = r.get(f.element);
+                    if (m && m.length) {
+                        let p = U(m);
+                        f.setRealPlayer(p);
+                    }
+                }),
+                i.forEach((f) => {
+                    f.parentPlayer
+                        ? f.syncPlayerEvents(f.parentPlayer)
+                        : f.destroy();
+                });
+            for (let f = 0; f < v.length; f++) {
+                let m = v[f],
+                    p = m[z];
+                if ((ee(m, ge), p && p.hasAnimation)) continue;
+                let T = [];
+                if (o.size) {
+                    let q = o.get(m);
+                    q && q.length && T.push(...q);
+                    let R = this.driver.query(m, Ke, !0);
+                    for (let V = 0; V < R.length; V++) {
+                        let w = o.get(R[V]);
+                        w && w.length && T.push(...w);
+                    }
+                }
+                let P = T.filter((q) => !q.destroyed);
+                P.length ? mi(this, m, P) : this.processLeaveNode(m);
+            }
+            return (
+                (v.length = 0),
+                Pe.forEach((f) => {
+                    this.players.push(f),
+                        f.onDone(() => {
+                            f.destroy();
+                            let m = this.players.indexOf(f);
+                            this.players.splice(m, 1);
+                        }),
+                        f.play();
+                }),
+                Pe
+            );
+        }
+        afterFlush(e) {
+            this._flushFns.push(e);
+        }
+        afterFlushAnimationsDone(e) {
+            this._whenQuietFns.push(e);
+        }
+        _getPreviousPlayers(e, t, s, i, r) {
+            let a = [];
+            if (t) {
+                let o = this.playersByQueriedElement.get(e);
+                o && (a = o);
+            } else {
+                let o = this.playersByElement.get(e);
+                if (o) {
+                    let l = !r || r == ne;
+                    o.forEach((h) => {
+                        h.queued || (!l && h.triggerName != i) || a.push(h);
+                    });
+                }
+            }
+            return (
+                (s || i) &&
+                    (a = a.filter(
+                        (o) =>
+                            !(
+                                (s && s != o.namespaceId) ||
+                                (i && i != o.triggerName)
+                            )
+                    )),
+                a
+            );
+        }
+        _beforeAnimationBuild(e, t, s) {
+            let i = t.triggerName,
+                r = t.element,
+                a = t.isRemovalTransition ? void 0 : e,
+                o = t.isRemovalTransition ? void 0 : i;
+            for (let l of t.timelines) {
+                let h = l.element,
+                    c = h !== r,
+                    u = L(s, h, []);
+                this._getPreviousPlayers(h, c, a, o, t.toState).forEach((y) => {
+                    let d = y.getRealPlayer();
+                    d.beforeDestroy && d.beforeDestroy(),
+                        y.destroy(),
+                        u.push(y);
+                });
+            }
+            X(r, t.fromStyles);
+        }
+        _buildAnimation(e, t, s, i, r, a) {
+            let o = t.triggerName,
+                l = t.element,
+                h = [],
+                c = new Set(),
+                u = new Set(),
+                _ = t.timelines.map((d) => {
+                    let g = d.element;
+                    c.add(g);
+                    let v = g[z];
+                    if (v && v.removedBeforeQueried)
+                        return new x(d.duration, d.delay);
+                    let b = g !== l,
+                        A = pi(
+                            (s.get(g) || hi).map((k) => k.getRealPlayer())
+                        ).filter((k) => {
+                            let D = k;
+                            return D.element ? D.element === g : !1;
+                        }),
+                        C = r.get(g),
+                        N = a.get(g),
+                        Z = It(this._normalizer, d.keyframes, C, N),
+                        K = this._buildPlayer(d, Z, A);
+                    if ((d.subTimeline && i && u.add(g), b)) {
+                        let k = new oe(e, o, g);
+                        k.setRealPlayer(K), h.push(k);
+                    }
+                    return K;
+                });
+            h.forEach((d) => {
+                L(this.playersByQueriedElement, d.element, []).push(d),
+                    d.onDone(() =>
+                        ci(this.playersByQueriedElement, d.element, d)
+                    );
+            }),
+                c.forEach((d) => I(d, vt));
+            let y = U(_);
+            return (
+                y.onDestroy(() => {
+                    c.forEach((d) => ee(d, vt)), Q(l, t.toStyles);
+                }),
+                u.forEach((d) => {
+                    L(i, d, []).push(y);
+                }),
+                y
+            );
+        }
+        _buildPlayer(e, t, s) {
+            return t.length > 0
+                ? this.driver.animate(
+                      e.element,
+                      t,
+                      e.duration,
+                      e.delay,
+                      e.easing,
+                      s
+                  )
+                : new x(e.duration, e.delay);
+        }
+    },
+    oe = class {
+        constructor(e, t, s) {
+            (this.namespaceId = e),
+                (this.triggerName = t),
+                (this.element = s),
+                (this._player = new x()),
+                (this._containsRealPlayer = !1),
+                (this._queuedCallbacks = new Map()),
+                (this.destroyed = !1),
+                (this.parentPlayer = null),
+                (this.markedForDestroy = !1),
+                (this.disabled = !1),
+                (this.queued = !0),
+                (this.totalTime = 0);
+        }
+        setRealPlayer(e) {
+            this._containsRealPlayer ||
+                ((this._player = e),
+                this._queuedCallbacks.forEach((t, s) => {
+                    t.forEach((i) => tt(e, s, void 0, i));
+                }),
+                this._queuedCallbacks.clear(),
+                (this._containsRealPlayer = !0),
+                this.overrideTotalTime(e.totalTime),
+                (this.queued = !1));
+        }
+        getRealPlayer() {
+            return this._player;
+        }
+        overrideTotalTime(e) {
+            this.totalTime = e;
+        }
+        syncPlayerEvents(e) {
+            let t = this._player;
+            t.triggerCallback && e.onStart(() => t.triggerCallback("start")),
+                e.onDone(() => this.finish()),
+                e.onDestroy(() => this.destroy());
+        }
+        _queueEvent(e, t) {
+            L(this._queuedCallbacks, e, []).push(t);
+        }
+        onDone(e) {
+            this.queued && this._queueEvent("done", e), this._player.onDone(e);
+        }
+        onStart(e) {
+            this.queued && this._queueEvent("start", e),
+                this._player.onStart(e);
+        }
+        onDestroy(e) {
+            this.queued && this._queueEvent("destroy", e),
+                this._player.onDestroy(e);
+        }
+        init() {
+            this._player.init();
+        }
+        hasStarted() {
+            return this.queued ? !1 : this._player.hasStarted();
+        }
+        play() {
+            !this.queued && this._player.play();
+        }
+        pause() {
+            !this.queued && this._player.pause();
+        }
+        restart() {
+            !this.queued && this._player.restart();
+        }
+        finish() {
+            this._player.finish();
+        }
+        destroy() {
+            (this.destroyed = !0), this._player.destroy();
+        }
+        reset() {
+            !this.queued && this._player.reset();
+        }
+        setPosition(e) {
+            this.queued || this._player.setPosition(e);
+        }
+        getPosition() {
+            return this.queued ? 0 : this._player.getPosition();
+        }
+        triggerCallback(e) {
+            let t = this._player;
+            t.triggerCallback && t.triggerCallback(e);
+        }
+    };
+function ci(n, e, t) {
+    let s = n.get(e);
+    if (s) {
+        if (s.length) {
+            let i = s.indexOf(t);
+            s.splice(i, 1);
+        }
+        s.length == 0 && n.delete(e);
+    }
+    return s;
+}
+function fi(n) {
+    return n ?? null;
+}
+function me(n) {
+    return n && n.nodeType === 1;
+}
+function di(n) {
+    return n == "start" || n == "done";
+}
+function kt(n, e) {
+    let t = n.style.display;
+    return (n.style.display = e ?? "none"), t;
+}
+function Dt(n, e, t, s, i) {
+    let r = [];
+    t.forEach((l) => r.push(kt(l)));
+    let a = [];
+    s.forEach((l, h) => {
+        let c = new Map();
+        l.forEach((u) => {
+            let _ = e.computeStyle(h, u, i);
+            c.set(u, _), (!_ || _.length == 0) && ((h[z] = ui), a.push(h));
+        }),
+            n.set(h, c);
+    });
+    let o = 0;
+    return t.forEach((l) => kt(l, r[o++])), a;
+}
+function Rt(n, e) {
+    let t = new Map();
+    if ((n.forEach((o) => t.set(o, [])), e.length == 0)) return t;
+    let s = 1,
+        i = new Set(e),
+        r = new Map();
+    function a(o) {
+        if (!o) return s;
+        let l = r.get(o);
+        if (l) return l;
+        let h = o.parentNode;
+        return (
+            t.has(h) ? (l = h) : i.has(h) ? (l = s) : (l = a(h)), r.set(o, l), l
+        );
+    }
+    return (
+        e.forEach((o) => {
+            let l = a(o);
+            l !== s && t.get(l).push(o);
+        }),
+        t
+    );
+}
+function I(n, e) {
+    n.classList?.add(e);
+}
+function ee(n, e) {
+    n.classList?.remove(e);
+}
+function mi(n, e, t) {
+    U(t).onDone(() => n.processLeaveNode(e));
+}
+function pi(n) {
+    let e = [];
+    return jt(n, e), e;
+}
+function jt(n, e) {
+    for (let t = 0; t < n.length; t++) {
+        let s = n[t];
+        s instanceof Ce ? jt(s.players, e) : e.push(s);
+    }
+}
+function gi(n, e) {
+    let t = Object.keys(n),
+        s = Object.keys(e);
+    if (t.length != s.length) return !1;
+    for (let i = 0; i < t.length; i++) {
+        let r = t[i];
+        if (!e.hasOwnProperty(r) || n[r] !== e[r]) return !1;
+    }
+    return !0;
+}
+function Ot(n, e, t) {
+    let s = t.get(n);
+    if (!s) return !1;
+    let i = e.get(n);
+    return i ? s.forEach((r) => i.add(r)) : e.set(n, s), t.delete(n), !0;
+}
+var we = class {
+    constructor(e, t, s, i) {
+        (this._driver = t),
+            (this._normalizer = s),
+            (this._triggerCache = {}),
+            (this.onRemovalComplete = (r, a) => {}),
+            (this._transitionEngine = new Ze(e.body, t, s, i)),
+            (this._timelineEngine = new Ye(e.body, t, s)),
+            (this._transitionEngine.onRemovalComplete = (r, a) =>
+                this.onRemovalComplete(r, a));
+    }
+    registerTrigger(e, t, s, i, r) {
+        let a = e + "-" + i,
+            o = this._triggerCache[a];
+        if (!o) {
+            let l = [],
+                h = [],
+                c = ot(this._driver, r, l, h);
+            if (l.length) throw ps(i, l);
+            h.length && void 0,
+                (o = si(i, c, this._normalizer)),
+                (this._triggerCache[a] = o);
+        }
+        this._transitionEngine.registerTrigger(t, i, o);
+    }
+    register(e, t) {
+        this._transitionEngine.register(e, t);
+    }
+    destroy(e, t) {
+        this._transitionEngine.destroy(e, t);
+    }
+    onInsert(e, t, s, i) {
+        this._transitionEngine.insertNode(e, t, s, i);
+    }
+    onRemove(e, t, s) {
+        this._transitionEngine.removeNode(e, t, s);
+    }
+    disableAnimations(e, t) {
+        this._transitionEngine.markElementAsDisabled(e, t);
+    }
+    process(e, t, s, i) {
+        if (s.charAt(0) == "@") {
+            let [r, a] = Et(s),
+                o = i;
+            this._timelineEngine.command(r, t, a, o);
+        } else this._transitionEngine.trigger(e, t, s, i);
+    }
+    listen(e, t, s, i, r) {
+        if (s.charAt(0) == "@") {
+            let [a, o] = Et(s);
+            return this._timelineEngine.listen(a, t, o, r);
+        }
+        return this._transitionEngine.listen(e, t, s, i, r);
+    }
+    flush(e = -1) {
+        this._transitionEngine.flush(e);
+    }
+    get players() {
+        return [
+            ...this._transitionEngine.players,
+            ...this._timelineEngine.players,
+        ];
+    }
+    whenRenderingDone() {
+        return this._transitionEngine.whenRenderingDone();
+    }
+    afterFlushAnimationsDone(e) {
+        this._transitionEngine.afterFlushAnimationsDone(e);
+    }
+};
+function yi(n, e) {
+    let t = null,
+        s = null;
+    return (
+        Array.isArray(e) && e.length
+            ? ((t = Fe(e[0])), e.length > 1 && (s = Fe(e[e.length - 1])))
+            : e instanceof Map && (t = Fe(e)),
+        t || s ? new Je(n, t, s) : null
+    );
+}
+var te = class te {
+    constructor(e, t, s) {
+        (this._element = e),
+            (this._startStyles = t),
+            (this._endStyles = s),
+            (this._state = 0);
+        let i = te.initialStylesByElement.get(e);
+        i || te.initialStylesByElement.set(e, (i = new Map())),
+            (this._initialStyles = i);
+    }
+    start() {
+        this._state < 1 &&
+            (this._startStyles &&
+                Q(this._element, this._startStyles, this._initialStyles),
+            (this._state = 1));
+    }
+    finish() {
+        this.start(),
+            this._state < 2 &&
+                (Q(this._element, this._initialStyles),
+                this._endStyles &&
+                    (Q(this._element, this._endStyles),
+                    (this._endStyles = null)),
+                (this._state = 1));
+    }
+    destroy() {
+        this.finish(),
+            this._state < 3 &&
+                (te.initialStylesByElement.delete(this._element),
+                this._startStyles &&
+                    (X(this._element, this._startStyles),
+                    (this._endStyles = null)),
+                this._endStyles &&
+                    (X(this._element, this._endStyles),
+                    (this._endStyles = null)),
+                Q(this._element, this._initialStyles),
+                (this._state = 3));
+    }
+};
+te.initialStylesByElement = new WeakMap();
+var Je = te;
+function Fe(n) {
+    let e = null;
+    return (
+        n.forEach((t, s) => {
+            _i(s) && ((e = e || new Map()), e.set(s, t));
+        }),
+        e
+    );
+}
+function _i(n) {
+    return n === "display" || n === "position";
+}
+var be = class {
+        constructor(e, t, s, i) {
+            (this.element = e),
+                (this.keyframes = t),
+                (this.options = s),
+                (this._specialStyles = i),
+                (this._onDoneFns = []),
+                (this._onStartFns = []),
+                (this._onDestroyFns = []),
+                (this._initialized = !1),
+                (this._finished = !1),
+                (this._started = !1),
+                (this._destroyed = !1),
+                (this._originalOnDoneFns = []),
+                (this._originalOnStartFns = []),
+                (this.time = 0),
+                (this.parentPlayer = null),
+                (this.currentSnapshot = new Map()),
+                (this._duration = s.duration),
+                (this._delay = s.delay || 0),
+                (this.time = this._duration + this._delay);
+        }
+        _onFinish() {
+            this._finished ||
+                ((this._finished = !0),
+                this._onDoneFns.forEach((e) => e()),
+                (this._onDoneFns = []));
+        }
+        init() {
+            this._buildPlayer(), this._preparePlayerBeforeStart();
+        }
+        _buildPlayer() {
+            if (this._initialized) return;
+            this._initialized = !0;
+            let e = this.keyframes;
+            (this.domPlayer = this._triggerWebAnimation(
+                this.element,
+                e,
+                this.options
+            )),
+                (this._finalKeyframe = e.length ? e[e.length - 1] : new Map());
+            let t = () => this._onFinish();
+            this.domPlayer.addEventListener("finish", t),
+                this.onDestroy(() => {
+                    this.domPlayer.removeEventListener("finish", t);
+                });
+        }
+        _preparePlayerBeforeStart() {
+            this._delay ? this._resetDomPlayerState() : this.domPlayer.pause();
+        }
+        _convertKeyframesToObject(e) {
+            let t = [];
+            return (
+                e.forEach((s) => {
+                    t.push(Object.fromEntries(s));
+                }),
+                t
+            );
+        }
+        _triggerWebAnimation(e, t, s) {
+            return e.animate(this._convertKeyframesToObject(t), s);
+        }
+        onStart(e) {
+            this._originalOnStartFns.push(e), this._onStartFns.push(e);
+        }
+        onDone(e) {
+            this._originalOnDoneFns.push(e), this._onDoneFns.push(e);
+        }
+        onDestroy(e) {
+            this._onDestroyFns.push(e);
+        }
+        play() {
+            this._buildPlayer(),
+                this.hasStarted() ||
+                    (this._onStartFns.forEach((e) => e()),
+                    (this._onStartFns = []),
+                    (this._started = !0),
+                    this._specialStyles && this._specialStyles.start()),
+                this.domPlayer.play();
+        }
+        pause() {
+            this.init(), this.domPlayer.pause();
+        }
+        finish() {
+            this.init(),
+                this._specialStyles && this._specialStyles.finish(),
+                this._onFinish(),
+                this.domPlayer.finish();
+        }
+        reset() {
+            this._resetDomPlayerState(),
+                (this._destroyed = !1),
+                (this._finished = !1),
+                (this._started = !1),
+                (this._onStartFns = this._originalOnStartFns),
+                (this._onDoneFns = this._originalOnDoneFns);
+        }
+        _resetDomPlayerState() {
+            this.domPlayer && this.domPlayer.cancel();
+        }
+        restart() {
+            this.reset(), this.play();
+        }
+        hasStarted() {
+            return this._started;
+        }
+        destroy() {
+            this._destroyed ||
+                ((this._destroyed = !0),
+                this._resetDomPlayerState(),
+                this._onFinish(),
+                this._specialStyles && this._specialStyles.destroy(),
+                this._onDestroyFns.forEach((e) => e()),
+                (this._onDestroyFns = []));
+        }
+        setPosition(e) {
+            this.domPlayer === void 0 && this.init(),
+                (this.domPlayer.currentTime = e * this.time);
+        }
+        getPosition() {
+            return +(this.domPlayer.currentTime ?? 0) / this.time;
+        }
+        get totalTime() {
+            return this._delay + this._duration;
+        }
+        beforeDestroy() {
+            let e = new Map();
+            this.hasStarted() &&
+                this._finalKeyframe.forEach((s, i) => {
+                    i !== "offset" &&
+                        e.set(i, this._finished ? s : at(this.element, i));
+                }),
+                (this.currentSnapshot = e);
+        }
+        triggerCallback(e) {
+            let t = e === "start" ? this._onStartFns : this._onDoneFns;
+            t.forEach((s) => s()), (t.length = 0);
+        }
+    },
+    xe = class {
+        validateStyleProperty(e) {
+            return !0;
+        }
+        validateAnimatableStyleProperty(e) {
+            return !0;
+        }
+        matchesElement(e, t) {
+            return !1;
+        }
+        containsElement(e, t) {
+            return zt(e, t);
+        }
+        getParentElement(e) {
+            return it(e);
+        }
+        query(e, t, s) {
+            return Kt(e, t, s);
+        }
+        computeStyle(e, t, s) {
+            return at(e, t);
+        }
+        animate(e, t, s, i, r, a = []) {
+            let o = i == 0 ? "both" : "forwards",
+                l = { duration: s, delay: i, fill: o };
+            r && (l.easing = r);
+            let h = new Map(),
+                c = a.filter((y) => y instanceof be);
+            Ks(s, i) &&
+                c.forEach((y) => {
+                    y.currentSnapshot.forEach((d, g) => h.set(g, d));
+                });
+            let u = Fs(t).map((y) => new Map(y));
+            u = qs(e, u, h);
+            let _ = yi(e, u);
+            return new be(e, u, l, _);
+        }
+    };
+function Ni(n, e, t) {
+    return n === "noop"
+        ? new we(e, new qt(), new ze(), t)
+        : new we(e, new xe(), new Qe(), t);
+}
+var Lt = class {
+        constructor(e, t) {
+            this._driver = e;
+            let s = [],
+                i = [],
+                r = ot(e, t, s, i);
+            if (s.length) throw ds(s);
+            i.length && void 0, (this._animationAst = r);
+        }
+        buildTimelines(e, t, s, i, r) {
+            let a = Array.isArray(t) ? wt(t) : t,
+                o = Array.isArray(s) ? wt(s) : s,
+                l = [];
+            r = r || new se();
+            let h = ht(
+                this._driver,
+                e,
+                this._animationAst,
+                nt,
+                ge,
+                a,
+                o,
+                i,
+                r,
+                l
+            );
+            if (l.length) throw ms(l);
+            return h;
+        }
+    },
+    pe = "@",
+    Wt = "@.disabled",
+    Ae = class {
+        constructor(e, t, s, i) {
+            (this.namespaceId = e),
+                (this.delegate = t),
+                (this.engine = s),
+                (this._onDestroy = i),
+                (this.ɵtype = 0);
+        }
+        get data() {
+            return this.delegate.data;
+        }
+        destroyNode(e) {
+            this.delegate.destroyNode?.(e);
+        }
+        destroy() {
+            this.engine.destroy(this.namespaceId, this.delegate),
+                this.engine.afterFlushAnimationsDone(() => {
+                    queueMicrotask(() => {
+                        this.delegate.destroy();
+                    });
+                }),
+                this._onDestroy?.();
+        }
+        createElement(e, t) {
+            return this.delegate.createElement(e, t);
+        }
+        createComment(e) {
+            return this.delegate.createComment(e);
+        }
+        createText(e) {
+            return this.delegate.createText(e);
+        }
+        appendChild(e, t) {
+            this.delegate.appendChild(e, t),
+                this.engine.onInsert(this.namespaceId, t, e, !1);
+        }
+        insertBefore(e, t, s, i = !0) {
+            this.delegate.insertBefore(e, t, s),
+                this.engine.onInsert(this.namespaceId, t, e, i);
+        }
+        removeChild(e, t, s) {
+            this.engine.onRemove(this.namespaceId, t, this.delegate);
+        }
+        selectRootElement(e, t) {
+            return this.delegate.selectRootElement(e, t);
+        }
+        parentNode(e) {
+            return this.delegate.parentNode(e);
+        }
+        nextSibling(e) {
+            return this.delegate.nextSibling(e);
+        }
+        setAttribute(e, t, s, i) {
+            this.delegate.setAttribute(e, t, s, i);
+        }
+        removeAttribute(e, t, s) {
+            this.delegate.removeAttribute(e, t, s);
+        }
+        addClass(e, t) {
+            this.delegate.addClass(e, t);
+        }
+        removeClass(e, t) {
+            this.delegate.removeClass(e, t);
+        }
+        setStyle(e, t, s, i) {
+            this.delegate.setStyle(e, t, s, i);
+        }
+        removeStyle(e, t, s) {
+            this.delegate.removeStyle(e, t, s);
+        }
+        setProperty(e, t, s) {
+            t.charAt(0) == pe && t == Wt
+                ? this.disableAnimations(e, !!s)
+                : this.delegate.setProperty(e, t, s);
+        }
+        setValue(e, t) {
+            this.delegate.setValue(e, t);
+        }
+        listen(e, t, s) {
+            return this.delegate.listen(e, t, s);
+        }
+        disableAnimations(e, t) {
+            this.engine.disableAnimations(e, t);
+        }
+    },
+    et = class extends Ae {
+        constructor(e, t, s, i, r) {
+            super(t, s, i, r), (this.factory = e), (this.namespaceId = t);
+        }
+        setProperty(e, t, s) {
+            t.charAt(0) == pe
+                ? t.charAt(1) == "." && t == Wt
+                    ? ((s = s === void 0 ? !0 : !!s),
+                      this.disableAnimations(e, s))
+                    : this.engine.process(this.namespaceId, e, t.slice(1), s)
+                : this.delegate.setProperty(e, t, s);
+        }
+        listen(e, t, s) {
+            if (t.charAt(0) == pe) {
+                let i = Ei(e),
+                    r = t.slice(1),
+                    a = "";
+                return (
+                    r.charAt(0) != pe && ([r, a] = Si(r)),
+                    this.engine.listen(this.namespaceId, i, r, a, (o) => {
+                        let l = o._data || -1;
+                        this.factory.scheduleListenerCallback(l, s, o);
+                    })
+                );
+            }
+            return this.delegate.listen(e, t, s);
+        }
+    };
+function Ei(n) {
+    switch (n) {
+        case "body":
+            return document.body;
+        case "document":
+            return document;
+        case "window":
+            return window;
+        default:
+            return n;
+    }
+}
+function Si(n) {
+    let e = n.indexOf("."),
+        t = n.substring(0, e),
+        s = n.slice(e + 1);
+    return [t, s];
+}
+var Ft = class {
+    constructor(e, t, s) {
+        (this.delegate = e),
+            (this.engine = t),
+            (this._zone = s),
+            (this._currentId = 0),
+            (this._microtaskId = 1),
+            (this._animationCallbacksBuffer = []),
+            (this._rendererCache = new Map()),
+            (this._cdRecurDepth = 0),
+            (t.onRemovalComplete = (i, r) => {
+                let a = r?.parentNode(i);
+                a && r.removeChild(a, i);
+            });
+    }
+    createRenderer(e, t) {
+        let s = "",
+            i = this.delegate.createRenderer(e, t);
+        if (!e || !t?.data?.animation) {
+            let h = this._rendererCache,
+                c = h.get(i);
+            if (!c) {
+                let u = () => h.delete(i);
+                (c = new Ae(s, i, this.engine, u)), h.set(i, c);
+            }
+            return c;
+        }
+        let r = t.id,
+            a = t.id + "-" + this._currentId;
+        this._currentId++, this.engine.register(a, e);
+        let o = (h) => {
+            Array.isArray(h)
+                ? h.forEach(o)
+                : this.engine.registerTrigger(r, a, e, h.name, h);
+        };
+        return t.data.animation.forEach(o), new et(this, a, i, this.engine);
+    }
+    begin() {
+        this._cdRecurDepth++, this.delegate.begin && this.delegate.begin();
+    }
+    _scheduleCountTask() {
+        queueMicrotask(() => {
+            this._microtaskId++;
+        });
+    }
+    scheduleListenerCallback(e, t, s) {
+        if (e >= 0 && e < this._microtaskId) {
+            this._zone.run(() => t(s));
+            return;
+        }
+        let i = this._animationCallbacksBuffer;
+        i.length == 0 &&
+            queueMicrotask(() => {
+                this._zone.run(() => {
+                    i.forEach((r) => {
+                        let [a, o] = r;
+                        a(o);
+                    }),
+                        (this._animationCallbacksBuffer = []);
+                });
+            }),
+            i.push([t, s]);
+    }
+    end() {
+        this._cdRecurDepth--,
+            this._cdRecurDepth == 0 &&
+                this._zone.runOutsideAngular(() => {
+                    this._scheduleCountTask(),
+                        this.engine.flush(this._microtaskId);
+                }),
+            this.delegate.end && this.delegate.end();
+    }
+    whenRenderingDone() {
+        return this.engine.whenRenderingDone();
+    }
+};
+export {
+    Tt as AnimationDriver,
+    qt as NoopAnimationDriver,
+    Lt as ɵAnimation,
+    we as ɵAnimationEngine,
+    et as ɵAnimationRenderer,
+    Ft as ɵAnimationRendererFactory,
+    Ie as ɵAnimationStyleNormalizer,
+    Ae as ɵBaseAnimationRenderer,
+    ze as ɵNoopAnimationStyleNormalizer,
+    xe as ɵWebAnimationsDriver,
+    be as ɵWebAnimationsPlayer,
+    Qe as ɵWebAnimationsStyleNormalizer,
+    Ks as ɵallowPreviousPlayerStylesMerge,
+    Pi as ɵcamelCaseToDashCase,
+    zt as ɵcontainsElement,
+    Ni as ɵcreateEngine,
+    it as ɵgetParentElement,
+    Kt as ɵinvokeQuery,
+    Fs as ɵnormalizeKeyframes,
+    ks as ɵvalidateStyleProperty,
+    Ai as ɵvalidateWebAnimatableStyleProperty,
+};

--- a/angularDist/main-F66ZL65X.js
+++ b/angularDist/main-F66ZL65X.js
@@ -1,2 +1,16624 @@
-import{$ as Na,$a as gr,$b as Dt,A as qt,Aa as ja,Ab as Ze,B as dt,Ba as Mi,Bb as gt,Bc as Cr,C as cr,Ca as Va,Cb as Xe,Cc as Wn,D as re,Da as Qt,Db as at,E as se,Ea as Bt,Eb as lt,Ec as ti,F as An,Fa as ki,Fb as he,Fc as Dr,G as dr,Ga as Ye,Gb as F,Gc as Gn,H as ut,Ha as qe,Hb as te,I as Ta,Ia as za,Ib as Oi,J as ur,Ja as Ba,Jb as Xa,K as hr,Ka as Ua,Kb as Ka,L as Zt,La as Ha,Lb as Qa,M as ae,Ma as $a,Mb as Q,N as mr,Na as Wa,Nb as tt,O as Aa,Oa as Ga,Ob as Ni,P as Fa,Pa as Mt,Pb as Ke,Q as Oa,Qa as Se,Qb as Ln,R as Fn,Ra as Ya,Rb as Ja,S as Xt,Sa as Ti,Sb as jn,T as vt,Ta as R,Tb as Vn,U as mt,Ua as u,Ub as yr,V as et,Va as Ie,Vb as zn,W as $,Wa as Ct,Wb as xr,X as le,Xa as qa,Xb as wr,Y as Si,Ya as Nn,Yb as Re,Z as b,Za as Pn,Zb as Bn,_ as E,_a as Ai,_b as tl,a as p,aa as C,ab as I,ac as Me,b as q,ba as fr,bb as br,bc as el,ca as m,cb as kt,cc as il,d as rr,da as g,db as vr,dc as W,e as St,ea as On,eb as U,ec as nl,f as Ra,fa as pr,fb as nt,fc as ol,g as $e,ga as Ii,gb as Za,gc as rl,h as sr,ha as y,hb as _r,hc as ke,i as Ei,ia as P,ib as Fi,ic as sl,j as N,ja as S,jb as ot,jc as al,k as rt,ka as D,kb as ft,kc as T,l as Mn,la as Ge,lb as L,lc as ll,m as oe,ma as Pa,mb as st,mc as Pi,n as ht,na as ce,nb as Jt,nc as cl,o as v,oa as zt,ob as Ut,oc as dl,p as Ce,pa as yt,pb as x,pc as Te,q as We,qa as xt,qb as _,qc as Un,r as Ma,ra as wt,rb as H,rc as Qe,s as M,sa as La,sb as de,sc as Ht,t as Vt,ta as _t,tb as ue,tc as Je,u as Rt,ua as De,ub as It,uc as ul,v as ar,va as Kt,vb as Ft,vc as hl,w as kn,wa as Ee,wb as Z,wc as Hn,x as lr,xa as A,xb as X,xc as ml,y as Tn,ya as it,yb as pt,yc as $n,z as ka,za as Ri,zb as K}from"./chunk-LPDIY7FO.js";var ji=class{},qn=class{},Ae=class n{constructor(t){this.normalizedNames=new Map,this.lazyUpdate=null,t?typeof t=="string"?this.lazyInit=()=>{this.headers=new Map,t.split(`
-`).forEach(o=>{let e=o.indexOf(":");if(e>0){let i=o.slice(0,e),r=i.toLowerCase(),s=o.slice(e+1).trim();this.maybeSetNormalizedName(i,r),this.headers.has(r)?this.headers.get(r).push(s):this.headers.set(r,[s])}})}:typeof Headers<"u"&&t instanceof Headers?(this.headers=new Map,t.forEach((o,e)=>{this.setHeaderEntries(e,o)})):this.lazyInit=()=>{this.headers=new Map,Object.entries(t).forEach(([o,e])=>{this.setHeaderEntries(o,e)})}:this.headers=new Map}has(t){return this.init(),this.headers.has(t.toLowerCase())}get(t){this.init();let o=this.headers.get(t.toLowerCase());return o&&o.length>0?o[0]:null}keys(){return this.init(),Array.from(this.normalizedNames.values())}getAll(t){return this.init(),this.headers.get(t.toLowerCase())||null}append(t,o){return this.clone({name:t,value:o,op:"a"})}set(t,o){return this.clone({name:t,value:o,op:"s"})}delete(t,o){return this.clone({name:t,value:o,op:"d"})}maybeSetNormalizedName(t,o){this.normalizedNames.has(o)||this.normalizedNames.set(o,t)}init(){this.lazyInit&&(this.lazyInit instanceof n?this.copyFrom(this.lazyInit):this.lazyInit(),this.lazyInit=null,this.lazyUpdate&&(this.lazyUpdate.forEach(t=>this.applyUpdate(t)),this.lazyUpdate=null))}copyFrom(t){t.init(),Array.from(t.headers.keys()).forEach(o=>{this.headers.set(o,t.headers.get(o)),this.normalizedNames.set(o,t.normalizedNames.get(o))})}clone(t){let o=new n;return o.lazyInit=this.lazyInit&&this.lazyInit instanceof n?this.lazyInit:this,o.lazyUpdate=(this.lazyUpdate||[]).concat([t]),o}applyUpdate(t){let o=t.name.toLowerCase();switch(t.op){case"a":case"s":let e=t.value;if(typeof e=="string"&&(e=[e]),e.length===0)return;this.maybeSetNormalizedName(t.name,o);let i=(t.op==="a"?this.headers.get(o):void 0)||[];i.push(...e),this.headers.set(o,i);break;case"d":let r=t.value;if(!r)this.headers.delete(o),this.normalizedNames.delete(o);else{let s=this.headers.get(o);if(!s)return;s=s.filter(a=>r.indexOf(a)===-1),s.length===0?(this.headers.delete(o),this.normalizedNames.delete(o)):this.headers.set(o,s)}break}}setHeaderEntries(t,o){let e=(Array.isArray(o)?o:[o]).map(r=>r.toString()),i=t.toLowerCase();this.headers.set(i,e),this.maybeSetNormalizedName(t,i)}forEach(t){this.init(),Array.from(this.normalizedNames.keys()).forEach(o=>t(this.normalizedNames.get(o),this.headers.get(o)))}};var Sr=class{encodeKey(t){return fl(t)}encodeValue(t){return fl(t)}decodeKey(t){return decodeURIComponent(t)}decodeValue(t){return decodeURIComponent(t)}};function Lu(n,t){let o=new Map;return n.length>0&&n.replace(/^\?/,"").split("&").forEach(i=>{let r=i.indexOf("="),[s,a]=r==-1?[t.decodeKey(i),""]:[t.decodeKey(i.slice(0,r)),t.decodeValue(i.slice(r+1))],l=o.get(s)||[];l.push(a),o.set(s,l)}),o}var ju=/%(\d[a-f0-9])/gi,Vu={40:"@","3A":":",24:"$","2C":",","3B":";","3D":"=","3F":"?","2F":"/"};function fl(n){return encodeURIComponent(n).replace(ju,(t,o)=>Vu[o]??t)}function Yn(n){return`${n}`}var me=class n{constructor(t={}){if(this.updates=null,this.cloneFrom=null,this.encoder=t.encoder||new Sr,t.fromString){if(t.fromObject)throw new Error("Cannot specify both fromString and fromObject.");this.map=Lu(t.fromString,this.encoder)}else t.fromObject?(this.map=new Map,Object.keys(t.fromObject).forEach(o=>{let e=t.fromObject[o],i=Array.isArray(e)?e.map(Yn):[Yn(e)];this.map.set(o,i)})):this.map=null}has(t){return this.init(),this.map.has(t)}get(t){this.init();let o=this.map.get(t);return o?o[0]:null}getAll(t){return this.init(),this.map.get(t)||null}keys(){return this.init(),Array.from(this.map.keys())}append(t,o){return this.clone({param:t,value:o,op:"a"})}appendAll(t){let o=[];return Object.keys(t).forEach(e=>{let i=t[e];Array.isArray(i)?i.forEach(r=>{o.push({param:e,value:r,op:"a"})}):o.push({param:e,value:i,op:"a"})}),this.clone(o)}set(t,o){return this.clone({param:t,value:o,op:"s"})}delete(t,o){return this.clone({param:t,value:o,op:"d"})}toString(){return this.init(),this.keys().map(t=>{let o=this.encoder.encodeKey(t);return this.map.get(t).map(e=>o+"="+this.encoder.encodeValue(e)).join("&")}).filter(t=>t!=="").join("&")}clone(t){let o=new n({encoder:this.encoder});return o.cloneFrom=this.cloneFrom||this,o.updates=(this.updates||[]).concat(t),o}init(){this.map===null&&(this.map=new Map),this.cloneFrom!==null&&(this.cloneFrom.init(),this.cloneFrom.keys().forEach(t=>this.map.set(t,this.cloneFrom.map.get(t))),this.updates.forEach(t=>{switch(t.op){case"a":case"s":let o=(t.op==="a"?this.map.get(t.param):void 0)||[];o.push(Yn(t.value)),this.map.set(t.param,o);break;case"d":if(t.value!==void 0){let e=this.map.get(t.param)||[],i=e.indexOf(Yn(t.value));i!==-1&&e.splice(i,1),e.length>0?this.map.set(t.param,e):this.map.delete(t.param)}else{this.map.delete(t.param);break}}}),this.cloneFrom=this.updates=null)}};var Ir=class{constructor(){this.map=new Map}set(t,o){return this.map.set(t,o),this}get(t){return this.map.has(t)||this.map.set(t,t.defaultValue()),this.map.get(t)}delete(t){return this.map.delete(t),this}has(t){return this.map.has(t)}keys(){return this.map.keys()}};function zu(n){switch(n){case"DELETE":case"GET":case"HEAD":case"OPTIONS":case"JSONP":return!1;default:return!0}}function pl(n){return typeof ArrayBuffer<"u"&&n instanceof ArrayBuffer}function gl(n){return typeof Blob<"u"&&n instanceof Blob}function bl(n){return typeof FormData<"u"&&n instanceof FormData}function Bu(n){return typeof URLSearchParams<"u"&&n instanceof URLSearchParams}var Li=class n{constructor(t,o,e,i){this.url=o,this.body=null,this.reportProgress=!1,this.withCredentials=!1,this.responseType="json",this.method=t.toUpperCase();let r;if(zu(this.method)||i?(this.body=e!==void 0?e:null,r=i):r=e,r&&(this.reportProgress=!!r.reportProgress,this.withCredentials=!!r.withCredentials,r.responseType&&(this.responseType=r.responseType),r.headers&&(this.headers=r.headers),r.context&&(this.context=r.context),r.params&&(this.params=r.params),this.transferCache=r.transferCache),this.headers??=new Ae,this.context??=new Ir,!this.params)this.params=new me,this.urlWithParams=o;else{let s=this.params.toString();if(s.length===0)this.urlWithParams=o;else{let a=o.indexOf("?"),l=a===-1?"?":a<o.length-1?"&":"";this.urlWithParams=o+l+s}}}serializeBody(){return this.body===null?null:typeof this.body=="string"||pl(this.body)||gl(this.body)||bl(this.body)||Bu(this.body)?this.body:this.body instanceof me?this.body.toString():typeof this.body=="object"||typeof this.body=="boolean"||Array.isArray(this.body)?JSON.stringify(this.body):this.body.toString()}detectContentTypeHeader(){return this.body===null||bl(this.body)?null:gl(this.body)?this.body.type||null:pl(this.body)?null:typeof this.body=="string"?"text/plain":this.body instanceof me?"application/x-www-form-urlencoded;charset=UTF-8":typeof this.body=="object"||typeof this.body=="number"||typeof this.body=="boolean"?"application/json":null}clone(t={}){let o=t.method||this.method,e=t.url||this.url,i=t.responseType||this.responseType,r=t.transferCache??this.transferCache,s=t.body!==void 0?t.body:this.body,a=t.withCredentials??this.withCredentials,l=t.reportProgress??this.reportProgress,c=t.headers||this.headers,d=t.params||this.params,h=t.context??this.context;return t.setHeaders!==void 0&&(c=Object.keys(t.setHeaders).reduce((f,w)=>f.set(w,t.setHeaders[w]),c)),t.setParams&&(d=Object.keys(t.setParams).reduce((f,w)=>f.set(w,t.setParams[w]),d)),new n(o,e,s,{params:d,headers:c,context:h,reportProgress:l,responseType:i,withCredentials:a,transferCache:r})}},ei=function(n){return n[n.Sent=0]="Sent",n[n.UploadProgress=1]="UploadProgress",n[n.ResponseHeader=2]="ResponseHeader",n[n.DownloadProgress=3]="DownloadProgress",n[n.Response=4]="Response",n[n.User=5]="User",n}(ei||{}),Vi=class{constructor(t,o=Kn.Ok,e="OK"){this.headers=t.headers||new Ae,this.status=t.status!==void 0?t.status:o,this.statusText=t.statusText||e,this.url=t.url||null,this.ok=this.status>=200&&this.status<300}},Rr=class n extends Vi{constructor(t={}){super(t),this.type=ei.ResponseHeader}clone(t={}){return new n({headers:t.headers||this.headers,status:t.status!==void 0?t.status:this.status,statusText:t.statusText||this.statusText,url:t.url||this.url||void 0})}},Zn=class n extends Vi{constructor(t={}){super(t),this.type=ei.Response,this.body=t.body!==void 0?t.body:null}clone(t={}){return new n({body:t.body!==void 0?t.body:this.body,headers:t.headers||this.headers,status:t.status!==void 0?t.status:this.status,statusText:t.statusText||this.statusText,url:t.url||this.url||void 0})}},Xn=class extends Vi{constructor(t){super(t,0,"Unknown Error"),this.name="HttpErrorResponse",this.ok=!1,this.status>=200&&this.status<300?this.message=`Http failure during parsing for ${t.url||"(unknown url)"}`:this.message=`Http failure response for ${t.url||"(unknown url)"}: ${t.status} ${t.statusText}`,this.error=t.error||null}},Kn=function(n){return n[n.Continue=100]="Continue",n[n.SwitchingProtocols=101]="SwitchingProtocols",n[n.Processing=102]="Processing",n[n.EarlyHints=103]="EarlyHints",n[n.Ok=200]="Ok",n[n.Created=201]="Created",n[n.Accepted=202]="Accepted",n[n.NonAuthoritativeInformation=203]="NonAuthoritativeInformation",n[n.NoContent=204]="NoContent",n[n.ResetContent=205]="ResetContent",n[n.PartialContent=206]="PartialContent",n[n.MultiStatus=207]="MultiStatus",n[n.AlreadyReported=208]="AlreadyReported",n[n.ImUsed=226]="ImUsed",n[n.MultipleChoices=300]="MultipleChoices",n[n.MovedPermanently=301]="MovedPermanently",n[n.Found=302]="Found",n[n.SeeOther=303]="SeeOther",n[n.NotModified=304]="NotModified",n[n.UseProxy=305]="UseProxy",n[n.Unused=306]="Unused",n[n.TemporaryRedirect=307]="TemporaryRedirect",n[n.PermanentRedirect=308]="PermanentRedirect",n[n.BadRequest=400]="BadRequest",n[n.Unauthorized=401]="Unauthorized",n[n.PaymentRequired=402]="PaymentRequired",n[n.Forbidden=403]="Forbidden",n[n.NotFound=404]="NotFound",n[n.MethodNotAllowed=405]="MethodNotAllowed",n[n.NotAcceptable=406]="NotAcceptable",n[n.ProxyAuthenticationRequired=407]="ProxyAuthenticationRequired",n[n.RequestTimeout=408]="RequestTimeout",n[n.Conflict=409]="Conflict",n[n.Gone=410]="Gone",n[n.LengthRequired=411]="LengthRequired",n[n.PreconditionFailed=412]="PreconditionFailed",n[n.PayloadTooLarge=413]="PayloadTooLarge",n[n.UriTooLong=414]="UriTooLong",n[n.UnsupportedMediaType=415]="UnsupportedMediaType",n[n.RangeNotSatisfiable=416]="RangeNotSatisfiable",n[n.ExpectationFailed=417]="ExpectationFailed",n[n.ImATeapot=418]="ImATeapot",n[n.MisdirectedRequest=421]="MisdirectedRequest",n[n.UnprocessableEntity=422]="UnprocessableEntity",n[n.Locked=423]="Locked",n[n.FailedDependency=424]="FailedDependency",n[n.TooEarly=425]="TooEarly",n[n.UpgradeRequired=426]="UpgradeRequired",n[n.PreconditionRequired=428]="PreconditionRequired",n[n.TooManyRequests=429]="TooManyRequests",n[n.RequestHeaderFieldsTooLarge=431]="RequestHeaderFieldsTooLarge",n[n.UnavailableForLegalReasons=451]="UnavailableForLegalReasons",n[n.InternalServerError=500]="InternalServerError",n[n.NotImplemented=501]="NotImplemented",n[n.BadGateway=502]="BadGateway",n[n.ServiceUnavailable=503]="ServiceUnavailable",n[n.GatewayTimeout=504]="GatewayTimeout",n[n.HttpVersionNotSupported=505]="HttpVersionNotSupported",n[n.VariantAlsoNegotiates=506]="VariantAlsoNegotiates",n[n.InsufficientStorage=507]="InsufficientStorage",n[n.LoopDetected=508]="LoopDetected",n[n.NotExtended=510]="NotExtended",n[n.NetworkAuthenticationRequired=511]="NetworkAuthenticationRequired",n}(Kn||{});function Er(n,t){return{body:t,headers:n.headers,context:n.context,observe:n.observe,params:n.params,reportProgress:n.reportProgress,responseType:n.responseType,withCredentials:n.withCredentials,transferCache:n.transferCache}}var Oe=(()=>{let t=class t{constructor(e){this.handler=e}request(e,i,r={}){let s;if(e instanceof Li)s=e;else{let c;r.headers instanceof Ae?c=r.headers:c=new Ae(r.headers);let d;r.params&&(r.params instanceof me?d=r.params:d=new me({fromObject:r.params})),s=new Li(e,i,r.body!==void 0?r.body:null,{headers:c,context:r.context,params:d,reportProgress:r.reportProgress,responseType:r.responseType||"json",withCredentials:r.withCredentials,transferCache:r.transferCache})}let a=v(s).pipe(se(c=>this.handler.handle(c)));if(e instanceof Li||r.observe==="events")return a;let l=a.pipe(dt(c=>c instanceof Zn));switch(r.observe||"body"){case"body":switch(s.responseType){case"arraybuffer":return l.pipe(M(c=>{if(c.body!==null&&!(c.body instanceof ArrayBuffer))throw new Error("Response is not an ArrayBuffer.");return c.body}));case"blob":return l.pipe(M(c=>{if(c.body!==null&&!(c.body instanceof Blob))throw new Error("Response is not a Blob.");return c.body}));case"text":return l.pipe(M(c=>{if(c.body!==null&&typeof c.body!="string")throw new Error("Response is not a string.");return c.body}));case"json":default:return l.pipe(M(c=>c.body))}case"response":return l;default:throw new Error(`Unreachable: unhandled observe type ${r.observe}}`)}}delete(e,i={}){return this.request("DELETE",e,i)}get(e,i={}){return this.request("GET",e,i)}head(e,i={}){return this.request("HEAD",e,i)}jsonp(e,i){return this.request("JSONP",e,{params:new me().append(i,"JSONP_CALLBACK"),observe:"body",responseType:"json"})}options(e,i={}){return this.request("OPTIONS",e,i)}patch(e,i,r={}){return this.request("PATCH",e,Er(r,i))}post(e,i,r={}){return this.request("POST",e,Er(r,i))}put(e,i,r={}){return this.request("PUT",e,Er(r,i))}};t.\u0275fac=function(i){return new(i||t)(m(ji))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})();function xl(n,t){return t(n)}function Uu(n,t){return(o,e)=>t.intercept(o,{handle:i=>n(i,e)})}function Hu(n,t,o){return(e,i)=>zt(o,()=>t(e,r=>n(r,i)))}var $u=new C(""),Mr=new C(""),Wu=new C(""),Gu=new C("");function Yu(){let n=null;return(t,o)=>{n===null&&(n=(g($u,{optional:!0})??[]).reduceRight(Uu,xl));let e=g(Fi),i=e.add();return n(t,o).pipe(Zt(()=>e.remove(i)))}}var vl=(()=>{let t=class t extends ji{constructor(e,i){super(),this.backend=e,this.injector=i,this.chain=null,this.pendingTasks=g(Fi);let r=g(Gu,{optional:!0});this.backend=r??e}handle(e){if(this.chain===null){let r=Array.from(new Set([...this.injector.get(Mr),...this.injector.get(Wu,[])]));this.chain=r.reduceRight((s,a)=>Hu(s,a,this.injector),xl)}let i=this.pendingTasks.add();return this.chain(e,r=>this.backend.handle(r)).pipe(Zt(()=>this.pendingTasks.remove(i)))}};t.\u0275fac=function(i){return new(i||t)(m(qn),m(ce))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})();var qu=/^\)\]\}',?\n/;function Zu(n){return"responseURL"in n&&n.responseURL?n.responseURL:/^X-Request-URL:/m.test(n.getAllResponseHeaders())?n.getResponseHeader("X-Request-URL"):null}var _l=(()=>{let t=class t{constructor(e){this.xhrFactory=e}handle(e){if(e.method==="JSONP")throw new $(-2800,!1);let i=this.xhrFactory;return(i.\u0275loadImpl?ht(i.\u0275loadImpl()):v(null)).pipe(vt(()=>new $e(s=>{let a=i.build();if(a.open(e.method,e.urlWithParams),e.withCredentials&&(a.withCredentials=!0),e.headers.forEach((k,V)=>a.setRequestHeader(k,V.join(","))),e.headers.has("Accept")||a.setRequestHeader("Accept","application/json, text/plain, */*"),!e.headers.has("Content-Type")){let k=e.detectContentTypeHeader();k!==null&&a.setRequestHeader("Content-Type",k)}if(e.responseType){let k=e.responseType.toLowerCase();a.responseType=k!=="json"?k:"text"}let l=e.serializeBody(),c=null,d=()=>{if(c!==null)return c;let k=a.statusText||"OK",V=new Ae(a.getAllResponseHeaders()),Pt=Zu(a)||e.url;return c=new Rr({headers:V,status:a.status,statusText:k,url:Pt}),c},h=()=>{let{headers:k,status:V,statusText:Pt,url:Ia}=d(),Et=null;V!==Kn.NoContent&&(Et=typeof a.response>"u"?a.responseText:a.response),V===0&&(V=Et?Kn.Ok:0);let or=V>=200&&V<300;if(e.responseType==="json"&&typeof Et=="string"){let Au=Et;Et=Et.replace(qu,"");try{Et=Et!==""?JSON.parse(Et):null}catch(Fu){Et=Au,or&&(or=!1,Et={error:Fu,text:Et})}}or?(s.next(new Zn({body:Et,headers:k,status:V,statusText:Pt,url:Ia||void 0})),s.complete()):s.error(new Xn({error:Et,headers:k,status:V,statusText:Pt,url:Ia||void 0}))},f=k=>{let{url:V}=d(),Pt=new Xn({error:k,status:a.status||0,statusText:a.statusText||"Unknown Error",url:V||void 0});s.error(Pt)},w=!1,j=k=>{w||(s.next(d()),w=!0);let V={type:ei.DownloadProgress,loaded:k.loaded};k.lengthComputable&&(V.total=k.total),e.responseType==="text"&&a.responseText&&(V.partialText=a.responseText),s.next(V)},z=k=>{let V={type:ei.UploadProgress,loaded:k.loaded};k.lengthComputable&&(V.total=k.total),s.next(V)};return a.addEventListener("load",h),a.addEventListener("error",f),a.addEventListener("timeout",f),a.addEventListener("abort",f),e.reportProgress&&(a.addEventListener("progress",j),l!==null&&a.upload&&a.upload.addEventListener("progress",z)),a.send(l),s.next({type:ei.Sent}),()=>{a.removeEventListener("error",f),a.removeEventListener("abort",f),a.removeEventListener("load",h),a.removeEventListener("timeout",f),e.reportProgress&&(a.removeEventListener("progress",j),l!==null&&a.upload&&a.upload.removeEventListener("progress",z)),a.readyState!==a.DONE&&a.abort()}})))}};t.\u0275fac=function(i){return new(i||t)(m($n))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})(),wl=new C(""),Xu="XSRF-TOKEN",Ku=new C("",{providedIn:"root",factory:()=>Xu}),Qu="X-XSRF-TOKEN",Ju=new C("",{providedIn:"root",factory:()=>Qu}),Qn=class{},th=(()=>{let t=class t{constructor(e,i,r){this.doc=e,this.platform=i,this.cookieName=r,this.lastCookieString="",this.lastToken=null,this.parseCount=0}getToken(){if(this.platform==="server")return null;let e=this.doc.cookie||"";return e!==this.lastCookieString&&(this.parseCount++,this.lastToken=Un(e,this.cookieName),this.lastCookieString=e),this.lastToken}};t.\u0275fac=function(i){return new(i||t)(m(T),m(Qt),m(Ku))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})();function eh(n,t){let o=n.url.toLowerCase();if(!g(wl)||n.method==="GET"||n.method==="HEAD"||o.startsWith("http://")||o.startsWith("https://"))return t(n);let e=g(Qn).getToken(),i=g(Ju);return e!=null&&!n.headers.has(i)&&(n=n.clone({headers:n.headers.set(i,e)})),t(n)}var Cl=function(n){return n[n.Interceptors=0]="Interceptors",n[n.LegacyInterceptors=1]="LegacyInterceptors",n[n.CustomXsrfConfiguration=2]="CustomXsrfConfiguration",n[n.NoXsrfProtection=3]="NoXsrfProtection",n[n.JsonpSupport=4]="JsonpSupport",n[n.RequestsMadeViaParent=5]="RequestsMadeViaParent",n[n.Fetch=6]="Fetch",n}(Cl||{});function ih(n,t){return{\u0275kind:n,\u0275providers:t}}function nh(...n){let t=[Oe,_l,vl,{provide:ji,useExisting:vl},{provide:qn,useExisting:_l},{provide:Mr,useValue:eh,multi:!0},{provide:wl,useValue:!0},{provide:Qn,useClass:th}];for(let o of n)t.push(...o.\u0275providers);return Ge(t)}var yl=new C("");function oh(){return ih(Cl.LegacyInterceptors,[{provide:yl,useFactory:Yu},{provide:Mr,useExisting:yl,multi:!0}])}var Dl=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({providers:[nh(oh())]});let n=t;return n})();var Fr=class extends al{constructor(){super(...arguments),this.supportsDOMEvents=!0}},Or=class n extends Fr{static makeCurrent(){sl(new n)}onAndCancel(t,o,e){return t.addEventListener(o,e),()=>{t.removeEventListener(o,e)}}dispatchEvent(t,o){t.dispatchEvent(o)}remove(t){t.parentNode&&t.parentNode.removeChild(t)}createElement(t,o){return o=o||this.getDefaultDocument(),o.createElement(t)}createHtmlDocument(){return document.implementation.createHTMLDocument("fakeTitle")}getDefaultDocument(){return document}isElementNode(t){return t.nodeType===Node.ELEMENT_NODE}isShadowRoot(t){return t instanceof DocumentFragment}getGlobalEventTarget(t,o){return o==="window"?window:o==="document"?t:o==="body"?t.body:null}getBaseHref(t){let o=sh();return o==null?null:ah(o)}resetBaseElement(){zi=null}getUserAgent(){return window.navigator.userAgent}getCookie(t){return Un(document.cookie,t)}},zi=null;function sh(){return zi=zi||document.querySelector("base"),zi?zi.getAttribute("href"):null}function ah(n){return new URL(n,document.baseURI).pathname}var Nr=class{addToWindow(t){le.getAngularTestability=(e,i=!0)=>{let r=t.findTestabilityInTree(e,i);if(r==null)throw new $(5103,!1);return r},le.getAllAngularTestabilities=()=>t.getAllTestabilities(),le.getAllAngularRootElements=()=>t.getAllRootElements();let o=e=>{let i=le.getAllAngularTestabilities(),r=i.length,s=function(){r--,r==0&&e()};i.forEach(a=>{a.whenStable(s)})};le.frameworkStabilizers||(le.frameworkStabilizers=[]),le.frameworkStabilizers.push(o)}findTestabilityInTree(t,o,e){if(o==null)return null;let i=t.getTestability(o);return i??(e?ke().isShadowRoot(o)?this.findTestabilityInTree(t,o.host,!0):this.findTestabilityInTree(t,o.parentElement,!0):null)}},lh=(()=>{let t=class t{build(){return new XMLHttpRequest}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})(),Pr=new C(""),Il=(()=>{let t=class t{constructor(e,i){this._zone=i,this._eventNameToPlugin=new Map,e.forEach(r=>{r.manager=this}),this._plugins=e.slice().reverse()}addEventListener(e,i,r){return this._findPluginFor(i).addEventListener(e,i,r)}getZone(){return this._zone}_findPluginFor(e){let i=this._eventNameToPlugin.get(e);if(i)return i;if(i=this._plugins.find(s=>s.supports(e)),!i)throw new $(5101,!1);return this._eventNameToPlugin.set(e,i),i}};t.\u0275fac=function(i){return new(i||t)(m(Pr),m(I))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})(),Jn=class{constructor(t){this._doc=t}},Tr="ng-app-id",Rl=(()=>{let t=class t{constructor(e,i,r,s={}){this.doc=e,this.appId=i,this.nonce=r,this.platformId=s,this.styleRef=new Map,this.hostNodes=new Set,this.styleNodesInDOM=this.collectServerRenderedStyles(),this.platformIsServer=Hn(s),this.resetHostNodes()}addStyles(e){for(let i of e)this.changeUsageCount(i,1)===1&&this.onStyleAdded(i)}removeStyles(e){for(let i of e)this.changeUsageCount(i,-1)<=0&&this.onStyleRemoved(i)}ngOnDestroy(){let e=this.styleNodesInDOM;e&&(e.forEach(i=>i.remove()),e.clear());for(let i of this.getAllStyles())this.onStyleRemoved(i);this.resetHostNodes()}addHost(e){this.hostNodes.add(e);for(let i of this.getAllStyles())this.addStyleToHost(e,i)}removeHost(e){this.hostNodes.delete(e)}getAllStyles(){return this.styleRef.keys()}onStyleAdded(e){for(let i of this.hostNodes)this.addStyleToHost(i,e)}onStyleRemoved(e){let i=this.styleRef;i.get(e)?.elements?.forEach(r=>r.remove()),i.delete(e)}collectServerRenderedStyles(){let e=this.doc.head?.querySelectorAll(`style[${Tr}="${this.appId}"]`);if(e?.length){let i=new Map;return e.forEach(r=>{r.textContent!=null&&i.set(r.textContent,r)}),i}return null}changeUsageCount(e,i){let r=this.styleRef;if(r.has(e)){let s=r.get(e);return s.usage+=i,s.usage}return r.set(e,{usage:i,elements:[]}),i}getStyleElement(e,i){let r=this.styleNodesInDOM,s=r?.get(i);if(s?.parentNode===e)return r.delete(i),s.removeAttribute(Tr),s;{let a=this.doc.createElement("style");return this.nonce&&a.setAttribute("nonce",this.nonce),a.textContent=i,this.platformIsServer&&a.setAttribute(Tr,this.appId),e.appendChild(a),a}}addStyleToHost(e,i){let r=this.getStyleElement(e,i),s=this.styleRef,a=s.get(i)?.elements;a?a.push(r):s.set(i,{elements:[r],usage:1})}resetHostNodes(){let e=this.hostNodes;e.clear(),e.add(this.doc.head)}};t.\u0275fac=function(i){return new(i||t)(m(T),m(Mi),m(ki,8),m(Qt))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})(),Ar={svg:"http://www.w3.org/2000/svg",xhtml:"http://www.w3.org/1999/xhtml",xlink:"http://www.w3.org/1999/xlink",xml:"http://www.w3.org/XML/1998/namespace",xmlns:"http://www.w3.org/2000/xmlns/",math:"http://www.w3.org/1998/MathML/"},Vr=/%COMP%/g,Ml="%COMP%",ch=`_nghost-${Ml}`,dh=`_ngcontent-${Ml}`,uh=!0,hh=new C("",{providedIn:"root",factory:()=>uh});function mh(n){return dh.replace(Vr,n)}function fh(n){return ch.replace(Vr,n)}function kl(n,t){return t.map(o=>o.replace(Vr,n))}var to=(()=>{let t=class t{constructor(e,i,r,s,a,l,c,d=null){this.eventManager=e,this.sharedStylesHost=i,this.appId=r,this.removeStylesOnCompDestroy=s,this.doc=a,this.platformId=l,this.ngZone=c,this.nonce=d,this.rendererByCompId=new Map,this.platformIsServer=Hn(l),this.defaultRenderer=new Bi(e,a,c,this.platformIsServer)}createRenderer(e,i){if(!e||!i)return this.defaultRenderer;this.platformIsServer&&i.encapsulation===Ii.ShadowDom&&(i=q(p({},i),{encapsulation:Ii.Emulated}));let r=this.getOrCreateRenderer(e,i);return r instanceof eo?r.applyToHost(e):r instanceof Ui&&r.applyStyles(),r}getOrCreateRenderer(e,i){let r=this.rendererByCompId,s=r.get(i.id);if(!s){let a=this.doc,l=this.ngZone,c=this.eventManager,d=this.sharedStylesHost,h=this.removeStylesOnCompDestroy,f=this.platformIsServer;switch(i.encapsulation){case Ii.Emulated:s=new eo(c,d,i,this.appId,h,a,l,f);break;case Ii.ShadowDom:return new Lr(c,d,e,i,a,l,this.nonce,f);default:s=new Ui(c,d,i,h,a,l,f);break}r.set(i.id,s)}return s}ngOnDestroy(){this.rendererByCompId.clear()}};t.\u0275fac=function(i){return new(i||t)(m(Il),m(Rl),m(Mi),m(hh),m(T),m(Qt),m(I),m(ki))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})(),Bi=class{constructor(t,o,e,i){this.eventManager=t,this.doc=o,this.ngZone=e,this.platformIsServer=i,this.data=Object.create(null),this.throwOnSyntheticProps=!0,this.destroyNode=null}destroy(){}createElement(t,o){return o?this.doc.createElementNS(Ar[o]||o,t):this.doc.createElement(t)}createComment(t){return this.doc.createComment(t)}createText(t){return this.doc.createTextNode(t)}appendChild(t,o){(El(t)?t.content:t).appendChild(o)}insertBefore(t,o,e){t&&(El(t)?t.content:t).insertBefore(o,e)}removeChild(t,o){t&&t.removeChild(o)}selectRootElement(t,o){let e=typeof t=="string"?this.doc.querySelector(t):t;if(!e)throw new $(-5104,!1);return o||(e.textContent=""),e}parentNode(t){return t.parentNode}nextSibling(t){return t.nextSibling}setAttribute(t,o,e,i){if(i){o=i+":"+o;let r=Ar[i];r?t.setAttributeNS(r,o,e):t.setAttribute(o,e)}else t.setAttribute(o,e)}removeAttribute(t,o,e){if(e){let i=Ar[e];i?t.removeAttributeNS(i,o):t.removeAttribute(`${e}:${o}`)}else t.removeAttribute(o)}addClass(t,o){t.classList.add(o)}removeClass(t,o){t.classList.remove(o)}setStyle(t,o,e,i){i&(Ti.DashCase|Ti.Important)?t.style.setProperty(o,e,i&Ti.Important?"important":""):t.style[o]=e}removeStyle(t,o,e){e&Ti.DashCase?t.style.removeProperty(o):t.style[o]=""}setProperty(t,o,e){t!=null&&(t[o]=e)}setValue(t,o){t.nodeValue=o}listen(t,o,e){if(typeof t=="string"&&(t=ke().getGlobalEventTarget(this.doc,t),!t))throw new Error(`Unsupported event target ${t} for event ${o}`);return this.eventManager.addEventListener(t,o,this.decoratePreventDefault(e))}decoratePreventDefault(t){return o=>{if(o==="__ngUnwrap__")return t;(this.platformIsServer?this.ngZone.runGuarded(()=>t(o)):t(o))===!1&&o.preventDefault()}}};function El(n){return n.tagName==="TEMPLATE"&&n.content!==void 0}var Lr=class extends Bi{constructor(t,o,e,i,r,s,a,l){super(t,r,s,l),this.sharedStylesHost=o,this.hostEl=e,this.shadowRoot=e.attachShadow({mode:"open"}),this.sharedStylesHost.addHost(this.shadowRoot);let c=kl(i.id,i.styles);for(let d of c){let h=document.createElement("style");a&&h.setAttribute("nonce",a),h.textContent=d,this.shadowRoot.appendChild(h)}}nodeOrShadowRoot(t){return t===this.hostEl?this.shadowRoot:t}appendChild(t,o){return super.appendChild(this.nodeOrShadowRoot(t),o)}insertBefore(t,o,e){return super.insertBefore(this.nodeOrShadowRoot(t),o,e)}removeChild(t,o){return super.removeChild(this.nodeOrShadowRoot(t),o)}parentNode(t){return this.nodeOrShadowRoot(super.parentNode(this.nodeOrShadowRoot(t)))}destroy(){this.sharedStylesHost.removeHost(this.shadowRoot)}},Ui=class extends Bi{constructor(t,o,e,i,r,s,a,l){super(t,r,s,a),this.sharedStylesHost=o,this.removeStylesOnCompDestroy=i,this.styles=l?kl(l,e.styles):e.styles}applyStyles(){this.sharedStylesHost.addStyles(this.styles)}destroy(){this.removeStylesOnCompDestroy&&this.sharedStylesHost.removeStyles(this.styles)}},eo=class extends Ui{constructor(t,o,e,i,r,s,a,l){let c=i+"-"+e.id;super(t,o,e,r,s,a,l,c),this.contentAttr=mh(c),this.hostAttr=fh(c)}applyToHost(t){this.applyStyles(),this.setAttribute(t,this.hostAttr,"")}createElement(t,o){let e=super.createElement(t,o);return super.setAttribute(e,this.contentAttr,""),e}},ph=(()=>{let t=class t extends Jn{constructor(e){super(e)}supports(e){return!0}addEventListener(e,i,r){return e.addEventListener(i,r,!1),()=>this.removeEventListener(e,i,r)}removeEventListener(e,i,r){return e.removeEventListener(i,r)}};t.\u0275fac=function(i){return new(i||t)(m(T))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})(),Sl=["alt","control","meta","shift"],gh={"\b":"Backspace","	":"Tab","\x7F":"Delete","\x1B":"Escape",Del:"Delete",Esc:"Escape",Left:"ArrowLeft",Right:"ArrowRight",Up:"ArrowUp",Down:"ArrowDown",Menu:"ContextMenu",Scroll:"ScrollLock",Win:"OS"},bh={alt:n=>n.altKey,control:n=>n.ctrlKey,meta:n=>n.metaKey,shift:n=>n.shiftKey},vh=(()=>{let t=class t extends Jn{constructor(e){super(e)}supports(e){return t.parseEventName(e)!=null}addEventListener(e,i,r){let s=t.parseEventName(i),a=t.eventCallback(s.fullKey,r,this.manager.getZone());return this.manager.getZone().runOutsideAngular(()=>ke().onAndCancel(e,s.domEventName,a))}static parseEventName(e){let i=e.toLowerCase().split("."),r=i.shift();if(i.length===0||!(r==="keydown"||r==="keyup"))return null;let s=t._normalizeKey(i.pop()),a="",l=i.indexOf("code");if(l>-1&&(i.splice(l,1),a="code."),Sl.forEach(d=>{let h=i.indexOf(d);h>-1&&(i.splice(h,1),a+=d+".")}),a+=s,i.length!=0||s.length===0)return null;let c={};return c.domEventName=r,c.fullKey=a,c}static matchEventFullKeyCode(e,i){let r=gh[e.key]||e.key,s="";return i.indexOf("code.")>-1&&(r=e.code,s="code."),r==null||!r?!1:(r=r.toLowerCase(),r===" "?r="space":r==="."&&(r="dot"),Sl.forEach(a=>{if(a!==r){let l=bh[a];l(e)&&(s+=a+".")}}),s+=r,s===i)}static eventCallback(e,i,r){return s=>{t.matchEventFullKeyCode(s,e)&&r.runGuarded(()=>i(s))}}static _normalizeKey(e){return e==="esc"?"escape":e}};t.\u0275fac=function(i){return new(i||t)(m(T))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})();function _h(){Or.makeCurrent()}function yh(){return new Ee}function xh(){return ja(document),document}var wh=[{provide:Qt,useValue:ul},{provide:Va,useValue:_h,multi:!0},{provide:T,useFactory:xh,deps:[]}],Tl=tl(el,"browser",wh),Ch=new C(""),Dh=[{provide:jn,useClass:Nr,deps:[]},{provide:Ja,useClass:Vn,deps:[I,yr,jn]},{provide:Vn,useClass:Vn,deps:[I,yr,jn]}],Eh=[{provide:Pa,useValue:"root"},{provide:Ee,useFactory:yh,deps:[]},{provide:Pr,useClass:ph,multi:!0,deps:[T,I,Qt]},{provide:Pr,useClass:vh,multi:!0,deps:[T]},to,Rl,Il,{provide:Pn,useExisting:to},{provide:$n,useClass:lh,deps:[]},[]],Al=(()=>{let t=class t{constructor(e){}static withServerTransition(e){return{ngModule:t,providers:[{provide:Mi,useValue:e.appId}]}}};t.\u0275fac=function(i){return new(i||t)(m(Ch,12))},t.\u0275mod=S({type:t}),t.\u0275inj=E({providers:[...Eh,...Dh],imports:[Je,il]});let n=t;return n})();var Fl=(()=>{let t=class t{constructor(e){this._doc=e}getTitle(){return this._doc.title}setTitle(e){this._doc.title=e||""}};t.\u0275fac=function(i){return new(i||t)(m(T))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var zr=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:function(i){let r=null;return i?r=new(i||t):r=m(Sh),r},providedIn:"root"});let n=t;return n})(),Sh=(()=>{let t=class t extends zr{constructor(e){super(),this._doc=e}sanitize(e,i){if(i==null)return null;switch(e){case Mt.NONE:return i;case Mt.HTML:return qe(i,"HTML")?Ye(i):Ga(this._doc,String(i)).toString();case Mt.STYLE:return qe(i,"Style")?Ye(i):i;case Mt.SCRIPT:if(qe(i,"Script"))return Ye(i);throw new $(5200,!1);case Mt.URL:return qe(i,"URL")?Ye(i):Wa(String(i));case Mt.RESOURCE_URL:if(qe(i,"ResourceURL"))return Ye(i);throw new $(5201,!1);default:throw new $(5202,!1)}}bypassSecurityTrustHtml(e){return za(e)}bypassSecurityTrustStyle(e){return Ba(e)}bypassSecurityTrustScript(e){return Ua(e)}bypassSecurityTrustUrl(e){return Ha(e)}bypassSecurityTrustResourceUrl(e){return $a(e)}};t.\u0275fac=function(i){return new(i||t)(m(T))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var fe=(()=>{let t=class t{constructor(e){this.http=e,this.hostUrl="https://pricepinion.azurewebsites.net/"}getAllProducts(){return this.http.get(`${this.hostUrl}api/products`)}getOneProduct(e){return this.http.get(`${this.hostUrl}api/product/${e}`)}setSaveForLater(e){return this.http.post(`${this.hostUrl}api/customer/save-for-later`,{productID:e},{withCredentials:!0})}getSaveForLater(){return this.http.get(`${this.hostUrl}api/save-for-later`,{withCredentials:!0})}deleteSflProduct(e){return this.http.delete(`${this.hostUrl}api/customer/delete-one-product-from-sfl/${e}`,{withCredentials:!0})}deleteAllSflProducts(){return this.http.delete(`${this.hostUrl}api/customer/delete-all-products-from-sfl`,{withCredentials:!0})}authenticateGoogle(){return this.http.get(`${this.hostUrl}auth/google`)}};t.\u0275fac=function(i){return new(i||t)(m(Oe))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var O="primary",on=Symbol("RouteTitle"),Yr=class{constructor(t){this.params=t||{}}has(t){return Object.prototype.hasOwnProperty.call(this.params,t)}get(t){if(this.has(t)){let o=this.params[t];return Array.isArray(o)?o[0]:o}return null}getAll(t){if(this.has(t)){let o=this.params[t];return Array.isArray(o)?o:[o]}return[]}get keys(){return Object.keys(this.params)}};function si(n){return new Yr(n)}function Ih(n,t,o){let e=o.path.split("/");if(e.length>n.length||o.pathMatch==="full"&&(t.hasChildren()||e.length<n.length))return null;let i={};for(let r=0;r<e.length;r++){let s=e[r],a=n[r];if(s.startsWith(":"))i[s.substring(1)]=a;else if(s!==a.path)return null}return{consumed:n.slice(0,e.length),posParams:i}}function Rh(n,t){if(n.length!==t.length)return!1;for(let o=0;o<n.length;++o)if(!$t(n[o],t[o]))return!1;return!0}function $t(n,t){let o=n?qr(n):void 0,e=t?qr(t):void 0;if(!o||!e||o.length!=e.length)return!1;let i;for(let r=0;r<o.length;r++)if(i=o[r],!Ul(n[i],t[i]))return!1;return!0}function qr(n){return[...Object.keys(n),...Object.getOwnPropertySymbols(n)]}function Ul(n,t){if(Array.isArray(n)&&Array.isArray(t)){if(n.length!==t.length)return!1;let o=[...n].sort(),e=[...t].sort();return o.every((i,r)=>e[r]===i)}else return n===t}function Hl(n){return n.length>0?n[n.length-1]:null}function ve(n){return We(n)?n:zn(n)?ht(Promise.resolve(n)):v(n)}var Mh={exact:Wl,subset:Gl},$l={exact:kh,subset:Th,ignored:()=>!0};function Ol(n,t,o){return Mh[o.paths](n.root,t.root,o.matrixParams)&&$l[o.queryParams](n.queryParams,t.queryParams)&&!(o.fragment==="exact"&&n.fragment!==t.fragment)}function kh(n,t){return $t(n,t)}function Wl(n,t,o){if(!Pe(n.segments,t.segments)||!oo(n.segments,t.segments,o)||n.numberOfChildren!==t.numberOfChildren)return!1;for(let e in t.children)if(!n.children[e]||!Wl(n.children[e],t.children[e],o))return!1;return!0}function Th(n,t){return Object.keys(t).length<=Object.keys(n).length&&Object.keys(t).every(o=>Ul(n[o],t[o]))}function Gl(n,t,o){return Yl(n,t,t.segments,o)}function Yl(n,t,o,e){if(n.segments.length>o.length){let i=n.segments.slice(0,o.length);return!(!Pe(i,o)||t.hasChildren()||!oo(i,o,e))}else if(n.segments.length===o.length){if(!Pe(n.segments,o)||!oo(n.segments,o,e))return!1;for(let i in t.children)if(!n.children[i]||!Gl(n.children[i],t.children[i],e))return!1;return!0}else{let i=o.slice(0,n.segments.length),r=o.slice(n.segments.length);return!Pe(n.segments,i)||!oo(n.segments,i,e)||!n.children[O]?!1:Yl(n.children[O],t,r,e)}}function oo(n,t,o){return t.every((e,i)=>$l[o](n[i].parameters,e.parameters))}var pe=class{constructor(t=new G([],{}),o={},e=null){this.root=t,this.queryParams=o,this.fragment=e}get queryParamMap(){return this._queryParamMap??=si(this.queryParams),this._queryParamMap}toString(){return Oh.serialize(this)}},G=class{constructor(t,o){this.segments=t,this.children=o,this.parent=null,Object.values(o).forEach(e=>e.parent=this)}hasChildren(){return this.numberOfChildren>0}get numberOfChildren(){return Object.keys(this.children).length}toString(){return ro(this)}},Ne=class{constructor(t,o){this.path=t,this.parameters=o}get parameterMap(){return this._parameterMap??=si(this.parameters),this._parameterMap}toString(){return Zl(this)}};function Ah(n,t){return Pe(n,t)&&n.every((o,e)=>$t(o.parameters,t[e].parameters))}function Pe(n,t){return n.length!==t.length?!1:n.every((o,e)=>o.path===t[e].path)}function Fh(n,t){let o=[];return Object.entries(n.children).forEach(([e,i])=>{e===O&&(o=o.concat(t(i,e)))}),Object.entries(n.children).forEach(([e,i])=>{e!==O&&(o=o.concat(t(i,e)))}),o}var rn=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:()=>new Zi,providedIn:"root"});let n=t;return n})(),Zi=class{parse(t){let o=new Xr(t);return new pe(o.parseRootSegment(),o.parseQueryParams(),o.parseFragment())}serialize(t){let o=`/${Hi(t.root,!0)}`,e=Lh(t.queryParams),i=typeof t.fragment=="string"?`#${Nh(t.fragment)}`:"";return`${o}${e}${i}`}},Oh=new Zi;function ro(n){return n.segments.map(t=>Zl(t)).join("/")}function Hi(n,t){if(!n.hasChildren())return ro(n);if(t){let o=n.children[O]?Hi(n.children[O],!1):"",e=[];return Object.entries(n.children).forEach(([i,r])=>{i!==O&&e.push(`${i}:${Hi(r,!1)}`)}),e.length>0?`${o}(${e.join("//")})`:o}else{let o=Fh(n,(e,i)=>i===O?[Hi(n.children[O],!1)]:[`${i}:${Hi(e,!1)}`]);return Object.keys(n.children).length===1&&n.children[O]!=null?`${ro(n)}/${o[0]}`:`${ro(n)}/(${o.join("//")})`}}function ql(n){return encodeURIComponent(n).replace(/%40/g,"@").replace(/%3A/gi,":").replace(/%24/g,"$").replace(/%2C/gi,",")}function io(n){return ql(n).replace(/%3B/gi,";")}function Nh(n){return encodeURI(n)}function Zr(n){return ql(n).replace(/\(/g,"%28").replace(/\)/g,"%29").replace(/%26/gi,"&")}function so(n){return decodeURIComponent(n)}function Nl(n){return so(n.replace(/\+/g,"%20"))}function Zl(n){return`${Zr(n.path)}${Ph(n.parameters)}`}function Ph(n){return Object.entries(n).map(([t,o])=>`;${Zr(t)}=${Zr(o)}`).join("")}function Lh(n){let t=Object.entries(n).map(([o,e])=>Array.isArray(e)?e.map(i=>`${io(o)}=${io(i)}`).join("&"):`${io(o)}=${io(e)}`).filter(o=>o);return t.length?`?${t.join("&")}`:""}var jh=/^[^\/()?;#]+/;function Hr(n){let t=n.match(jh);return t?t[0]:""}var Vh=/^[^\/()?;=#]+/;function zh(n){let t=n.match(Vh);return t?t[0]:""}var Bh=/^[^=?&#]+/;function Uh(n){let t=n.match(Bh);return t?t[0]:""}var Hh=/^[^&#]+/;function $h(n){let t=n.match(Hh);return t?t[0]:""}var Xr=class{constructor(t){this.url=t,this.remaining=t}parseRootSegment(){return this.consumeOptional("/"),this.remaining===""||this.peekStartsWith("?")||this.peekStartsWith("#")?new G([],{}):new G([],this.parseChildren())}parseQueryParams(){let t={};if(this.consumeOptional("?"))do this.parseQueryParam(t);while(this.consumeOptional("&"));return t}parseFragment(){return this.consumeOptional("#")?decodeURIComponent(this.remaining):null}parseChildren(){if(this.remaining==="")return{};this.consumeOptional("/");let t=[];for(this.peekStartsWith("(")||t.push(this.parseSegment());this.peekStartsWith("/")&&!this.peekStartsWith("//")&&!this.peekStartsWith("/(");)this.capture("/"),t.push(this.parseSegment());let o={};this.peekStartsWith("/(")&&(this.capture("/"),o=this.parseParens(!0));let e={};return this.peekStartsWith("(")&&(e=this.parseParens(!1)),(t.length>0||Object.keys(o).length>0)&&(e[O]=new G(t,o)),e}parseSegment(){let t=Hr(this.remaining);if(t===""&&this.peekStartsWith(";"))throw new $(4009,!1);return this.capture(t),new Ne(so(t),this.parseMatrixParams())}parseMatrixParams(){let t={};for(;this.consumeOptional(";");)this.parseParam(t);return t}parseParam(t){let o=zh(this.remaining);if(!o)return;this.capture(o);let e="";if(this.consumeOptional("=")){let i=Hr(this.remaining);i&&(e=i,this.capture(e))}t[so(o)]=so(e)}parseQueryParam(t){let o=Uh(this.remaining);if(!o)return;this.capture(o);let e="";if(this.consumeOptional("=")){let s=$h(this.remaining);s&&(e=s,this.capture(e))}let i=Nl(o),r=Nl(e);if(t.hasOwnProperty(i)){let s=t[i];Array.isArray(s)||(s=[s],t[i]=s),s.push(r)}else t[i]=r}parseParens(t){let o={};for(this.capture("(");!this.consumeOptional(")")&&this.remaining.length>0;){let e=Hr(this.remaining),i=this.remaining[e.length];if(i!=="/"&&i!==")"&&i!==";")throw new $(4010,!1);let r;e.indexOf(":")>-1?(r=e.slice(0,e.indexOf(":")),this.capture(r),this.capture(":")):t&&(r=O);let s=this.parseChildren();o[r]=Object.keys(s).length===1?s[O]:new G([],s),this.consumeOptional("//")}return o}peekStartsWith(t){return this.remaining.startsWith(t)}consumeOptional(t){return this.peekStartsWith(t)?(this.remaining=this.remaining.substring(t.length),!0):!1}capture(t){if(!this.consumeOptional(t))throw new $(4011,!1)}};function Xl(n){return n.segments.length>0?new G([],{[O]:n}):n}function Kl(n){let t={};for(let[e,i]of Object.entries(n.children)){let r=Kl(i);if(e===O&&r.segments.length===0&&r.hasChildren())for(let[s,a]of Object.entries(r.children))t[s]=a;else(r.segments.length>0||r.hasChildren())&&(t[e]=r)}let o=new G(n.segments,t);return Wh(o)}function Wh(n){if(n.numberOfChildren===1&&n.children[O]){let t=n.children[O];return new G(n.segments.concat(t.segments),t.children)}return n}function ai(n){return n instanceof pe}function Gh(n,t,o=null,e=null){let i=Ql(n);return Jl(i,t,o,e)}function Ql(n){let t;function o(r){let s={};for(let l of r.children){let c=o(l);s[l.outlet]=c}let a=new G(r.url,s);return r===n&&(t=a),a}let e=o(n.root),i=Xl(e);return t??i}function Jl(n,t,o,e){let i=n;for(;i.parent;)i=i.parent;if(t.length===0)return $r(i,i,i,o,e);let r=Yh(t);if(r.toRoot())return $r(i,i,new G([],{}),o,e);let s=qh(r,i,n),a=s.processChildren?Gi(s.segmentGroup,s.index,r.commands):ec(s.segmentGroup,s.index,r.commands);return $r(i,s.segmentGroup,a,o,e)}function ao(n){return typeof n=="object"&&n!=null&&!n.outlets&&!n.segmentPath}function Xi(n){return typeof n=="object"&&n!=null&&n.outlets}function $r(n,t,o,e,i){let r={};e&&Object.entries(e).forEach(([l,c])=>{r[l]=Array.isArray(c)?c.map(d=>`${d}`):`${c}`});let s;n===t?s=o:s=tc(n,t,o);let a=Xl(Kl(s));return new pe(a,r,i)}function tc(n,t,o){let e={};return Object.entries(n.children).forEach(([i,r])=>{r===t?e[i]=o:e[i]=tc(r,t,o)}),new G(n.segments,e)}var lo=class{constructor(t,o,e){if(this.isAbsolute=t,this.numberOfDoubleDots=o,this.commands=e,t&&e.length>0&&ao(e[0]))throw new $(4003,!1);let i=e.find(Xi);if(i&&i!==Hl(e))throw new $(4004,!1)}toRoot(){return this.isAbsolute&&this.commands.length===1&&this.commands[0]=="/"}};function Yh(n){if(typeof n[0]=="string"&&n.length===1&&n[0]==="/")return new lo(!0,0,n);let t=0,o=!1,e=n.reduce((i,r,s)=>{if(typeof r=="object"&&r!=null){if(r.outlets){let a={};return Object.entries(r.outlets).forEach(([l,c])=>{a[l]=typeof c=="string"?c.split("/"):c}),[...i,{outlets:a}]}if(r.segmentPath)return[...i,r.segmentPath]}return typeof r!="string"?[...i,r]:s===0?(r.split("/").forEach((a,l)=>{l==0&&a==="."||(l==0&&a===""?o=!0:a===".."?t++:a!=""&&i.push(a))}),i):[...i,r]},[]);return new lo(o,t,e)}var oi=class{constructor(t,o,e){this.segmentGroup=t,this.processChildren=o,this.index=e}};function qh(n,t,o){if(n.isAbsolute)return new oi(t,!0,0);if(!o)return new oi(t,!1,NaN);if(o.parent===null)return new oi(o,!0,0);let e=ao(n.commands[0])?0:1,i=o.segments.length-1+e;return Zh(o,i,n.numberOfDoubleDots)}function Zh(n,t,o){let e=n,i=t,r=o;for(;r>i;){if(r-=i,e=e.parent,!e)throw new $(4005,!1);i=e.segments.length}return new oi(e,!1,i-r)}function Xh(n){return Xi(n[0])?n[0].outlets:{[O]:n}}function ec(n,t,o){if(n??=new G([],{}),n.segments.length===0&&n.hasChildren())return Gi(n,t,o);let e=Kh(n,t,o),i=o.slice(e.commandIndex);if(e.match&&e.pathIndex<n.segments.length){let r=new G(n.segments.slice(0,e.pathIndex),{});return r.children[O]=new G(n.segments.slice(e.pathIndex),n.children),Gi(r,0,i)}else return e.match&&i.length===0?new G(n.segments,{}):e.match&&!n.hasChildren()?Kr(n,t,o):e.match?Gi(n,0,i):Kr(n,t,o)}function Gi(n,t,o){if(o.length===0)return new G(n.segments,{});{let e=Xh(o),i={};if(Object.keys(e).some(r=>r!==O)&&n.children[O]&&n.numberOfChildren===1&&n.children[O].segments.length===0){let r=Gi(n.children[O],t,o);return new G(n.segments,r.children)}return Object.entries(e).forEach(([r,s])=>{typeof s=="string"&&(s=[s]),s!==null&&(i[r]=ec(n.children[r],t,s))}),Object.entries(n.children).forEach(([r,s])=>{e[r]===void 0&&(i[r]=s)}),new G(n.segments,i)}}function Kh(n,t,o){let e=0,i=t,r={match:!1,pathIndex:0,commandIndex:0};for(;i<n.segments.length;){if(e>=o.length)return r;let s=n.segments[i],a=o[e];if(Xi(a))break;let l=`${a}`,c=e<o.length-1?o[e+1]:null;if(i>0&&l===void 0)break;if(l&&c&&typeof c=="object"&&c.outlets===void 0){if(!Ll(l,c,s))return r;e+=2}else{if(!Ll(l,{},s))return r;e++}i++}return{match:!0,pathIndex:i,commandIndex:e}}function Kr(n,t,o){let e=n.segments.slice(0,t),i=0;for(;i<o.length;){let r=o[i];if(Xi(r)){let l=Qh(r.outlets);return new G(e,l)}if(i===0&&ao(o[0])){let l=n.segments[t];e.push(new Ne(l.path,Pl(o[0]))),i++;continue}let s=Xi(r)?r.outlets[O]:`${r}`,a=i<o.length-1?o[i+1]:null;s&&a&&ao(a)?(e.push(new Ne(s,Pl(a))),i+=2):(e.push(new Ne(s,{})),i++)}return new G(e,{})}function Qh(n){let t={};return Object.entries(n).forEach(([o,e])=>{typeof e=="string"&&(e=[e]),e!==null&&(t[o]=Kr(new G([],{}),0,e))}),t}function Pl(n){let t={};return Object.entries(n).forEach(([o,e])=>t[o]=`${e}`),t}function Ll(n,t,o){return n==o.path&&$t(t,o.parameters)}var Yi="imperative",bt=function(n){return n[n.NavigationStart=0]="NavigationStart",n[n.NavigationEnd=1]="NavigationEnd",n[n.NavigationCancel=2]="NavigationCancel",n[n.NavigationError=3]="NavigationError",n[n.RoutesRecognized=4]="RoutesRecognized",n[n.ResolveStart=5]="ResolveStart",n[n.ResolveEnd=6]="ResolveEnd",n[n.GuardsCheckStart=7]="GuardsCheckStart",n[n.GuardsCheckEnd=8]="GuardsCheckEnd",n[n.RouteConfigLoadStart=9]="RouteConfigLoadStart",n[n.RouteConfigLoadEnd=10]="RouteConfigLoadEnd",n[n.ChildActivationStart=11]="ChildActivationStart",n[n.ChildActivationEnd=12]="ChildActivationEnd",n[n.ActivationStart=13]="ActivationStart",n[n.ActivationEnd=14]="ActivationEnd",n[n.Scroll=15]="Scroll",n[n.NavigationSkipped=16]="NavigationSkipped",n}(bt||{}),Ot=class{constructor(t,o){this.id=t,this.url=o}},li=class extends Ot{constructor(t,o,e="imperative",i=null){super(t,o),this.type=bt.NavigationStart,this.navigationTrigger=e,this.restoredState=i}toString(){return`NavigationStart(id: ${this.id}, url: '${this.url}')`}},Wt=class extends Ot{constructor(t,o,e){super(t,o),this.urlAfterRedirects=e,this.type=bt.NavigationEnd}toString(){return`NavigationEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}')`}},At=function(n){return n[n.Redirect=0]="Redirect",n[n.SupersededByNewNavigation=1]="SupersededByNewNavigation",n[n.NoDataFromResolver=2]="NoDataFromResolver",n[n.GuardRejected=3]="GuardRejected",n}(At||{}),co=function(n){return n[n.IgnoredSameUrlNavigation=0]="IgnoredSameUrlNavigation",n[n.IgnoredByUrlHandlingStrategy=1]="IgnoredByUrlHandlingStrategy",n}(co||{}),ge=class extends Ot{constructor(t,o,e,i){super(t,o),this.reason=e,this.code=i,this.type=bt.NavigationCancel}toString(){return`NavigationCancel(id: ${this.id}, url: '${this.url}')`}},be=class extends Ot{constructor(t,o,e,i){super(t,o),this.reason=e,this.code=i,this.type=bt.NavigationSkipped}},Ki=class extends Ot{constructor(t,o,e,i){super(t,o),this.error=e,this.target=i,this.type=bt.NavigationError}toString(){return`NavigationError(id: ${this.id}, url: '${this.url}', error: ${this.error})`}},uo=class extends Ot{constructor(t,o,e,i){super(t,o),this.urlAfterRedirects=e,this.state=i,this.type=bt.RoutesRecognized}toString(){return`RoutesRecognized(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`}},Qr=class extends Ot{constructor(t,o,e,i){super(t,o),this.urlAfterRedirects=e,this.state=i,this.type=bt.GuardsCheckStart}toString(){return`GuardsCheckStart(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`}},Jr=class extends Ot{constructor(t,o,e,i,r){super(t,o),this.urlAfterRedirects=e,this.state=i,this.shouldActivate=r,this.type=bt.GuardsCheckEnd}toString(){return`GuardsCheckEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state}, shouldActivate: ${this.shouldActivate})`}},ts=class extends Ot{constructor(t,o,e,i){super(t,o),this.urlAfterRedirects=e,this.state=i,this.type=bt.ResolveStart}toString(){return`ResolveStart(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`}},es=class extends Ot{constructor(t,o,e,i){super(t,o),this.urlAfterRedirects=e,this.state=i,this.type=bt.ResolveEnd}toString(){return`ResolveEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`}},is=class{constructor(t){this.route=t,this.type=bt.RouteConfigLoadStart}toString(){return`RouteConfigLoadStart(path: ${this.route.path})`}},ns=class{constructor(t){this.route=t,this.type=bt.RouteConfigLoadEnd}toString(){return`RouteConfigLoadEnd(path: ${this.route.path})`}},os=class{constructor(t){this.snapshot=t,this.type=bt.ChildActivationStart}toString(){return`ChildActivationStart(path: '${this.snapshot.routeConfig&&this.snapshot.routeConfig.path||""}')`}},rs=class{constructor(t){this.snapshot=t,this.type=bt.ChildActivationEnd}toString(){return`ChildActivationEnd(path: '${this.snapshot.routeConfig&&this.snapshot.routeConfig.path||""}')`}},ss=class{constructor(t){this.snapshot=t,this.type=bt.ActivationStart}toString(){return`ActivationStart(path: '${this.snapshot.routeConfig&&this.snapshot.routeConfig.path||""}')`}},as=class{constructor(t){this.snapshot=t,this.type=bt.ActivationEnd}toString(){return`ActivationEnd(path: '${this.snapshot.routeConfig&&this.snapshot.routeConfig.path||""}')`}},ho=class{constructor(t,o,e){this.routerEvent=t,this.position=o,this.anchor=e,this.type=bt.Scroll}toString(){let t=this.position?`${this.position[0]}, ${this.position[1]}`:null;return`Scroll(anchor: '${this.anchor}', position: '${t}')`}},Qi=class{},Ji=class{constructor(t){this.url=t}};var ls=class{constructor(){this.outlet=null,this.route=null,this.injector=null,this.children=new sn,this.attachRef=null}},sn=(()=>{let t=class t{constructor(){this.contexts=new Map}onChildOutletCreated(e,i){let r=this.getOrCreateContext(e);r.outlet=i,this.contexts.set(e,r)}onChildOutletDestroyed(e){let i=this.getContext(e);i&&(i.outlet=null,i.attachRef=null)}onOutletDeactivated(){let e=this.contexts;return this.contexts=new Map,e}onOutletReAttached(e){this.contexts=e}getOrCreateContext(e){let i=this.getContext(e);return i||(i=new ls,this.contexts.set(e,i)),i}getContext(e){return this.contexts.get(e)||null}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),mo=class{constructor(t){this._root=t}get root(){return this._root.value}parent(t){let o=this.pathFromRoot(t);return o.length>1?o[o.length-2]:null}children(t){let o=cs(t,this._root);return o?o.children.map(e=>e.value):[]}firstChild(t){let o=cs(t,this._root);return o&&o.children.length>0?o.children[0].value:null}siblings(t){let o=ds(t,this._root);return o.length<2?[]:o[o.length-2].children.map(i=>i.value).filter(i=>i!==t)}pathFromRoot(t){return ds(t,this._root).map(o=>o.value)}};function cs(n,t){if(n===t.value)return t;for(let o of t.children){let e=cs(n,o);if(e)return e}return null}function ds(n,t){if(n===t.value)return[t];for(let o of t.children){let e=ds(n,o);if(e.length)return e.unshift(t),e}return[]}var Tt=class{constructor(t,o){this.value=t,this.children=o}toString(){return`TreeNode(${this.value})`}};function ni(n){let t={};return n&&n.children.forEach(o=>t[o.value.outlet]=o),t}var fo=class extends mo{constructor(t,o){super(t),this.snapshot=o,ys(this,t)}toString(){return this.snapshot.toString()}};function ic(n){let t=Jh(n),o=new rt([new Ne("",{})]),e=new rt({}),i=new rt({}),r=new rt({}),s=new rt(""),a=new ee(o,e,r,s,i,O,n,t.root);return a.snapshot=t.root,new fo(new Tt(a,[]),t)}function Jh(n){let t={},o={},e={},i="",r=new tn([],t,e,i,o,O,n,null,{});return new po("",new Tt(r,[]))}var ee=class{constructor(t,o,e,i,r,s,a,l){this.urlSubject=t,this.paramsSubject=o,this.queryParamsSubject=e,this.fragmentSubject=i,this.dataSubject=r,this.outlet=s,this.component=a,this._futureSnapshot=l,this.title=this.dataSubject?.pipe(M(c=>c[on]))??v(void 0),this.url=t,this.params=o,this.queryParams=e,this.fragment=i,this.data=r}get routeConfig(){return this._futureSnapshot.routeConfig}get root(){return this._routerState.root}get parent(){return this._routerState.parent(this)}get firstChild(){return this._routerState.firstChild(this)}get children(){return this._routerState.children(this)}get pathFromRoot(){return this._routerState.pathFromRoot(this)}get paramMap(){return this._paramMap??=this.params.pipe(M(t=>si(t))),this._paramMap}get queryParamMap(){return this._queryParamMap??=this.queryParams.pipe(M(t=>si(t))),this._queryParamMap}toString(){return this.snapshot?this.snapshot.toString():`Future(${this._futureSnapshot})`}};function _s(n,t,o="emptyOnly"){let e,{routeConfig:i}=n;return t!==null&&(o==="always"||i?.path===""||!t.component&&!t.routeConfig?.loadComponent)?e={params:p(p({},t.params),n.params),data:p(p({},t.data),n.data),resolve:p(p(p(p({},n.data),t.data),i?.data),n._resolvedData)}:e={params:p({},n.params),data:p({},n.data),resolve:p(p({},n.data),n._resolvedData??{})},i&&oc(i)&&(e.resolve[on]=i.title),e}var tn=class{get title(){return this.data?.[on]}constructor(t,o,e,i,r,s,a,l,c){this.url=t,this.params=o,this.queryParams=e,this.fragment=i,this.data=r,this.outlet=s,this.component=a,this.routeConfig=l,this._resolve=c}get root(){return this._routerState.root}get parent(){return this._routerState.parent(this)}get firstChild(){return this._routerState.firstChild(this)}get children(){return this._routerState.children(this)}get pathFromRoot(){return this._routerState.pathFromRoot(this)}get paramMap(){return this._paramMap??=si(this.params),this._paramMap}get queryParamMap(){return this._queryParamMap??=si(this.queryParams),this._queryParamMap}toString(){let t=this.url.map(e=>e.toString()).join("/"),o=this.routeConfig?this.routeConfig.path:"";return`Route(url:'${t}', path:'${o}')`}},po=class extends mo{constructor(t,o){super(o),this.url=t,ys(this,o)}toString(){return nc(this._root)}};function ys(n,t){t.value._routerState=n,t.children.forEach(o=>ys(n,o))}function nc(n){let t=n.children.length>0?` { ${n.children.map(nc).join(", ")} } `:"";return`${n.value}${t}`}function Wr(n){if(n.snapshot){let t=n.snapshot,o=n._futureSnapshot;n.snapshot=o,$t(t.queryParams,o.queryParams)||n.queryParamsSubject.next(o.queryParams),t.fragment!==o.fragment&&n.fragmentSubject.next(o.fragment),$t(t.params,o.params)||n.paramsSubject.next(o.params),Rh(t.url,o.url)||n.urlSubject.next(o.url),$t(t.data,o.data)||n.dataSubject.next(o.data)}else n.snapshot=n._futureSnapshot,n.dataSubject.next(n._futureSnapshot.data)}function us(n,t){let o=$t(n.params,t.params)&&Ah(n.url,t.url),e=!n.parent!=!t.parent;return o&&!e&&(!n.parent||us(n.parent,t.parent))}function oc(n){return typeof n.title=="string"||n.title===null}var xs=(()=>{let t=class t{constructor(){this.activated=null,this._activatedRoute=null,this.name=O,this.activateEvents=new it,this.deactivateEvents=new it,this.attachEvents=new it,this.detachEvents=new it,this.parentContexts=g(sn),this.location=g(kt),this.changeDetector=g(Dt),this.environmentInjector=g(ce),this.inputBinder=g(yo,{optional:!0}),this.supportsBindingToComponentInputs=!0}get activatedComponentRef(){return this.activated}ngOnChanges(e){if(e.name){let{firstChange:i,previousValue:r}=e.name;if(i)return;this.isTrackedInParentContexts(r)&&(this.deactivate(),this.parentContexts.onChildOutletDestroyed(r)),this.initializeOutletWithName()}}ngOnDestroy(){this.isTrackedInParentContexts(this.name)&&this.parentContexts.onChildOutletDestroyed(this.name),this.inputBinder?.unsubscribeFromRouteData(this)}isTrackedInParentContexts(e){return this.parentContexts.getContext(e)?.outlet===this}ngOnInit(){this.initializeOutletWithName()}initializeOutletWithName(){if(this.parentContexts.onChildOutletCreated(this.name,this),this.activated)return;let e=this.parentContexts.getContext(this.name);e?.route&&(e.attachRef?this.attach(e.attachRef,e.route):this.activateWith(e.route,e.injector))}get isActivated(){return!!this.activated}get component(){if(!this.activated)throw new $(4012,!1);return this.activated.instance}get activatedRoute(){if(!this.activated)throw new $(4012,!1);return this._activatedRoute}get activatedRouteData(){return this._activatedRoute?this._activatedRoute.snapshot.data:{}}detach(){if(!this.activated)throw new $(4012,!1);this.location.detach();let e=this.activated;return this.activated=null,this._activatedRoute=null,this.detachEvents.emit(e.instance),e}attach(e,i){this.activated=e,this._activatedRoute=i,this.location.insert(e.hostView),this.inputBinder?.bindActivatedRouteToOutletComponent(this),this.attachEvents.emit(e.instance)}deactivate(){if(this.activated){let e=this.component;this.activated.destroy(),this.activated=null,this._activatedRoute=null,this.deactivateEvents.emit(e)}}activateWith(e,i){if(this.isActivated)throw new $(4013,!1);this._activatedRoute=e;let r=this.location,a=e.snapshot.component,l=this.parentContexts.getOrCreateContext(this.name).children,c=new hs(e,l,r.injector);this.activated=r.createComponent(a,{index:r.length,injector:c,environmentInjector:i??this.environmentInjector}),this.changeDetector.markForCheck(),this.inputBinder?.bindActivatedRouteToOutletComponent(this),this.activateEvents.emit(this.activated.instance)}};t.\u0275fac=function(i){return new(i||t)},t.\u0275dir=D({type:t,selectors:[["router-outlet"]],inputs:{name:"name"},outputs:{activateEvents:"activate",deactivateEvents:"deactivate",attachEvents:"attach",detachEvents:"detach"},exportAs:["outlet"],standalone:!0,features:[yt]});let n=t;return n})(),hs=class n{__ngOutletInjector(t){return new n(this.route,this.childContexts,t)}constructor(t,o,e){this.route=t,this.childContexts=o,this.parent=e}get(t,o){return t===ee?this.route:t===sn?this.childContexts:this.parent.get(t,o)}},yo=new C(""),jl=(()=>{let t=class t{constructor(){this.outletDataSubscriptions=new Map}bindActivatedRouteToOutletComponent(e){this.unsubscribeFromRouteData(e),this.subscribeToRouteData(e)}unsubscribeFromRouteData(e){this.outletDataSubscriptions.get(e)?.unsubscribe(),this.outletDataSubscriptions.delete(e)}subscribeToRouteData(e){let{activatedRoute:i}=e,r=Vt([i.queryParams,i.params,i.data]).pipe(vt(([s,a,l],c)=>(l=p(p(p({},s),a),l),c===0?v(l):Promise.resolve(l)))).subscribe(s=>{if(!e.isActivated||!e.activatedComponentRef||e.activatedRoute!==i||i.component===null){this.unsubscribeFromRouteData(e);return}let a=rl(i.component);if(!a){this.unsubscribeFromRouteData(e);return}for(let{templateName:l}of a.inputs)e.activatedComponentRef.setInput(l,s[l])});this.outletDataSubscriptions.set(e,r)}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})();function tm(n,t,o){let e=en(n,t._root,o?o._root:void 0);return new fo(e,t)}function en(n,t,o){if(o&&n.shouldReuseRoute(t.value,o.value.snapshot)){let e=o.value;e._futureSnapshot=t.value;let i=em(n,t,o);return new Tt(e,i)}else{if(n.shouldAttach(t.value)){let r=n.retrieve(t.value);if(r!==null){let s=r.route;return s.value._futureSnapshot=t.value,s.children=t.children.map(a=>en(n,a)),s}}let e=im(t.value),i=t.children.map(r=>en(n,r));return new Tt(e,i)}}function em(n,t,o){return t.children.map(e=>{for(let i of o.children)if(n.shouldReuseRoute(e.value,i.value.snapshot))return en(n,e,i);return en(n,e)})}function im(n){return new ee(new rt(n.url),new rt(n.params),new rt(n.queryParams),new rt(n.fragment),new rt(n.data),n.outlet,n.component,n)}var rc="ngNavigationCancelingError";function sc(n,t){let{redirectTo:o,navigationBehaviorOptions:e}=ai(t)?{redirectTo:t,navigationBehaviorOptions:void 0}:t,i=ac(!1,At.Redirect);return i.url=o,i.navigationBehaviorOptions=e,i}function ac(n,t){let o=new Error(`NavigationCancelingError: ${n||""}`);return o[rc]=!0,o.cancellationCode=t,o}function nm(n){return lc(n)&&ai(n.url)}function lc(n){return!!n&&n[rc]}var om=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275cmp=P({type:t,selectors:[["ng-component"]],standalone:!0,features:[tt],decls:1,vars:0,template:function(i,r){i&1&&H(0,"router-outlet")},dependencies:[xs],encapsulation:2});let n=t;return n})();function rm(n,t){return n.providers&&!n._injector&&(n._injector=_r(n.providers,t,`Route: ${n.path}`)),n._injector??t}function ws(n){let t=n.children&&n.children.map(ws),o=t?q(p({},n),{children:t}):p({},n);return!o.component&&!o.loadComponent&&(t||o.loadChildren)&&o.outlet&&o.outlet!==O&&(o.component=om),o}function Gt(n){return n.outlet||O}function sm(n,t){let o=n.filter(e=>Gt(e)===t);return o.push(...n.filter(e=>Gt(e)!==t)),o}function an(n){if(!n)return null;if(n.routeConfig?._injector)return n.routeConfig._injector;for(let t=n.parent;t;t=t.parent){let o=t.routeConfig;if(o?._loadedInjector)return o._loadedInjector;if(o?._injector)return o._injector}return null}var am=(n,t,o,e)=>M(i=>(new ms(t,i.targetRouterState,i.currentRouterState,o,e).activate(n),i)),ms=class{constructor(t,o,e,i,r){this.routeReuseStrategy=t,this.futureState=o,this.currState=e,this.forwardEvent=i,this.inputBindingEnabled=r}activate(t){let o=this.futureState._root,e=this.currState?this.currState._root:null;this.deactivateChildRoutes(o,e,t),Wr(this.futureState.root),this.activateChildRoutes(o,e,t)}deactivateChildRoutes(t,o,e){let i=ni(o);t.children.forEach(r=>{let s=r.value.outlet;this.deactivateRoutes(r,i[s],e),delete i[s]}),Object.values(i).forEach(r=>{this.deactivateRouteAndItsChildren(r,e)})}deactivateRoutes(t,o,e){let i=t.value,r=o?o.value:null;if(i===r)if(i.component){let s=e.getContext(i.outlet);s&&this.deactivateChildRoutes(t,o,s.children)}else this.deactivateChildRoutes(t,o,e);else r&&this.deactivateRouteAndItsChildren(o,e)}deactivateRouteAndItsChildren(t,o){t.value.component&&this.routeReuseStrategy.shouldDetach(t.value.snapshot)?this.detachAndStoreRouteSubtree(t,o):this.deactivateRouteAndOutlet(t,o)}detachAndStoreRouteSubtree(t,o){let e=o.getContext(t.value.outlet),i=e&&t.value.component?e.children:o,r=ni(t);for(let s of Object.values(r))this.deactivateRouteAndItsChildren(s,i);if(e&&e.outlet){let s=e.outlet.detach(),a=e.children.onOutletDeactivated();this.routeReuseStrategy.store(t.value.snapshot,{componentRef:s,route:t,contexts:a})}}deactivateRouteAndOutlet(t,o){let e=o.getContext(t.value.outlet),i=e&&t.value.component?e.children:o,r=ni(t);for(let s of Object.values(r))this.deactivateRouteAndItsChildren(s,i);e&&(e.outlet&&(e.outlet.deactivate(),e.children.onOutletDeactivated()),e.attachRef=null,e.route=null)}activateChildRoutes(t,o,e){let i=ni(o);t.children.forEach(r=>{this.activateRoutes(r,i[r.value.outlet],e),this.forwardEvent(new as(r.value.snapshot))}),t.children.length&&this.forwardEvent(new rs(t.value.snapshot))}activateRoutes(t,o,e){let i=t.value,r=o?o.value:null;if(Wr(i),i===r)if(i.component){let s=e.getOrCreateContext(i.outlet);this.activateChildRoutes(t,o,s.children)}else this.activateChildRoutes(t,o,e);else if(i.component){let s=e.getOrCreateContext(i.outlet);if(this.routeReuseStrategy.shouldAttach(i.snapshot)){let a=this.routeReuseStrategy.retrieve(i.snapshot);this.routeReuseStrategy.store(i.snapshot,null),s.children.onOutletReAttached(a.contexts),s.attachRef=a.componentRef,s.route=a.route.value,s.outlet&&s.outlet.attach(a.componentRef,a.route.value),Wr(a.route.value),this.activateChildRoutes(t,null,s.children)}else{let a=an(i.snapshot);s.attachRef=null,s.route=i,s.injector=a,s.outlet&&s.outlet.activateWith(i,s.injector),this.activateChildRoutes(t,null,s.children)}}else this.activateChildRoutes(t,null,e)}},go=class{constructor(t){this.path=t,this.route=this.path[this.path.length-1]}},ri=class{constructor(t,o){this.component=t,this.route=o}};function lm(n,t,o){let e=n._root,i=t?t._root:null;return $i(e,i,o,[e.value])}function cm(n){let t=n.routeConfig?n.routeConfig.canActivateChild:null;return!t||t.length===0?null:{node:n,guards:t}}function di(n,t){let o=Symbol(),e=t.get(n,o);return e===o?typeof n=="function"&&!Na(n)?n:t.get(n):e}function $i(n,t,o,e,i={canDeactivateChecks:[],canActivateChecks:[]}){let r=ni(t);return n.children.forEach(s=>{dm(s,r[s.value.outlet],o,e.concat([s.value]),i),delete r[s.value.outlet]}),Object.entries(r).forEach(([s,a])=>qi(a,o.getContext(s),i)),i}function dm(n,t,o,e,i={canDeactivateChecks:[],canActivateChecks:[]}){let r=n.value,s=t?t.value:null,a=o?o.getContext(n.value.outlet):null;if(s&&r.routeConfig===s.routeConfig){let l=um(s,r,r.routeConfig.runGuardsAndResolvers);l?i.canActivateChecks.push(new go(e)):(r.data=s.data,r._resolvedData=s._resolvedData),r.component?$i(n,t,a?a.children:null,e,i):$i(n,t,o,e,i),l&&a&&a.outlet&&a.outlet.isActivated&&i.canDeactivateChecks.push(new ri(a.outlet.component,s))}else s&&qi(t,a,i),i.canActivateChecks.push(new go(e)),r.component?$i(n,null,a?a.children:null,e,i):$i(n,null,o,e,i);return i}function um(n,t,o){if(typeof o=="function")return o(n,t);switch(o){case"pathParamsChange":return!Pe(n.url,t.url);case"pathParamsOrQueryParamsChange":return!Pe(n.url,t.url)||!$t(n.queryParams,t.queryParams);case"always":return!0;case"paramsOrQueryParamsChange":return!us(n,t)||!$t(n.queryParams,t.queryParams);case"paramsChange":default:return!us(n,t)}}function qi(n,t,o){let e=ni(n),i=n.value;Object.entries(e).forEach(([r,s])=>{i.component?t?qi(s,t.children.getContext(r),o):qi(s,null,o):qi(s,t,o)}),i.component?t&&t.outlet&&t.outlet.isActivated?o.canDeactivateChecks.push(new ri(t.outlet.component,i)):o.canDeactivateChecks.push(new ri(null,i)):o.canDeactivateChecks.push(new ri(null,i))}function ln(n){return typeof n=="function"}function hm(n){return typeof n=="boolean"}function mm(n){return n&&ln(n.canLoad)}function fm(n){return n&&ln(n.canActivate)}function pm(n){return n&&ln(n.canActivateChild)}function gm(n){return n&&ln(n.canDeactivate)}function bm(n){return n&&ln(n.canMatch)}function cc(n){return n instanceof Ma||n?.name==="EmptyError"}var no=Symbol("INITIAL_VALUE");function ci(){return vt(n=>Vt(n.map(t=>t.pipe(ut(1),Xt(no)))).pipe(M(t=>{for(let o of t)if(o!==!0){if(o===no)return no;if(o===!1||o instanceof pe)return o}return!0}),dt(t=>t!==no),ut(1)))}function vm(n,t){return Rt(o=>{let{targetSnapshot:e,currentSnapshot:i,guards:{canActivateChecks:r,canDeactivateChecks:s}}=o;return s.length===0&&r.length===0?v(q(p({},o),{guardsResult:!0})):_m(s,e,i,n).pipe(Rt(a=>a&&hm(a)?ym(e,r,n,t):v(a)),M(a=>q(p({},o),{guardsResult:a})))})}function _m(n,t,o,e){return ht(n).pipe(Rt(i=>Em(i.component,i.route,o,t,e)),ae(i=>i!==!0,!0))}function ym(n,t,o,e){return ht(t).pipe(se(i=>kn(wm(i.route.parent,e),xm(i.route,e),Dm(n,i.path,o),Cm(n,i.route,o))),ae(i=>i!==!0,!0))}function xm(n,t){return n!==null&&t&&t(new ss(n)),v(!0)}function wm(n,t){return n!==null&&t&&t(new os(n)),v(!0)}function Cm(n,t,o){let e=t.routeConfig?t.routeConfig.canActivate:null;if(!e||e.length===0)return v(!0);let i=e.map(r=>lr(()=>{let s=an(t)??o,a=di(r,s),l=fm(a)?a.canActivate(t,n):zt(s,()=>a(t,n));return ve(l).pipe(ae())}));return v(i).pipe(ci())}function Dm(n,t,o){let e=t[t.length-1],r=t.slice(0,t.length-1).reverse().map(s=>cm(s)).filter(s=>s!==null).map(s=>lr(()=>{let a=s.guards.map(l=>{let c=an(s.node)??o,d=di(l,c),h=pm(d)?d.canActivateChild(e,n):zt(c,()=>d(e,n));return ve(h).pipe(ae())});return v(a).pipe(ci())}));return v(r).pipe(ci())}function Em(n,t,o,e,i){let r=t&&t.routeConfig?t.routeConfig.canDeactivate:null;if(!r||r.length===0)return v(!0);let s=r.map(a=>{let l=an(t)??i,c=di(a,l),d=gm(c)?c.canDeactivate(n,t,o,e):zt(l,()=>c(n,t,o,e));return ve(d).pipe(ae())});return v(s).pipe(ci())}function Sm(n,t,o,e){let i=t.canLoad;if(i===void 0||i.length===0)return v(!0);let r=i.map(s=>{let a=di(s,n),l=mm(a)?a.canLoad(t,o):zt(n,()=>a(t,o));return ve(l)});return v(r).pipe(ci(),dc(e))}function dc(n){return Ra(et(t=>{if(ai(t))throw sc(n,t)}),M(t=>t===!0))}function Im(n,t,o,e){let i=t.canMatch;if(!i||i.length===0)return v(!0);let r=i.map(s=>{let a=di(s,n),l=bm(a)?a.canMatch(t,o):zt(n,()=>a(t,o));return ve(l)});return v(r).pipe(ci(),dc(e))}var nn=class{constructor(t){this.segmentGroup=t||null}},bo=class extends Error{constructor(t){super(),this.urlTree=t}};function ii(n){return Ce(new nn(n))}function Rm(n){return Ce(new $(4e3,!1))}function Mm(n){return Ce(ac(!1,At.GuardRejected))}var fs=class{constructor(t,o){this.urlSerializer=t,this.urlTree=o}lineralizeSegments(t,o){let e=[],i=o.root;for(;;){if(e=e.concat(i.segments),i.numberOfChildren===0)return v(e);if(i.numberOfChildren>1||!i.children[O])return Rm(t.redirectTo);i=i.children[O]}}applyRedirectCommands(t,o,e){let i=this.applyRedirectCreateUrlTree(o,this.urlSerializer.parse(o),t,e);if(o.startsWith("/"))throw new bo(i);return i}applyRedirectCreateUrlTree(t,o,e,i){let r=this.createSegmentGroup(t,o.root,e,i);return new pe(r,this.createQueryParams(o.queryParams,this.urlTree.queryParams),o.fragment)}createQueryParams(t,o){let e={};return Object.entries(t).forEach(([i,r])=>{if(typeof r=="string"&&r.startsWith(":")){let a=r.substring(1);e[i]=o[a]}else e[i]=r}),e}createSegmentGroup(t,o,e,i){let r=this.createSegments(t,o.segments,e,i),s={};return Object.entries(o.children).forEach(([a,l])=>{s[a]=this.createSegmentGroup(t,l,e,i)}),new G(r,s)}createSegments(t,o,e,i){return o.map(r=>r.path.startsWith(":")?this.findPosParam(t,r,i):this.findOrReturn(r,e))}findPosParam(t,o,e){let i=e[o.path.substring(1)];if(!i)throw new $(4001,!1);return i}findOrReturn(t,o){let e=0;for(let i of o){if(i.path===t.path)return o.splice(e),i;e++}return t}},ps={matched:!1,consumedSegments:[],remainingSegments:[],parameters:{},positionalParamSegments:{}};function km(n,t,o,e,i){let r=Cs(n,t,o);return r.matched?(e=rm(t,e),Im(e,t,o,i).pipe(M(s=>s===!0?r:p({},ps)))):v(r)}function Cs(n,t,o){if(t.path==="**")return Tm(o);if(t.path==="")return t.pathMatch==="full"&&(n.hasChildren()||o.length>0)?p({},ps):{matched:!0,consumedSegments:[],remainingSegments:o,parameters:{},positionalParamSegments:{}};let i=(t.matcher||Ih)(o,n,t);if(!i)return p({},ps);let r={};Object.entries(i.posParams??{}).forEach(([a,l])=>{r[a]=l.path});let s=i.consumed.length>0?p(p({},r),i.consumed[i.consumed.length-1].parameters):r;return{matched:!0,consumedSegments:i.consumed,remainingSegments:o.slice(i.consumed.length),parameters:s,positionalParamSegments:i.posParams??{}}}function Tm(n){return{matched:!0,parameters:n.length>0?Hl(n).parameters:{},consumedSegments:n,remainingSegments:[],positionalParamSegments:{}}}function Vl(n,t,o,e){return o.length>0&&Om(n,o,e)?{segmentGroup:new G(t,Fm(e,new G(o,n.children))),slicedSegments:[]}:o.length===0&&Nm(n,o,e)?{segmentGroup:new G(n.segments,Am(n,o,e,n.children)),slicedSegments:o}:{segmentGroup:new G(n.segments,n.children),slicedSegments:o}}function Am(n,t,o,e){let i={};for(let r of o)if(xo(n,t,r)&&!e[Gt(r)]){let s=new G([],{});i[Gt(r)]=s}return p(p({},e),i)}function Fm(n,t){let o={};o[O]=t;for(let e of n)if(e.path===""&&Gt(e)!==O){let i=new G([],{});o[Gt(e)]=i}return o}function Om(n,t,o){return o.some(e=>xo(n,t,e)&&Gt(e)!==O)}function Nm(n,t,o){return o.some(e=>xo(n,t,e))}function xo(n,t,o){return(n.hasChildren()||t.length>0)&&o.pathMatch==="full"?!1:o.path===""}function Pm(n,t,o,e){return Gt(n)!==e&&(e===O||!xo(t,o,n))?!1:Cs(t,n,o).matched}function Lm(n,t,o){return t.length===0&&!n.children[o]}var gs=class{};function jm(n,t,o,e,i,r,s="emptyOnly"){return new bs(n,t,o,e,i,s,r).recognize()}var Vm=31,bs=class{constructor(t,o,e,i,r,s,a){this.injector=t,this.configLoader=o,this.rootComponentType=e,this.config=i,this.urlTree=r,this.paramsInheritanceStrategy=s,this.urlSerializer=a,this.applyRedirects=new fs(this.urlSerializer,this.urlTree),this.absoluteRedirectCount=0,this.allowRedirects=!0}noMatchError(t){return new $(4002,`'${t.segmentGroup}'`)}recognize(){let t=Vl(this.urlTree.root,[],[],this.config).segmentGroup;return this.match(t).pipe(M(o=>{let e=new tn([],Object.freeze({}),Object.freeze(p({},this.urlTree.queryParams)),this.urlTree.fragment,{},O,this.rootComponentType,null,{}),i=new Tt(e,o),r=new po("",i),s=Gh(e,[],this.urlTree.queryParams,this.urlTree.fragment);return s.queryParams=this.urlTree.queryParams,r.url=this.urlSerializer.serialize(s),this.inheritParamsAndData(r._root,null),{state:r,tree:s}}))}match(t){return this.processSegmentGroup(this.injector,this.config,t,O).pipe(re(e=>{if(e instanceof bo)return this.urlTree=e.urlTree,this.match(e.urlTree.root);throw e instanceof nn?this.noMatchError(e):e}))}inheritParamsAndData(t,o){let e=t.value,i=_s(e,o,this.paramsInheritanceStrategy);e.params=Object.freeze(i.params),e.data=Object.freeze(i.data),t.children.forEach(r=>this.inheritParamsAndData(r,e))}processSegmentGroup(t,o,e,i){return e.segments.length===0&&e.hasChildren()?this.processChildren(t,o,e):this.processSegment(t,o,e,e.segments,i,!0).pipe(M(r=>r instanceof Tt?[r]:[]))}processChildren(t,o,e){let i=[];for(let r of Object.keys(e.children))r==="primary"?i.unshift(r):i.push(r);return ht(i).pipe(se(r=>{let s=e.children[r],a=sm(o,r);return this.processSegmentGroup(t,a,s,r)}),Fa((r,s)=>(r.push(...s),r)),dr(null),Aa(),Rt(r=>{if(r===null)return ii(e);let s=uc(r);return zm(s),v(s)}))}processSegment(t,o,e,i,r,s){return ht(o).pipe(se(a=>this.processSegmentAgainstRoute(a._injector??t,o,a,e,i,r,s).pipe(re(l=>{if(l instanceof nn)return v(null);throw l}))),ae(a=>!!a),re(a=>{if(cc(a))return Lm(e,i,r)?v(new gs):ii(e);throw a}))}processSegmentAgainstRoute(t,o,e,i,r,s,a){return Pm(e,i,r,s)?e.redirectTo===void 0?this.matchSegmentAgainstRoute(t,i,e,r,s):this.allowRedirects&&a?this.expandSegmentAgainstRouteUsingRedirect(t,i,o,e,r,s):ii(i):ii(i)}expandSegmentAgainstRouteUsingRedirect(t,o,e,i,r,s){let{matched:a,consumedSegments:l,positionalParamSegments:c,remainingSegments:d}=Cs(o,i,r);if(!a)return ii(o);i.redirectTo.startsWith("/")&&(this.absoluteRedirectCount++,this.absoluteRedirectCount>Vm&&(this.allowRedirects=!1));let h=this.applyRedirects.applyRedirectCommands(l,i.redirectTo,c);return this.applyRedirects.lineralizeSegments(i,h).pipe(Rt(f=>this.processSegment(t,e,o,f.concat(d),s,!1)))}matchSegmentAgainstRoute(t,o,e,i,r){let s=km(o,e,i,t,this.urlSerializer);return e.path==="**"&&(o.children={}),s.pipe(vt(a=>a.matched?(t=e._injector??t,this.getChildConfig(t,e,i).pipe(vt(({routes:l})=>{let c=e._loadedInjector??t,{consumedSegments:d,remainingSegments:h,parameters:f}=a,w=new tn(d,f,Object.freeze(p({},this.urlTree.queryParams)),this.urlTree.fragment,Um(e),Gt(e),e.component??e._loadedComponent??null,e,Hm(e)),{segmentGroup:j,slicedSegments:z}=Vl(o,d,h,l);if(z.length===0&&j.hasChildren())return this.processChildren(c,l,j).pipe(M(V=>V===null?null:new Tt(w,V)));if(l.length===0&&z.length===0)return v(new Tt(w,[]));let k=Gt(e)===r;return this.processSegment(c,l,j,z,k?O:r,!0).pipe(M(V=>new Tt(w,V instanceof Tt?[V]:[])))}))):ii(o)))}getChildConfig(t,o,e){return o.children?v({routes:o.children,injector:t}):o.loadChildren?o._loadedRoutes!==void 0?v({routes:o._loadedRoutes,injector:o._loadedInjector}):Sm(t,o,e,this.urlSerializer).pipe(Rt(i=>i?this.configLoader.loadChildren(t,o).pipe(et(r=>{o._loadedRoutes=r.routes,o._loadedInjector=r.injector})):Mm(o))):v({routes:[],injector:t})}};function zm(n){n.sort((t,o)=>t.value.outlet===O?-1:o.value.outlet===O?1:t.value.outlet.localeCompare(o.value.outlet))}function Bm(n){let t=n.value.routeConfig;return t&&t.path===""}function uc(n){let t=[],o=new Set;for(let e of n){if(!Bm(e)){t.push(e);continue}let i=t.find(r=>e.value.routeConfig===r.value.routeConfig);i!==void 0?(i.children.push(...e.children),o.add(i)):t.push(e)}for(let e of o){let i=uc(e.children);t.push(new Tt(e.value,i))}return t.filter(e=>!o.has(e))}function Um(n){return n.data||{}}function Hm(n){return n.resolve||{}}function $m(n,t,o,e,i,r){return Rt(s=>jm(n,t,o,e,s.extractedUrl,i,r).pipe(M(({state:a,tree:l})=>q(p({},s),{targetSnapshot:a,urlAfterRedirects:l}))))}function Wm(n,t){return Rt(o=>{let{targetSnapshot:e,guards:{canActivateChecks:i}}=o;if(!i.length)return v(o);let r=new Set(i.map(l=>l.route)),s=new Set;for(let l of r)if(!s.has(l))for(let c of hc(l))s.add(c);let a=0;return ht(s).pipe(se(l=>r.has(l)?Gm(l,e,n,t):(l.data=_s(l,l.parent,n).resolve,v(void 0))),et(()=>a++),mr(1),Rt(l=>a===s.size?v(o):oe))})}function hc(n){let t=n.children.map(o=>hc(o)).flat();return[n,...t]}function Gm(n,t,o,e){let i=n.routeConfig,r=n._resolve;return i?.title!==void 0&&!oc(i)&&(r[on]=i.title),Ym(r,n,t,e).pipe(M(s=>(n._resolvedData=s,n.data=_s(n,n.parent,o).resolve,null)))}function Ym(n,t,o,e){let i=qr(n);if(i.length===0)return v({});let r={};return ht(i).pipe(Rt(s=>qm(n[s],t,o,e).pipe(ae(),et(a=>{r[s]=a}))),mr(1),Ta(r),re(s=>cc(s)?oe:Ce(s)))}function qm(n,t,o,e){let i=an(t)??e,r=di(n,i),s=r.resolve?r.resolve(t,o):zt(i,()=>r(t,o));return ve(s)}function Gr(n){return vt(t=>{let o=n(t);return o?ht(o).pipe(M(()=>t)):v(t)})}var mc=(()=>{let t=class t{buildTitle(e){let i,r=e.root;for(;r!==void 0;)i=this.getResolvedTitleForRoute(r)??i,r=r.children.find(s=>s.outlet===O);return i}getResolvedTitleForRoute(e){return e.data[on]}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:()=>g(Zm),providedIn:"root"});let n=t;return n})(),Zm=(()=>{let t=class t extends mc{constructor(e){super(),this.title=e}updateTitle(e){let i=this.buildTitle(e);i!==void 0&&this.title.setTitle(i)}};t.\u0275fac=function(i){return new(i||t)(m(Fl))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),cn=new C("",{providedIn:"root",factory:()=>({})}),vo=new C(""),Ds=(()=>{let t=class t{constructor(){this.componentLoaders=new WeakMap,this.childrenLoaders=new WeakMap,this.compiler=g(Bn)}loadComponent(e){if(this.componentLoaders.get(e))return this.componentLoaders.get(e);if(e._loadedComponent)return v(e._loadedComponent);this.onLoadStartListener&&this.onLoadStartListener(e);let i=ve(e.loadComponent()).pipe(M(fc),et(s=>{this.onLoadEndListener&&this.onLoadEndListener(e),e._loadedComponent=s}),Zt(()=>{this.componentLoaders.delete(e)})),r=new Ei(i,()=>new N).pipe(sr());return this.componentLoaders.set(e,r),r}loadChildren(e,i){if(this.childrenLoaders.get(i))return this.childrenLoaders.get(i);if(i._loadedRoutes)return v({routes:i._loadedRoutes,injector:i._loadedInjector});this.onLoadStartListener&&this.onLoadStartListener(i);let s=Xm(i,this.compiler,e,this.onLoadEndListener).pipe(Zt(()=>{this.childrenLoaders.delete(i)})),a=new Ei(s,()=>new N).pipe(sr());return this.childrenLoaders.set(i,a),a}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function Xm(n,t,o,e){return ve(n.loadChildren()).pipe(M(fc),Rt(i=>i instanceof Za||Array.isArray(i)?v(i):ht(t.compileModuleAsync(i))),M(i=>{e&&e(n);let r,s,a=!1;return Array.isArray(i)?(s=i,a=!0):(r=i.create(o).injector,s=r.get(vo,[],{optional:!0,self:!0}).flat()),{routes:s.map(ws),injector:r}}))}function Km(n){return n&&typeof n=="object"&&"default"in n}function fc(n){return Km(n)?n.default:n}var Es=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:()=>g(Qm),providedIn:"root"});let n=t;return n})(),Qm=(()=>{let t=class t{shouldProcessUrl(e){return!0}extract(e){return e}merge(e,i){return e}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),pc=new C(""),gc=new C("");function Jm(n,t,o){let e=n.get(gc),i=n.get(T);return n.get(I).runOutsideAngular(()=>{if(!i.startViewTransition||e.skipNextTransition)return e.skipNextTransition=!1,new Promise(c=>setTimeout(c));let r,s=new Promise(c=>{r=c}),a=i.startViewTransition(()=>(r(),tf(n))),{onViewTransitionCreated:l}=e;return l&&zt(n,()=>l({transition:a,from:t,to:o})),s})}function tf(n){return new Promise(t=>{br(t,{injector:n})})}var Ss=(()=>{let t=class t{get hasRequestedNavigation(){return this.navigationId!==0}constructor(){this.currentNavigation=null,this.currentTransition=null,this.lastSuccessfulNavigation=null,this.events=new N,this.transitionAbortSubject=new N,this.configLoader=g(Ds),this.environmentInjector=g(ce),this.urlSerializer=g(rn),this.rootContexts=g(sn),this.location=g(Te),this.inputBindingEnabled=g(yo,{optional:!0})!==null,this.titleStrategy=g(mc),this.options=g(cn,{optional:!0})||{},this.paramsInheritanceStrategy=this.options.paramsInheritanceStrategy||"emptyOnly",this.urlHandlingStrategy=g(Es),this.createViewTransition=g(pc,{optional:!0}),this.navigationId=0,this.afterPreactivation=()=>v(void 0),this.rootComponentType=null;let e=r=>this.events.next(new is(r)),i=r=>this.events.next(new ns(r));this.configLoader.onLoadEndListener=i,this.configLoader.onLoadStartListener=e}complete(){this.transitions?.complete()}handleNavigationRequest(e){let i=++this.navigationId;this.transitions?.next(q(p(p({},this.transitions.value),e),{id:i}))}setupNavigations(e,i,r){return this.transitions=new rt({id:0,currentUrlTree:i,currentRawUrl:i,extractedUrl:this.urlHandlingStrategy.extract(i),urlAfterRedirects:this.urlHandlingStrategy.extract(i),rawUrl:i,extras:{},resolve:null,reject:null,promise:Promise.resolve(!0),source:Yi,restoredState:null,currentSnapshot:r.snapshot,targetSnapshot:null,currentRouterState:r,targetRouterState:null,guards:{canActivateChecks:[],canDeactivateChecks:[]},guardsResult:null}),this.transitions.pipe(dt(s=>s.id!==0),M(s=>q(p({},s),{extractedUrl:this.urlHandlingStrategy.extract(s.rawUrl)})),vt(s=>{let a=!1,l=!1;return v(s).pipe(vt(c=>{if(this.navigationId>s.id)return this.cancelNavigationTransition(s,"",At.SupersededByNewNavigation),oe;this.currentTransition=s,this.currentNavigation={id:c.id,initialUrl:c.rawUrl,extractedUrl:c.extractedUrl,trigger:c.source,extras:c.extras,previousNavigation:this.lastSuccessfulNavigation?q(p({},this.lastSuccessfulNavigation),{previousNavigation:null}):null};let d=!e.navigated||this.isUpdatingInternalState()||this.isUpdatedBrowserUrl(),h=c.extras.onSameUrlNavigation??e.onSameUrlNavigation;if(!d&&h!=="reload"){let f="";return this.events.next(new be(c.id,this.urlSerializer.serialize(c.rawUrl),f,co.IgnoredSameUrlNavigation)),c.resolve(null),oe}if(this.urlHandlingStrategy.shouldProcessUrl(c.rawUrl))return v(c).pipe(vt(f=>{let w=this.transitions?.getValue();return this.events.next(new li(f.id,this.urlSerializer.serialize(f.extractedUrl),f.source,f.restoredState)),w!==this.transitions?.getValue()?oe:Promise.resolve(f)}),$m(this.environmentInjector,this.configLoader,this.rootComponentType,e.config,this.urlSerializer,this.paramsInheritanceStrategy),et(f=>{s.targetSnapshot=f.targetSnapshot,s.urlAfterRedirects=f.urlAfterRedirects,this.currentNavigation=q(p({},this.currentNavigation),{finalUrl:f.urlAfterRedirects});let w=new uo(f.id,this.urlSerializer.serialize(f.extractedUrl),this.urlSerializer.serialize(f.urlAfterRedirects),f.targetSnapshot);this.events.next(w)}));if(d&&this.urlHandlingStrategy.shouldProcessUrl(c.currentRawUrl)){let{id:f,extractedUrl:w,source:j,restoredState:z,extras:k}=c,V=new li(f,this.urlSerializer.serialize(w),j,z);this.events.next(V);let Pt=ic(this.rootComponentType).snapshot;return this.currentTransition=s=q(p({},c),{targetSnapshot:Pt,urlAfterRedirects:w,extras:q(p({},k),{skipLocationChange:!1,replaceUrl:!1})}),this.currentNavigation.finalUrl=w,v(s)}else{let f="";return this.events.next(new be(c.id,this.urlSerializer.serialize(c.extractedUrl),f,co.IgnoredByUrlHandlingStrategy)),c.resolve(null),oe}}),et(c=>{let d=new Qr(c.id,this.urlSerializer.serialize(c.extractedUrl),this.urlSerializer.serialize(c.urlAfterRedirects),c.targetSnapshot);this.events.next(d)}),M(c=>(this.currentTransition=s=q(p({},c),{guards:lm(c.targetSnapshot,c.currentSnapshot,this.rootContexts)}),s)),vm(this.environmentInjector,c=>this.events.next(c)),et(c=>{if(s.guardsResult=c.guardsResult,ai(c.guardsResult))throw sc(this.urlSerializer,c.guardsResult);let d=new Jr(c.id,this.urlSerializer.serialize(c.extractedUrl),this.urlSerializer.serialize(c.urlAfterRedirects),c.targetSnapshot,!!c.guardsResult);this.events.next(d)}),dt(c=>c.guardsResult?!0:(this.cancelNavigationTransition(c,"",At.GuardRejected),!1)),Gr(c=>{if(c.guards.canActivateChecks.length)return v(c).pipe(et(d=>{let h=new ts(d.id,this.urlSerializer.serialize(d.extractedUrl),this.urlSerializer.serialize(d.urlAfterRedirects),d.targetSnapshot);this.events.next(h)}),vt(d=>{let h=!1;return v(d).pipe(Wm(this.paramsInheritanceStrategy,this.environmentInjector),et({next:()=>h=!0,complete:()=>{h||this.cancelNavigationTransition(d,"",At.NoDataFromResolver)}}))}),et(d=>{let h=new es(d.id,this.urlSerializer.serialize(d.extractedUrl),this.urlSerializer.serialize(d.urlAfterRedirects),d.targetSnapshot);this.events.next(h)}))}),Gr(c=>{let d=h=>{let f=[];h.routeConfig?.loadComponent&&!h.routeConfig._loadedComponent&&f.push(this.configLoader.loadComponent(h.routeConfig).pipe(et(w=>{h.component=w}),M(()=>{})));for(let w of h.children)f.push(...d(w));return f};return Vt(d(c.targetSnapshot.root)).pipe(dr(null),ut(1))}),Gr(()=>this.afterPreactivation()),vt(()=>{let{currentSnapshot:c,targetSnapshot:d}=s,h=this.createViewTransition?.(this.environmentInjector,c.root,d.root);return h?ht(h).pipe(M(()=>s)):v(s)}),M(c=>{let d=tm(e.routeReuseStrategy,c.targetSnapshot,c.currentRouterState);return this.currentTransition=s=q(p({},c),{targetRouterState:d}),this.currentNavigation.targetRouterState=d,s}),et(()=>{this.events.next(new Qi)}),am(this.rootContexts,e.routeReuseStrategy,c=>this.events.next(c),this.inputBindingEnabled),ut(1),et({next:c=>{a=!0,this.lastSuccessfulNavigation=this.currentNavigation,this.events.next(new Wt(c.id,this.urlSerializer.serialize(c.extractedUrl),this.urlSerializer.serialize(c.urlAfterRedirects))),this.titleStrategy?.updateTitle(c.targetRouterState.snapshot),c.resolve(!0)},complete:()=>{a=!0}}),mt(this.transitionAbortSubject.pipe(et(c=>{throw c}))),Zt(()=>{!a&&!l&&this.cancelNavigationTransition(s,"",At.SupersededByNewNavigation),this.currentTransition?.id===s.id&&(this.currentNavigation=null,this.currentTransition=null)}),re(c=>{if(l=!0,lc(c))this.events.next(new ge(s.id,this.urlSerializer.serialize(s.extractedUrl),c.message,c.cancellationCode)),nm(c)?this.events.next(new Ji(c.url)):s.resolve(!1);else{this.events.next(new Ki(s.id,this.urlSerializer.serialize(s.extractedUrl),c,s.targetSnapshot??void 0));try{s.resolve(e.errorHandler(c))}catch(d){this.options.resolveNavigationPromiseOnError?s.resolve(!1):s.reject(d)}}return oe}))}))}cancelNavigationTransition(e,i,r){let s=new ge(e.id,this.urlSerializer.serialize(e.extractedUrl),i,r);this.events.next(s),e.resolve(!1)}isUpdatingInternalState(){return this.currentTransition?.extractedUrl.toString()!==this.currentTransition?.currentUrlTree.toString()}isUpdatedBrowserUrl(){return this.urlHandlingStrategy.extract(this.urlSerializer.parse(this.location.path(!0))).toString()!==this.currentTransition?.extractedUrl.toString()&&!this.currentTransition?.extras.skipLocationChange}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function ef(n){return n!==Yi}var nf=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:()=>g(of),providedIn:"root"});let n=t;return n})(),vs=class{shouldDetach(t){return!1}store(t,o){}shouldAttach(t){return!1}retrieve(t){return null}shouldReuseRoute(t,o){return t.routeConfig===o.routeConfig}},of=(()=>{let t=class t extends vs{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),bc=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:()=>g(rf),providedIn:"root"});let n=t;return n})(),rf=(()=>{let t=class t extends bc{constructor(){super(...arguments),this.location=g(Te),this.urlSerializer=g(rn),this.options=g(cn,{optional:!0})||{},this.canceledNavigationResolution=this.options.canceledNavigationResolution||"replace",this.urlHandlingStrategy=g(Es),this.urlUpdateStrategy=this.options.urlUpdateStrategy||"deferred",this.currentUrlTree=new pe,this.rawUrlTree=this.currentUrlTree,this.currentPageId=0,this.lastSuccessfulId=-1,this.routerState=ic(null),this.stateMemento=this.createStateMemento()}getCurrentUrlTree(){return this.currentUrlTree}getRawUrlTree(){return this.rawUrlTree}restoredState(){return this.location.getState()}get browserPageId(){return this.canceledNavigationResolution!=="computed"?this.currentPageId:this.restoredState()?.\u0275routerPageId??this.currentPageId}getRouterState(){return this.routerState}createStateMemento(){return{rawUrlTree:this.rawUrlTree,currentUrlTree:this.currentUrlTree,routerState:this.routerState}}registerNonRouterCurrentEntryChangeListener(e){return this.location.subscribe(i=>{i.type==="popstate"&&e(i.url,i.state)})}handleRouterEvent(e,i){if(e instanceof li)this.stateMemento=this.createStateMemento();else if(e instanceof be)this.rawUrlTree=i.initialUrl;else if(e instanceof uo){if(this.urlUpdateStrategy==="eager"&&!i.extras.skipLocationChange){let r=this.urlHandlingStrategy.merge(i.finalUrl,i.initialUrl);this.setBrowserUrl(r,i)}}else e instanceof Qi?(this.currentUrlTree=i.finalUrl,this.rawUrlTree=this.urlHandlingStrategy.merge(i.finalUrl,i.initialUrl),this.routerState=i.targetRouterState,this.urlUpdateStrategy==="deferred"&&(i.extras.skipLocationChange||this.setBrowserUrl(this.rawUrlTree,i))):e instanceof ge&&(e.code===At.GuardRejected||e.code===At.NoDataFromResolver)?this.restoreHistory(i):e instanceof Ki?this.restoreHistory(i,!0):e instanceof Wt&&(this.lastSuccessfulId=e.id,this.currentPageId=this.browserPageId)}setBrowserUrl(e,i){let r=this.urlSerializer.serialize(e);if(this.location.isCurrentPathEqualTo(r)||i.extras.replaceUrl){let s=this.browserPageId,a=p(p({},i.extras.state),this.generateNgRouterState(i.id,s));this.location.replaceState(r,"",a)}else{let s=p(p({},i.extras.state),this.generateNgRouterState(i.id,this.browserPageId+1));this.location.go(r,"",s)}}restoreHistory(e,i=!1){if(this.canceledNavigationResolution==="computed"){let r=this.browserPageId,s=this.currentPageId-r;s!==0?this.location.historyGo(s):this.currentUrlTree===e.finalUrl&&s===0&&(this.resetState(e),this.resetUrlToCurrentUrlTree())}else this.canceledNavigationResolution==="replace"&&(i&&this.resetState(e),this.resetUrlToCurrentUrlTree())}resetState(e){this.routerState=this.stateMemento.routerState,this.currentUrlTree=this.stateMemento.currentUrlTree,this.rawUrlTree=this.urlHandlingStrategy.merge(this.currentUrlTree,e.finalUrl??this.rawUrlTree)}resetUrlToCurrentUrlTree(){this.location.replaceState(this.urlSerializer.serialize(this.rawUrlTree),"",this.generateNgRouterState(this.lastSuccessfulId,this.currentPageId))}generateNgRouterState(e,i){return this.canceledNavigationResolution==="computed"?{navigationId:e,\u0275routerPageId:i}:{navigationId:e}}};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),Wi=function(n){return n[n.COMPLETE=0]="COMPLETE",n[n.FAILED=1]="FAILED",n[n.REDIRECTING=2]="REDIRECTING",n}(Wi||{});function vc(n,t){n.events.pipe(dt(o=>o instanceof Wt||o instanceof ge||o instanceof Ki||o instanceof be),M(o=>o instanceof Wt||o instanceof be?Wi.COMPLETE:(o instanceof ge?o.code===At.Redirect||o.code===At.SupersededByNewNavigation:!1)?Wi.REDIRECTING:Wi.FAILED),dt(o=>o!==Wi.REDIRECTING),ut(1)).subscribe(()=>{t()})}function sf(n){throw n}var af={paths:"exact",fragment:"ignored",matrixParams:"ignored",queryParams:"exact"},lf={paths:"subset",fragment:"ignored",matrixParams:"ignored",queryParams:"subset"},Yt=(()=>{let t=class t{get currentUrlTree(){return this.stateManager.getCurrentUrlTree()}get rawUrlTree(){return this.stateManager.getRawUrlTree()}get events(){return this._events}get routerState(){return this.stateManager.getRouterState()}constructor(){this.disposed=!1,this.isNgZoneEnabled=!1,this.console=g(Ln),this.stateManager=g(bc),this.options=g(cn,{optional:!0})||{},this.pendingTasks=g(Fi),this.urlUpdateStrategy=this.options.urlUpdateStrategy||"deferred",this.navigationTransitions=g(Ss),this.urlSerializer=g(rn),this.location=g(Te),this.urlHandlingStrategy=g(Es),this._events=new N,this.errorHandler=this.options.errorHandler||sf,this.navigated=!1,this.routeReuseStrategy=g(nf),this.onSameUrlNavigation=this.options.onSameUrlNavigation||"ignore",this.config=g(vo,{optional:!0})?.flat()??[],this.componentInputBindingEnabled=!!g(yo,{optional:!0}),this.eventsSubscription=new St,this.isNgZoneEnabled=g(I)instanceof I&&I.isInAngularZone(),this.resetConfig(this.config),this.navigationTransitions.setupNavigations(this,this.currentUrlTree,this.routerState).subscribe({error:e=>{this.console.warn(e)}}),this.subscribeToNavigationEvents()}subscribeToNavigationEvents(){let e=this.navigationTransitions.events.subscribe(i=>{try{let r=this.navigationTransitions.currentTransition,s=this.navigationTransitions.currentNavigation;if(r!==null&&s!==null){if(this.stateManager.handleRouterEvent(i,s),i instanceof ge&&i.code!==At.Redirect&&i.code!==At.SupersededByNewNavigation)this.navigated=!0;else if(i instanceof Wt)this.navigated=!0;else if(i instanceof Ji){let a=this.urlHandlingStrategy.merge(i.url,r.currentRawUrl),l={info:r.extras.info,skipLocationChange:r.extras.skipLocationChange,replaceUrl:this.urlUpdateStrategy==="eager"||ef(r.source)};this.scheduleNavigation(a,Yi,null,l,{resolve:r.resolve,reject:r.reject,promise:r.promise})}}df(i)&&this._events.next(i)}catch(r){this.navigationTransitions.transitionAbortSubject.next(r)}});this.eventsSubscription.add(e)}resetRootComponentType(e){this.routerState.root.component=e,this.navigationTransitions.rootComponentType=e}initialNavigation(){this.setUpLocationChangeListener(),this.navigationTransitions.hasRequestedNavigation||this.navigateToSyncWithBrowser(this.location.path(!0),Yi,this.stateManager.restoredState())}setUpLocationChangeListener(){this.nonRouterCurrentEntryChangeSubscription??=this.stateManager.registerNonRouterCurrentEntryChangeListener((e,i)=>{setTimeout(()=>{this.navigateToSyncWithBrowser(e,"popstate",i)},0)})}navigateToSyncWithBrowser(e,i,r){let s={replaceUrl:!0},a=r?.navigationId?r:null;if(r){let c=p({},r);delete c.navigationId,delete c.\u0275routerPageId,Object.keys(c).length!==0&&(s.state=c)}let l=this.parseUrl(e);this.scheduleNavigation(l,i,a,s)}get url(){return this.serializeUrl(this.currentUrlTree)}getCurrentNavigation(){return this.navigationTransitions.currentNavigation}get lastSuccessfulNavigation(){return this.navigationTransitions.lastSuccessfulNavigation}resetConfig(e){this.config=e.map(ws),this.navigated=!1}ngOnDestroy(){this.dispose()}dispose(){this.navigationTransitions.complete(),this.nonRouterCurrentEntryChangeSubscription&&(this.nonRouterCurrentEntryChangeSubscription.unsubscribe(),this.nonRouterCurrentEntryChangeSubscription=void 0),this.disposed=!0,this.eventsSubscription.unsubscribe()}createUrlTree(e,i={}){let{relativeTo:r,queryParams:s,fragment:a,queryParamsHandling:l,preserveFragment:c}=i,d=c?this.currentUrlTree.fragment:a,h=null;switch(l){case"merge":h=p(p({},this.currentUrlTree.queryParams),s);break;case"preserve":h=this.currentUrlTree.queryParams;break;default:h=s||null}h!==null&&(h=this.removeEmptyProps(h));let f;try{let w=r?r.snapshot:this.routerState.snapshot.root;f=Ql(w)}catch{(typeof e[0]!="string"||!e[0].startsWith("/"))&&(e=[]),f=this.currentUrlTree.root}return Jl(f,e,h,d??null)}navigateByUrl(e,i={skipLocationChange:!1}){let r=ai(e)?e:this.parseUrl(e),s=this.urlHandlingStrategy.merge(r,this.rawUrlTree);return this.scheduleNavigation(s,Yi,null,i)}navigate(e,i={skipLocationChange:!1}){return cf(e),this.navigateByUrl(this.createUrlTree(e,i),i)}serializeUrl(e){return this.urlSerializer.serialize(e)}parseUrl(e){try{return this.urlSerializer.parse(e)}catch{return this.urlSerializer.parse("/")}}isActive(e,i){let r;if(i===!0?r=p({},af):i===!1?r=p({},lf):r=i,ai(e))return Ol(this.currentUrlTree,e,r);let s=this.parseUrl(e);return Ol(this.currentUrlTree,s,r)}removeEmptyProps(e){return Object.entries(e).reduce((i,[r,s])=>(s!=null&&(i[r]=s),i),{})}scheduleNavigation(e,i,r,s,a){if(this.disposed)return Promise.resolve(!1);let l,c,d;a?(l=a.resolve,c=a.reject,d=a.promise):d=new Promise((f,w)=>{l=f,c=w});let h=this.pendingTasks.add();return vc(this,()=>{queueMicrotask(()=>this.pendingTasks.remove(h))}),this.navigationTransitions.handleNavigationRequest({source:i,restoredState:r,currentUrlTree:this.currentUrlTree,currentRawUrl:this.currentUrlTree,rawUrl:e,extras:s,resolve:l,reject:c,promise:d,currentSnapshot:this.routerState.snapshot,currentRouterState:this.routerState}),d.catch(f=>Promise.reject(f))}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function cf(n){for(let t=0;t<n.length;t++)if(n[t]==null)throw new $(4008,!1)}function df(n){return!(n instanceof Qi)&&!(n instanceof Ji)}var ui=(()=>{let t=class t{constructor(e,i,r,s,a,l){this.router=e,this.route=i,this.tabIndexAttribute=r,this.renderer=s,this.el=a,this.locationStrategy=l,this.href=null,this.commands=null,this.onChanges=new N,this.preserveFragment=!1,this.skipLocationChange=!1,this.replaceUrl=!1;let c=a.nativeElement.tagName?.toLowerCase();this.isAnchorElement=c==="a"||c==="area",this.isAnchorElement?this.subscription=e.events.subscribe(d=>{d instanceof Wt&&this.updateHref()}):this.setTabIndexIfNotOnNativeEl("0")}setTabIndexIfNotOnNativeEl(e){this.tabIndexAttribute!=null||this.isAnchorElement||this.applyAttributeValue("tabindex",e)}ngOnChanges(e){this.isAnchorElement&&this.updateHref(),this.onChanges.next(this)}set routerLink(e){e!=null?(this.commands=Array.isArray(e)?e:[e],this.setTabIndexIfNotOnNativeEl("0")):(this.commands=null,this.setTabIndexIfNotOnNativeEl(null))}onClick(e,i,r,s,a){let l=this.urlTree;if(l===null||this.isAnchorElement&&(e!==0||i||r||s||a||typeof this.target=="string"&&this.target!="_self"))return!0;let c={skipLocationChange:this.skipLocationChange,replaceUrl:this.replaceUrl,state:this.state,info:this.info};return this.router.navigateByUrl(l,c),!this.isAnchorElement}ngOnDestroy(){this.subscription?.unsubscribe()}updateHref(){let e=this.urlTree;this.href=e!==null&&this.locationStrategy?this.locationStrategy?.prepareExternalUrl(this.router.serializeUrl(e)):null;let i=this.href===null?null:Ya(this.href,this.el.nativeElement.tagName.toLowerCase(),"href");this.applyAttributeValue("href",i)}applyAttributeValue(e,i){let r=this.renderer,s=this.el.nativeElement;i!==null?r.setAttribute(s,e,i):r.removeAttribute(s,e)}get urlTree(){return this.commands===null?null:this.router.createUrlTree(this.commands,{relativeTo:this.relativeTo!==void 0?this.relativeTo:this.route,queryParams:this.queryParams,fragment:this.fragment,queryParamsHandling:this.queryParamsHandling,preserveFragment:this.preserveFragment})}};t.\u0275fac=function(i){return new(i||t)(u(Yt),u(ee),De("tabindex"),u(Ai),u(A),u(Pi))},t.\u0275dir=D({type:t,selectors:[["","routerLink",""]],hostVars:1,hostBindings:function(i,r){i&1&&Z("click",function(a){return r.onClick(a.button,a.ctrlKey,a.shiftKey,a.altKey,a.metaKey)}),i&2&&ft("target",r.target)},inputs:{target:"target",queryParams:"queryParams",fragment:"fragment",queryParamsHandling:"queryParamsHandling",state:"state",info:"info",relativeTo:"relativeTo",preserveFragment:[y.HasDecoratorInputTransform,"preserveFragment","preserveFragment",W],skipLocationChange:[y.HasDecoratorInputTransform,"skipLocationChange","skipLocationChange",W],replaceUrl:[y.HasDecoratorInputTransform,"replaceUrl","replaceUrl",W],routerLink:"routerLink"},standalone:!0,features:[nt,yt]});let n=t;return n})();var _o=class{};var uf=(()=>{let t=class t{constructor(e,i,r,s,a){this.router=e,this.injector=r,this.preloadingStrategy=s,this.loader=a}setUpPreloading(){this.subscription=this.router.events.pipe(dt(e=>e instanceof Wt),se(()=>this.preload())).subscribe(()=>{})}preload(){return this.processRoutes(this.injector,this.router.config)}ngOnDestroy(){this.subscription&&this.subscription.unsubscribe()}processRoutes(e,i){let r=[];for(let s of i){s.providers&&!s._injector&&(s._injector=_r(s.providers,e,`Route: ${s.path}`));let a=s._injector??e,l=s._loadedInjector??a;(s.loadChildren&&!s._loadedRoutes&&s.canLoad===void 0||s.loadComponent&&!s._loadedComponent)&&r.push(this.preloadConfig(a,s)),(s.children||s._loadedRoutes)&&r.push(this.processRoutes(l,s.children??s._loadedRoutes))}return ht(r).pipe(ar())}preloadConfig(e,i){return this.preloadingStrategy.preload(i,()=>{let r;i.loadChildren&&i.canLoad===void 0?r=this.loader.loadChildren(e,i):r=v(null);let s=r.pipe(Rt(a=>a===null?v(void 0):(i._loadedRoutes=a.routes,i._loadedInjector=a.injector,this.processRoutes(a.injector??e,a.routes))));if(i.loadComponent&&!i._loadedComponent){let a=this.loader.loadComponent(i);return ht([s,a]).pipe(ar())}else return s})}};t.\u0275fac=function(i){return new(i||t)(m(Yt),m(Bn),m(ce),m(_o),m(Ds))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),_c=new C(""),hf=(()=>{let t=class t{constructor(e,i,r,s,a={}){this.urlSerializer=e,this.transitions=i,this.viewportScroller=r,this.zone=s,this.options=a,this.lastId=0,this.lastSource="imperative",this.restoredId=0,this.store={},this.environmentInjector=g(ce),a.scrollPositionRestoration||="disabled",a.anchorScrolling||="disabled"}init(){this.options.scrollPositionRestoration!=="disabled"&&this.viewportScroller.setHistoryScrollRestoration("manual"),this.routerEventsSubscription=this.createScrollEvents(),this.scrollEventsSubscription=this.consumeScrollEvents()}createScrollEvents(){return this.transitions.events.subscribe(e=>{e instanceof li?(this.store[this.lastId]=this.viewportScroller.getScrollPosition(),this.lastSource=e.navigationTrigger,this.restoredId=e.restoredState?e.restoredState.navigationId:0):e instanceof Wt?(this.lastId=e.id,this.scheduleScrollEvent(e,this.urlSerializer.parse(e.urlAfterRedirects).fragment)):e instanceof be&&e.code===co.IgnoredSameUrlNavigation&&(this.lastSource=void 0,this.restoredId=0,this.scheduleScrollEvent(e,this.urlSerializer.parse(e.url).fragment))})}consumeScrollEvents(){return this.transitions.events.subscribe(e=>{e instanceof ho&&(e.position?this.options.scrollPositionRestoration==="top"?this.viewportScroller.scrollToPosition([0,0]):this.options.scrollPositionRestoration==="enabled"&&this.viewportScroller.scrollToPosition(e.position):e.anchor&&this.options.anchorScrolling==="enabled"?this.viewportScroller.scrollToAnchor(e.anchor):this.options.scrollPositionRestoration!=="disabled"&&this.viewportScroller.scrollToPosition([0,0]))})}scheduleScrollEvent(e,i){this.zone.runOutsideAngular(()=>rr(this,null,function*(){yield new Promise(r=>{setTimeout(()=>{r()}),br(()=>{r()},{injector:this.environmentInjector})}),this.zone.run(()=>{this.transitions.events.next(new ho(e,this.lastSource==="popstate"?this.store[this.restoredId]:null,i))})}))}ngOnDestroy(){this.routerEventsSubscription?.unsubscribe(),this.scrollEventsSubscription?.unsubscribe()}};t.\u0275fac=function(i){Ie()},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})();function mf(n){return n.routerState.root}function dn(n,t){return{\u0275kind:n,\u0275providers:t}}function ff(){let n=g(Kt);return t=>{let o=n.get(Re);if(t!==o.components[0])return;let e=n.get(Yt),i=n.get(yc);n.get(Is)===1&&e.initialNavigation(),n.get(xc,null,fr.Optional)?.setUpPreloading(),n.get(_c,null,fr.Optional)?.init(),e.resetRootComponentType(o.componentTypes[0]),i.closed||(i.next(),i.complete(),i.unsubscribe())}}var yc=new C("",{factory:()=>new N}),Is=new C("",{providedIn:"root",factory:()=>1});function pf(){return dn(2,[{provide:Is,useValue:0},{provide:xr,multi:!0,deps:[Kt],useFactory:t=>{let o=t.get(ll,Promise.resolve());return()=>o.then(()=>new Promise(e=>{let i=t.get(Yt),r=t.get(yc);vc(i,()=>{e(!0)}),t.get(Ss).afterPreactivation=()=>(e(!0),r.closed?v(void 0):r),i.initialNavigation()}))}}])}function gf(){return dn(3,[{provide:xr,multi:!0,useFactory:()=>{let t=g(Yt);return()=>{t.setUpLocationChangeListener()}}},{provide:Is,useValue:2}])}var xc=new C("");function bf(n){return dn(0,[{provide:xc,useExisting:uf},{provide:_o,useExisting:n}])}function vf(){return dn(8,[jl,{provide:yo,useExisting:jl}])}function _f(n){let t=[{provide:pc,useValue:Jm},{provide:gc,useValue:p({skipNextTransition:!!n?.skipInitialTransition},n)}];return dn(9,t)}var zl=new C("ROUTER_FORROOT_GUARD"),yf=[Te,{provide:rn,useClass:Zi},Yt,sn,{provide:ee,useFactory:mf,deps:[Yt]},Ds,[]],Rs=(()=>{let t=class t{constructor(e){}static forRoot(e,i){return{ngModule:t,providers:[yf,[],{provide:vo,multi:!0,useValue:e},{provide:zl,useFactory:Df,deps:[[Yt,new On,new pr]]},{provide:cn,useValue:i||{}},i?.useHash?wf():Cf(),xf(),i?.preloadingStrategy?bf(i.preloadingStrategy).\u0275providers:[],i?.initialNavigation?Ef(i):[],i?.bindToComponentInputs?vf().\u0275providers:[],i?.enableViewTransitions?_f().\u0275providers:[],Sf()]}}static forChild(e){return{ngModule:t,providers:[{provide:vo,multi:!0,useValue:e}]}}};t.\u0275fac=function(i){return new(i||t)(m(zl,8))},t.\u0275mod=S({type:t}),t.\u0275inj=E({});let n=t;return n})();function xf(){return{provide:_c,useFactory:()=>{let n=g(ml),t=g(I),o=g(cn),e=g(Ss),i=g(rn);return o.scrollOffset&&n.setOffset(o.scrollOffset),new hf(i,e,n,t,o)}}}function wf(){return{provide:Pi,useClass:dl}}function Cf(){return{provide:Pi,useClass:cl}}function Df(n){return"guarded"}function Ef(n){return[n.initialNavigation==="disabled"?gf().\u0275providers:[],n.initialNavigation==="enabledBlocking"?pf().\u0275providers:[]]}var Bl=new C("");function Sf(){return[{provide:Bl,useFactory:ff},{provide:wr,multi:!0,useExisting:Bl}]}var kc=(()=>{let t=class t{constructor(e,i){this._renderer=e,this._elementRef=i,this.onChange=r=>{},this.onTouched=()=>{}}setProperty(e,i){this._renderer.setProperty(this._elementRef.nativeElement,e,i)}registerOnTouched(e){this.onTouched=e}registerOnChange(e){this.onChange=e}setDisabledState(e){this.setProperty("disabled",e)}};t.\u0275fac=function(i){return new(i||t)(u(Ai),u(A))},t.\u0275dir=D({type:t});let n=t;return n})(),If=(()=>{let t=class t extends kc{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,features:[U]});let n=t;return n})(),Fs=new C("");var Rf={provide:Fs,useExisting:Si(()=>pi),multi:!0};function Mf(){let n=ke()?ke().getUserAgent():"";return/android (\d+)/.test(n.toLowerCase())}var kf=new C(""),pi=(()=>{let t=class t extends kc{constructor(e,i,r){super(e,i),this._compositionMode=r,this._composing=!1,this._compositionMode==null&&(this._compositionMode=!Mf())}writeValue(e){let i=e??"";this.setProperty("value",i)}_handleInput(e){(!this._compositionMode||this._compositionMode&&!this._composing)&&this.onChange(e)}_compositionStart(){this._composing=!0}_compositionEnd(e){this._composing=!1,this._compositionMode&&this.onChange(e)}};t.\u0275fac=function(i){return new(i||t)(u(Ai),u(A),u(kf,8))},t.\u0275dir=D({type:t,selectors:[["input","formControlName","",3,"type","checkbox"],["textarea","formControlName",""],["input","formControl","",3,"type","checkbox"],["textarea","formControl",""],["input","ngModel","",3,"type","checkbox"],["textarea","ngModel",""],["","ngDefaultControl",""]],hostBindings:function(i,r){i&1&&Z("input",function(a){return r._handleInput(a.target.value)})("blur",function(){return r.onTouched()})("compositionstart",function(){return r._compositionStart()})("compositionend",function(a){return r._compositionEnd(a.target.value)})},features:[Q([Rf]),U]});let n=t;return n})();var Os=new C(""),Ns=new C("");function Tc(n){return n!=null}function Ac(n){return zn(n)?ht(n):n}function Fc(n){let t={};return n.forEach(o=>{t=o!=null?p(p({},t),o):t}),Object.keys(t).length===0?null:t}function Oc(n,t){return t.map(o=>o(n))}function Tf(n){return!n.validate}function Nc(n){return n.map(t=>Tf(t)?t:o=>t.validate(o))}function Af(n){if(!n)return null;let t=n.filter(Tc);return t.length==0?null:function(o){return Fc(Oc(o,t))}}function Pc(n){return n!=null?Af(Nc(n)):null}function Ff(n){if(!n)return null;let t=n.filter(Tc);return t.length==0?null:function(o){let e=Oc(o,t).map(Ac);return Tn(e).pipe(M(Fc))}}function Lc(n){return n!=null?Ff(Nc(n)):null}function wc(n,t){return n===null?[t]:Array.isArray(n)?[...n,t]:[n,t]}function jc(n){return n._rawValidators}function Vc(n){return n._rawAsyncValidators}function Ms(n){return n?Array.isArray(n)?n:[n]:[]}function Co(n,t){return Array.isArray(n)?n.includes(t):n===t}function Cc(n,t){let o=Ms(t);return Ms(n).forEach(i=>{Co(o,i)||o.push(i)}),o}function Dc(n,t){return Ms(t).filter(o=>!Co(n,o))}var Do=class{constructor(){this._rawValidators=[],this._rawAsyncValidators=[],this._onDestroyCallbacks=[]}get value(){return this.control?this.control.value:null}get valid(){return this.control?this.control.valid:null}get invalid(){return this.control?this.control.invalid:null}get pending(){return this.control?this.control.pending:null}get disabled(){return this.control?this.control.disabled:null}get enabled(){return this.control?this.control.enabled:null}get errors(){return this.control?this.control.errors:null}get pristine(){return this.control?this.control.pristine:null}get dirty(){return this.control?this.control.dirty:null}get touched(){return this.control?this.control.touched:null}get status(){return this.control?this.control.status:null}get untouched(){return this.control?this.control.untouched:null}get statusChanges(){return this.control?this.control.statusChanges:null}get valueChanges(){return this.control?this.control.valueChanges:null}get path(){return null}_setValidators(t){this._rawValidators=t||[],this._composedValidatorFn=Pc(this._rawValidators)}_setAsyncValidators(t){this._rawAsyncValidators=t||[],this._composedAsyncValidatorFn=Lc(this._rawAsyncValidators)}get validator(){return this._composedValidatorFn||null}get asyncValidator(){return this._composedAsyncValidatorFn||null}_registerOnDestroy(t){this._onDestroyCallbacks.push(t)}_invokeOnDestroyCallbacks(){this._onDestroyCallbacks.forEach(t=>t()),this._onDestroyCallbacks=[]}reset(t=void 0){this.control&&this.control.reset(t)}hasError(t,o){return this.control?this.control.hasError(t,o):!1}getError(t,o){return this.control?this.control.getError(t,o):null}},Le=class extends Do{get formDirective(){return null}get path(){return null}},je=class extends Do{constructor(){super(...arguments),this._parent=null,this.name=null,this.valueAccessor=null}},Eo=class{constructor(t){this._cd=t}get isTouched(){return!!this._cd?.control?.touched}get isUntouched(){return!!this._cd?.control?.untouched}get isPristine(){return!!this._cd?.control?.pristine}get isDirty(){return!!this._cd?.control?.dirty}get isValid(){return!!this._cd?.control?.valid}get isInvalid(){return!!this._cd?.control?.invalid}get isPending(){return!!this._cd?.control?.pending}get isSubmitted(){return!!this._cd?.submitted}},Of={"[class.ng-untouched]":"isUntouched","[class.ng-touched]":"isTouched","[class.ng-pristine]":"isPristine","[class.ng-dirty]":"isDirty","[class.ng-valid]":"isValid","[class.ng-invalid]":"isInvalid","[class.ng-pending]":"isPending"},mv=q(p({},Of),{"[class.ng-submitted]":"isSubmitted"}),Mo=(()=>{let t=class t extends Eo{constructor(e){super(e)}};t.\u0275fac=function(i){return new(i||t)(u(je,2))},t.\u0275dir=D({type:t,selectors:[["","formControlName",""],["","ngModel",""],["","formControl",""]],hostVars:14,hostBindings:function(i,r){i&2&&st("ng-untouched",r.isUntouched)("ng-touched",r.isTouched)("ng-pristine",r.isPristine)("ng-dirty",r.isDirty)("ng-valid",r.isValid)("ng-invalid",r.isInvalid)("ng-pending",r.isPending)},features:[U]});let n=t;return n})(),zc=(()=>{let t=class t extends Eo{constructor(e){super(e)}};t.\u0275fac=function(i){return new(i||t)(u(Le,10))},t.\u0275dir=D({type:t,selectors:[["","formGroupName",""],["","formArrayName",""],["","ngModelGroup",""],["","formGroup",""],["form",3,"ngNoForm",""],["","ngForm",""]],hostVars:16,hostBindings:function(i,r){i&2&&st("ng-untouched",r.isUntouched)("ng-touched",r.isTouched)("ng-pristine",r.isPristine)("ng-dirty",r.isDirty)("ng-valid",r.isValid)("ng-invalid",r.isInvalid)("ng-pending",r.isPending)("ng-submitted",r.isSubmitted)},features:[U]});let n=t;return n})();var un="VALID",wo="INVALID",mi="PENDING",hn="DISABLED";function Ps(n){return(ko(n)?n.validators:n)||null}function Nf(n){return Array.isArray(n)?Pc(n):n||null}function Ls(n,t){return(ko(t)?t.asyncValidators:n)||null}function Pf(n){return Array.isArray(n)?Lc(n):n||null}function ko(n){return n!=null&&!Array.isArray(n)&&typeof n=="object"}function Bc(n,t,o){let e=n.controls;if(!(t?Object.keys(e):e).length)throw new $(1e3,"");if(!e[o])throw new $(1001,"")}function Uc(n,t,o){n._forEachChild((e,i)=>{if(o[i]===void 0)throw new $(1002,"")})}var fi=class{constructor(t,o){this._pendingDirty=!1,this._hasOwnPendingAsyncValidator=!1,this._pendingTouched=!1,this._onCollectionChange=()=>{},this._parent=null,this.pristine=!0,this.touched=!1,this._onDisabledChange=[],this._assignValidators(t),this._assignAsyncValidators(o)}get validator(){return this._composedValidatorFn}set validator(t){this._rawValidators=this._composedValidatorFn=t}get asyncValidator(){return this._composedAsyncValidatorFn}set asyncValidator(t){this._rawAsyncValidators=this._composedAsyncValidatorFn=t}get parent(){return this._parent}get valid(){return this.status===un}get invalid(){return this.status===wo}get pending(){return this.status==mi}get disabled(){return this.status===hn}get enabled(){return this.status!==hn}get dirty(){return!this.pristine}get untouched(){return!this.touched}get updateOn(){return this._updateOn?this._updateOn:this.parent?this.parent.updateOn:"change"}setValidators(t){this._assignValidators(t)}setAsyncValidators(t){this._assignAsyncValidators(t)}addValidators(t){this.setValidators(Cc(t,this._rawValidators))}addAsyncValidators(t){this.setAsyncValidators(Cc(t,this._rawAsyncValidators))}removeValidators(t){this.setValidators(Dc(t,this._rawValidators))}removeAsyncValidators(t){this.setAsyncValidators(Dc(t,this._rawAsyncValidators))}hasValidator(t){return Co(this._rawValidators,t)}hasAsyncValidator(t){return Co(this._rawAsyncValidators,t)}clearValidators(){this.validator=null}clearAsyncValidators(){this.asyncValidator=null}markAsTouched(t={}){this.touched=!0,this._parent&&!t.onlySelf&&this._parent.markAsTouched(t)}markAllAsTouched(){this.markAsTouched({onlySelf:!0}),this._forEachChild(t=>t.markAllAsTouched())}markAsUntouched(t={}){this.touched=!1,this._pendingTouched=!1,this._forEachChild(o=>{o.markAsUntouched({onlySelf:!0})}),this._parent&&!t.onlySelf&&this._parent._updateTouched(t)}markAsDirty(t={}){this.pristine=!1,this._parent&&!t.onlySelf&&this._parent.markAsDirty(t)}markAsPristine(t={}){this.pristine=!0,this._pendingDirty=!1,this._forEachChild(o=>{o.markAsPristine({onlySelf:!0})}),this._parent&&!t.onlySelf&&this._parent._updatePristine(t)}markAsPending(t={}){this.status=mi,t.emitEvent!==!1&&this.statusChanges.emit(this.status),this._parent&&!t.onlySelf&&this._parent.markAsPending(t)}disable(t={}){let o=this._parentMarkedDirty(t.onlySelf);this.status=hn,this.errors=null,this._forEachChild(e=>{e.disable(q(p({},t),{onlySelf:!0}))}),this._updateValue(),t.emitEvent!==!1&&(this.valueChanges.emit(this.value),this.statusChanges.emit(this.status)),this._updateAncestors(q(p({},t),{skipPristineCheck:o})),this._onDisabledChange.forEach(e=>e(!0))}enable(t={}){let o=this._parentMarkedDirty(t.onlySelf);this.status=un,this._forEachChild(e=>{e.enable(q(p({},t),{onlySelf:!0}))}),this.updateValueAndValidity({onlySelf:!0,emitEvent:t.emitEvent}),this._updateAncestors(q(p({},t),{skipPristineCheck:o})),this._onDisabledChange.forEach(e=>e(!1))}_updateAncestors(t){this._parent&&!t.onlySelf&&(this._parent.updateValueAndValidity(t),t.skipPristineCheck||this._parent._updatePristine(),this._parent._updateTouched())}setParent(t){this._parent=t}getRawValue(){return this.value}updateValueAndValidity(t={}){this._setInitialStatus(),this._updateValue(),this.enabled&&(this._cancelExistingSubscription(),this.errors=this._runValidator(),this.status=this._calculateStatus(),(this.status===un||this.status===mi)&&this._runAsyncValidator(t.emitEvent)),t.emitEvent!==!1&&(this.valueChanges.emit(this.value),this.statusChanges.emit(this.status)),this._parent&&!t.onlySelf&&this._parent.updateValueAndValidity(t)}_updateTreeValidity(t={emitEvent:!0}){this._forEachChild(o=>o._updateTreeValidity(t)),this.updateValueAndValidity({onlySelf:!0,emitEvent:t.emitEvent})}_setInitialStatus(){this.status=this._allControlsDisabled()?hn:un}_runValidator(){return this.validator?this.validator(this):null}_runAsyncValidator(t){if(this.asyncValidator){this.status=mi,this._hasOwnPendingAsyncValidator=!0;let o=Ac(this.asyncValidator(this));this._asyncValidationSubscription=o.subscribe(e=>{this._hasOwnPendingAsyncValidator=!1,this.setErrors(e,{emitEvent:t})})}}_cancelExistingSubscription(){this._asyncValidationSubscription&&(this._asyncValidationSubscription.unsubscribe(),this._hasOwnPendingAsyncValidator=!1)}setErrors(t,o={}){this.errors=t,this._updateControlsErrors(o.emitEvent!==!1)}get(t){let o=t;return o==null||(Array.isArray(o)||(o=o.split(".")),o.length===0)?null:o.reduce((e,i)=>e&&e._find(i),this)}getError(t,o){let e=o?this.get(o):this;return e&&e.errors?e.errors[t]:null}hasError(t,o){return!!this.getError(t,o)}get root(){let t=this;for(;t._parent;)t=t._parent;return t}_updateControlsErrors(t){this.status=this._calculateStatus(),t&&this.statusChanges.emit(this.status),this._parent&&this._parent._updateControlsErrors(t)}_initObservables(){this.valueChanges=new it,this.statusChanges=new it}_calculateStatus(){return this._allControlsDisabled()?hn:this.errors?wo:this._hasOwnPendingAsyncValidator||this._anyControlsHaveStatus(mi)?mi:this._anyControlsHaveStatus(wo)?wo:un}_anyControlsHaveStatus(t){return this._anyControls(o=>o.status===t)}_anyControlsDirty(){return this._anyControls(t=>t.dirty)}_anyControlsTouched(){return this._anyControls(t=>t.touched)}_updatePristine(t={}){this.pristine=!this._anyControlsDirty(),this._parent&&!t.onlySelf&&this._parent._updatePristine(t)}_updateTouched(t={}){this.touched=this._anyControlsTouched(),this._parent&&!t.onlySelf&&this._parent._updateTouched(t)}_registerOnCollectionChange(t){this._onCollectionChange=t}_setUpdateStrategy(t){ko(t)&&t.updateOn!=null&&(this._updateOn=t.updateOn)}_parentMarkedDirty(t){let o=this._parent&&this._parent.dirty;return!t&&!!o&&!this._parent._anyControlsDirty()}_find(t){return null}_assignValidators(t){this._rawValidators=Array.isArray(t)?t.slice():t,this._composedValidatorFn=Nf(this._rawValidators)}_assignAsyncValidators(t){this._rawAsyncValidators=Array.isArray(t)?t.slice():t,this._composedAsyncValidatorFn=Pf(this._rawAsyncValidators)}},So=class extends fi{constructor(t,o,e){super(Ps(o),Ls(e,o)),this.controls=t,this._initObservables(),this._setUpdateStrategy(o),this._setUpControls(),this.updateValueAndValidity({onlySelf:!0,emitEvent:!!this.asyncValidator})}registerControl(t,o){return this.controls[t]?this.controls[t]:(this.controls[t]=o,o.setParent(this),o._registerOnCollectionChange(this._onCollectionChange),o)}addControl(t,o,e={}){this.registerControl(t,o),this.updateValueAndValidity({emitEvent:e.emitEvent}),this._onCollectionChange()}removeControl(t,o={}){this.controls[t]&&this.controls[t]._registerOnCollectionChange(()=>{}),delete this.controls[t],this.updateValueAndValidity({emitEvent:o.emitEvent}),this._onCollectionChange()}setControl(t,o,e={}){this.controls[t]&&this.controls[t]._registerOnCollectionChange(()=>{}),delete this.controls[t],o&&this.registerControl(t,o),this.updateValueAndValidity({emitEvent:e.emitEvent}),this._onCollectionChange()}contains(t){return this.controls.hasOwnProperty(t)&&this.controls[t].enabled}setValue(t,o={}){Uc(this,!0,t),Object.keys(t).forEach(e=>{Bc(this,!0,e),this.controls[e].setValue(t[e],{onlySelf:!0,emitEvent:o.emitEvent})}),this.updateValueAndValidity(o)}patchValue(t,o={}){t!=null&&(Object.keys(t).forEach(e=>{let i=this.controls[e];i&&i.patchValue(t[e],{onlySelf:!0,emitEvent:o.emitEvent})}),this.updateValueAndValidity(o))}reset(t={},o={}){this._forEachChild((e,i)=>{e.reset(t?t[i]:null,{onlySelf:!0,emitEvent:o.emitEvent})}),this._updatePristine(o),this._updateTouched(o),this.updateValueAndValidity(o)}getRawValue(){return this._reduceChildren({},(t,o,e)=>(t[e]=o.getRawValue(),t))}_syncPendingControls(){let t=this._reduceChildren(!1,(o,e)=>e._syncPendingControls()?!0:o);return t&&this.updateValueAndValidity({onlySelf:!0}),t}_forEachChild(t){Object.keys(this.controls).forEach(o=>{let e=this.controls[o];e&&t(e,o)})}_setUpControls(){this._forEachChild(t=>{t.setParent(this),t._registerOnCollectionChange(this._onCollectionChange)})}_updateValue(){this.value=this._reduceValue()}_anyControls(t){for(let[o,e]of Object.entries(this.controls))if(this.contains(o)&&t(e))return!0;return!1}_reduceValue(){let t={};return this._reduceChildren(t,(o,e,i)=>((e.enabled||this.disabled)&&(o[i]=e.value),o))}_reduceChildren(t,o){let e=t;return this._forEachChild((i,r)=>{e=o(e,i,r)}),e}_allControlsDisabled(){for(let t of Object.keys(this.controls))if(this.controls[t].enabled)return!1;return Object.keys(this.controls).length>0||this.disabled}_find(t){return this.controls.hasOwnProperty(t)?this.controls[t]:null}};var ks=class extends So{};var To=new C("CallSetDisabledState",{providedIn:"root",factory:()=>Ao}),Ao="always";function Hc(n,t){return[...t.path,n]}function Ts(n,t,o=Ao){js(n,t),t.valueAccessor.writeValue(n.value),(n.disabled||o==="always")&&t.valueAccessor.setDisabledState?.(n.disabled),jf(n,t),zf(n,t),Vf(n,t),Lf(n,t)}function Ec(n,t,o=!0){let e=()=>{};t.valueAccessor&&(t.valueAccessor.registerOnChange(e),t.valueAccessor.registerOnTouched(e)),Ro(n,t),n&&(t._invokeOnDestroyCallbacks(),n._registerOnCollectionChange(()=>{}))}function Io(n,t){n.forEach(o=>{o.registerOnValidatorChange&&o.registerOnValidatorChange(t)})}function Lf(n,t){if(t.valueAccessor.setDisabledState){let o=e=>{t.valueAccessor.setDisabledState(e)};n.registerOnDisabledChange(o),t._registerOnDestroy(()=>{n._unregisterOnDisabledChange(o)})}}function js(n,t){let o=jc(n);t.validator!==null?n.setValidators(wc(o,t.validator)):typeof o=="function"&&n.setValidators([o]);let e=Vc(n);t.asyncValidator!==null?n.setAsyncValidators(wc(e,t.asyncValidator)):typeof e=="function"&&n.setAsyncValidators([e]);let i=()=>n.updateValueAndValidity();Io(t._rawValidators,i),Io(t._rawAsyncValidators,i)}function Ro(n,t){let o=!1;if(n!==null){if(t.validator!==null){let i=jc(n);if(Array.isArray(i)&&i.length>0){let r=i.filter(s=>s!==t.validator);r.length!==i.length&&(o=!0,n.setValidators(r))}}if(t.asyncValidator!==null){let i=Vc(n);if(Array.isArray(i)&&i.length>0){let r=i.filter(s=>s!==t.asyncValidator);r.length!==i.length&&(o=!0,n.setAsyncValidators(r))}}}let e=()=>{};return Io(t._rawValidators,e),Io(t._rawAsyncValidators,e),o}function jf(n,t){t.valueAccessor.registerOnChange(o=>{n._pendingValue=o,n._pendingChange=!0,n._pendingDirty=!0,n.updateOn==="change"&&$c(n,t)})}function Vf(n,t){t.valueAccessor.registerOnTouched(()=>{n._pendingTouched=!0,n.updateOn==="blur"&&n._pendingChange&&$c(n,t),n.updateOn!=="submit"&&n.markAsTouched()})}function $c(n,t){n._pendingDirty&&n.markAsDirty(),n.setValue(n._pendingValue,{emitModelToViewChange:!1}),t.viewToModelUpdate(n._pendingValue),n._pendingChange=!1}function zf(n,t){let o=(e,i)=>{t.valueAccessor.writeValue(e),i&&t.viewToModelUpdate(e)};n.registerOnChange(o),t._registerOnDestroy(()=>{n._unregisterOnChange(o)})}function Bf(n,t){n==null,js(n,t)}function Uf(n,t){return Ro(n,t)}function Wc(n,t){if(!n.hasOwnProperty("model"))return!1;let o=n.model;return o.isFirstChange()?!0:!Object.is(t,o.currentValue)}function Hf(n){return Object.getPrototypeOf(n.constructor)===If}function $f(n,t){n._syncPendingControls(),t.forEach(o=>{let e=o.control;e.updateOn==="submit"&&e._pendingChange&&(o.viewToModelUpdate(e._pendingValue),e._pendingChange=!1)})}function Gc(n,t){if(!t)return null;Array.isArray(t);let o,e,i;return t.forEach(r=>{r.constructor===pi?o=r:Hf(r)?e=r:i=r}),i||e||o||null}function Wf(n,t){let o=n.indexOf(t);o>-1&&n.splice(o,1)}function Sc(n,t){let o=n.indexOf(t);o>-1&&n.splice(o,1)}function Ic(n){return typeof n=="object"&&n!==null&&Object.keys(n).length===2&&"value"in n&&"disabled"in n}var mn=class extends fi{constructor(t=null,o,e){super(Ps(o),Ls(e,o)),this.defaultValue=null,this._onChange=[],this._pendingChange=!1,this._applyFormState(t),this._setUpdateStrategy(o),this._initObservables(),this.updateValueAndValidity({onlySelf:!0,emitEvent:!!this.asyncValidator}),ko(o)&&(o.nonNullable||o.initialValueIsDefault)&&(Ic(t)?this.defaultValue=t.value:this.defaultValue=t)}setValue(t,o={}){this.value=this._pendingValue=t,this._onChange.length&&o.emitModelToViewChange!==!1&&this._onChange.forEach(e=>e(this.value,o.emitViewToModelChange!==!1)),this.updateValueAndValidity(o)}patchValue(t,o={}){this.setValue(t,o)}reset(t=this.defaultValue,o={}){this._applyFormState(t),this.markAsPristine(o),this.markAsUntouched(o),this.setValue(this.value,o),this._pendingChange=!1}_updateValue(){}_anyControls(t){return!1}_allControlsDisabled(){return this.disabled}registerOnChange(t){this._onChange.push(t)}_unregisterOnChange(t){Sc(this._onChange,t)}registerOnDisabledChange(t){this._onDisabledChange.push(t)}_unregisterOnDisabledChange(t){Sc(this._onDisabledChange,t)}_forEachChild(t){}_syncPendingControls(){return this.updateOn==="submit"&&(this._pendingDirty&&this.markAsDirty(),this._pendingTouched&&this.markAsTouched(),this._pendingChange)?(this.setValue(this._pendingValue,{onlySelf:!0,emitModelToViewChange:!1}),!0):!1}_applyFormState(t){Ic(t)?(this.value=this._pendingValue=t.value,t.disabled?this.disable({onlySelf:!0,emitEvent:!1}):this.enable({onlySelf:!0,emitEvent:!1})):this.value=this._pendingValue=t}};var Gf=n=>n instanceof mn;var Yf={provide:je,useExisting:Si(()=>Vs)},Rc=Promise.resolve(),Vs=(()=>{let t=class t extends je{constructor(e,i,r,s,a,l){super(),this._changeDetectorRef=a,this.callSetDisabledState=l,this.control=new mn,this._registered=!1,this.name="",this.update=new it,this._parent=e,this._setValidators(i),this._setAsyncValidators(r),this.valueAccessor=Gc(this,s)}ngOnChanges(e){if(this._checkForErrors(),!this._registered||"name"in e){if(this._registered&&(this._checkName(),this.formDirective)){let i=e.name.previousValue;this.formDirective.removeControl({name:i,path:this._getPath(i)})}this._setUpControl()}"isDisabled"in e&&this._updateDisabled(e),Wc(e,this.viewModel)&&(this._updateValue(this.model),this.viewModel=this.model)}ngOnDestroy(){this.formDirective&&this.formDirective.removeControl(this)}get path(){return this._getPath(this.name)}get formDirective(){return this._parent?this._parent.formDirective:null}viewToModelUpdate(e){this.viewModel=e,this.update.emit(e)}_setUpControl(){this._setUpdateStrategy(),this._isStandalone()?this._setUpStandalone():this.formDirective.addControl(this),this._registered=!0}_setUpdateStrategy(){this.options&&this.options.updateOn!=null&&(this.control._updateOn=this.options.updateOn)}_isStandalone(){return!this._parent||!!(this.options&&this.options.standalone)}_setUpStandalone(){Ts(this.control,this,this.callSetDisabledState),this.control.updateValueAndValidity({emitEvent:!1})}_checkForErrors(){this._isStandalone()||this._checkParentType(),this._checkName()}_checkParentType(){}_checkName(){this.options&&this.options.name&&(this.name=this.options.name),!this._isStandalone()&&this.name}_updateValue(e){Rc.then(()=>{this.control.setValue(e,{emitViewToModelChange:!1}),this._changeDetectorRef?.markForCheck()})}_updateDisabled(e){let i=e.isDisabled.currentValue,r=i!==0&&W(i);Rc.then(()=>{r&&!this.control.disabled?this.control.disable():!r&&this.control.disabled&&this.control.enable(),this._changeDetectorRef?.markForCheck()})}_getPath(e){return this._parent?Hc(e,this._parent):[e]}};t.\u0275fac=function(i){return new(i||t)(u(Le,9),u(Os,10),u(Ns,10),u(Fs,10),u(Dt,8),u(To,8))},t.\u0275dir=D({type:t,selectors:[["","ngModel","",3,"formControlName","",3,"formControl",""]],inputs:{name:"name",isDisabled:[y.None,"disabled","isDisabled"],model:[y.None,"ngModel","model"],options:[y.None,"ngModelOptions","options"]},outputs:{update:"ngModelChange"},exportAs:["ngModel"],features:[Q([Yf]),U,yt]});let n=t;return n})(),Yc=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275dir=D({type:t,selectors:[["form",3,"ngNoForm","",3,"ngNativeValidate",""]],hostAttrs:["novalidate",""]});let n=t;return n})();var qc=new C("");var qf={provide:Le,useExisting:Si(()=>zs)},zs=(()=>{let t=class t extends Le{constructor(e,i,r){super(),this.callSetDisabledState=r,this.submitted=!1,this._onCollectionChange=()=>this._updateDomValue(),this.directives=[],this.form=null,this.ngSubmit=new it,this._setValidators(e),this._setAsyncValidators(i)}ngOnChanges(e){this._checkFormPresent(),e.hasOwnProperty("form")&&(this._updateValidators(),this._updateDomValue(),this._updateRegistrations(),this._oldForm=this.form)}ngOnDestroy(){this.form&&(Ro(this.form,this),this.form._onCollectionChange===this._onCollectionChange&&this.form._registerOnCollectionChange(()=>{}))}get formDirective(){return this}get control(){return this.form}get path(){return[]}addControl(e){let i=this.form.get(e.path);return Ts(i,e,this.callSetDisabledState),i.updateValueAndValidity({emitEvent:!1}),this.directives.push(e),i}getControl(e){return this.form.get(e.path)}removeControl(e){Ec(e.control||null,e,!1),Wf(this.directives,e)}addFormGroup(e){this._setUpFormContainer(e)}removeFormGroup(e){this._cleanUpFormContainer(e)}getFormGroup(e){return this.form.get(e.path)}addFormArray(e){this._setUpFormContainer(e)}removeFormArray(e){this._cleanUpFormContainer(e)}getFormArray(e){return this.form.get(e.path)}updateModel(e,i){this.form.get(e.path).setValue(i)}onSubmit(e){return this.submitted=!0,$f(this.form,this.directives),this.ngSubmit.emit(e),e?.target?.method==="dialog"}onReset(){this.resetForm()}resetForm(e=void 0){this.form.reset(e),this.submitted=!1}_updateDomValue(){this.directives.forEach(e=>{let i=e.control,r=this.form.get(e.path);i!==r&&(Ec(i||null,e),Gf(r)&&(Ts(r,e,this.callSetDisabledState),e.control=r))}),this.form._updateTreeValidity({emitEvent:!1})}_setUpFormContainer(e){let i=this.form.get(e.path);Bf(i,e),i.updateValueAndValidity({emitEvent:!1})}_cleanUpFormContainer(e){if(this.form){let i=this.form.get(e.path);i&&Uf(i,e)&&i.updateValueAndValidity({emitEvent:!1})}}_updateRegistrations(){this.form._registerOnCollectionChange(this._onCollectionChange),this._oldForm&&this._oldForm._registerOnCollectionChange(()=>{})}_updateValidators(){js(this.form,this),this._oldForm&&Ro(this._oldForm,this)}_checkFormPresent(){this.form}};t.\u0275fac=function(i){return new(i||t)(u(Os,10),u(Ns,10),u(To,8))},t.\u0275dir=D({type:t,selectors:[["","formGroup",""]],hostBindings:function(i,r){i&1&&Z("submit",function(a){return r.onSubmit(a)})("reset",function(){return r.onReset()})},inputs:{form:[y.None,"formGroup","form"]},outputs:{ngSubmit:"ngSubmit"},exportAs:["ngForm"],features:[Q([qf]),U,yt]});let n=t;return n})();var Zf={provide:je,useExisting:Si(()=>Bs)},Bs=(()=>{let t=class t extends je{set isDisabled(e){}constructor(e,i,r,s,a){super(),this._ngModelWarningConfig=a,this._added=!1,this.name=null,this.update=new it,this._ngModelWarningSent=!1,this._parent=e,this._setValidators(i),this._setAsyncValidators(r),this.valueAccessor=Gc(this,s)}ngOnChanges(e){this._added||this._setUpControl(),Wc(e,this.viewModel)&&(this.viewModel=this.model,this.formDirective.updateModel(this,this.model))}ngOnDestroy(){this.formDirective&&this.formDirective.removeControl(this)}viewToModelUpdate(e){this.viewModel=e,this.update.emit(e)}get path(){return Hc(this.name==null?this.name:this.name.toString(),this._parent)}get formDirective(){return this._parent?this._parent.formDirective:null}_checkParentType(){}_setUpControl(){this._checkParentType(),this.control=this.formDirective.addControl(this),this._added=!0}};t._ngModelWarningSentOnce=!1,t.\u0275fac=function(i){return new(i||t)(u(Le,13),u(Os,10),u(Ns,10),u(Fs,10),u(qc,8))},t.\u0275dir=D({type:t,selectors:[["","formControlName",""]],inputs:{name:[y.None,"formControlName","name"],isDisabled:[y.None,"disabled","isDisabled"],model:[y.None,"ngModel","model"]},outputs:{update:"ngModelChange"},features:[Q([Zf]),U,yt]});let n=t;return n})();var Zc=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({});let n=t;return n})(),As=class extends fi{constructor(t,o,e){super(Ps(o),Ls(e,o)),this.controls=t,this._initObservables(),this._setUpdateStrategy(o),this._setUpControls(),this.updateValueAndValidity({onlySelf:!0,emitEvent:!!this.asyncValidator})}at(t){return this.controls[this._adjustIndex(t)]}push(t,o={}){this.controls.push(t),this._registerControl(t),this.updateValueAndValidity({emitEvent:o.emitEvent}),this._onCollectionChange()}insert(t,o,e={}){this.controls.splice(t,0,o),this._registerControl(o),this.updateValueAndValidity({emitEvent:e.emitEvent})}removeAt(t,o={}){let e=this._adjustIndex(t);e<0&&(e=0),this.controls[e]&&this.controls[e]._registerOnCollectionChange(()=>{}),this.controls.splice(e,1),this.updateValueAndValidity({emitEvent:o.emitEvent})}setControl(t,o,e={}){let i=this._adjustIndex(t);i<0&&(i=0),this.controls[i]&&this.controls[i]._registerOnCollectionChange(()=>{}),this.controls.splice(i,1),o&&(this.controls.splice(i,0,o),this._registerControl(o)),this.updateValueAndValidity({emitEvent:e.emitEvent}),this._onCollectionChange()}get length(){return this.controls.length}setValue(t,o={}){Uc(this,!1,t),t.forEach((e,i)=>{Bc(this,!1,i),this.at(i).setValue(e,{onlySelf:!0,emitEvent:o.emitEvent})}),this.updateValueAndValidity(o)}patchValue(t,o={}){t!=null&&(t.forEach((e,i)=>{this.at(i)&&this.at(i).patchValue(e,{onlySelf:!0,emitEvent:o.emitEvent})}),this.updateValueAndValidity(o))}reset(t=[],o={}){this._forEachChild((e,i)=>{e.reset(t[i],{onlySelf:!0,emitEvent:o.emitEvent})}),this._updatePristine(o),this._updateTouched(o),this.updateValueAndValidity(o)}getRawValue(){return this.controls.map(t=>t.getRawValue())}clear(t={}){this.controls.length<1||(this._forEachChild(o=>o._registerOnCollectionChange(()=>{})),this.controls.splice(0),this.updateValueAndValidity({emitEvent:t.emitEvent}))}_adjustIndex(t){return t<0?t+this.length:t}_syncPendingControls(){let t=this.controls.reduce((o,e)=>e._syncPendingControls()?!0:o,!1);return t&&this.updateValueAndValidity({onlySelf:!0}),t}_forEachChild(t){this.controls.forEach((o,e)=>{t(o,e)})}_updateValue(){this.value=this.controls.filter(t=>t.enabled||this.disabled).map(t=>t.value)}_anyControls(t){return this.controls.some(o=>o.enabled&&t(o))}_setUpControls(){this._forEachChild(t=>this._registerControl(t))}_allControlsDisabled(){for(let t of this.controls)if(t.enabled)return!1;return this.controls.length>0||this.disabled}_registerControl(t){t.setParent(this),t._registerOnCollectionChange(this._onCollectionChange)}_find(t){return this.at(t)??null}};function Mc(n){return!!n&&(n.asyncValidators!==void 0||n.validators!==void 0||n.updateOn!==void 0)}var Xc=(()=>{let t=class t{constructor(){this.useNonNullable=!1}get nonNullable(){let e=new t;return e.useNonNullable=!0,e}group(e,i=null){let r=this._reduceControls(e),s={};return Mc(i)?s=i:i!==null&&(s.validators=i.validator,s.asyncValidators=i.asyncValidator),new So(r,s)}record(e,i=null){let r=this._reduceControls(e);return new ks(r,i)}control(e,i,r){let s={};return this.useNonNullable?(Mc(i)?s=i:(s.validators=i,s.asyncValidators=r),new mn(e,q(p({},s),{nonNullable:!0}))):new mn(e,i,r)}array(e,i,r){let s=e.map(a=>this._createControl(a));return new As(s,i,r)}_reduceControls(e){let i={};return Object.keys(e).forEach(r=>{i[r]=this._createControl(e[r])}),i}_createControl(e){if(e instanceof mn)return e;if(e instanceof fi)return e;if(Array.isArray(e)){let i=e[0],r=e.length>1?e[1]:null,s=e.length>2?e[2]:null;return this.control(i,r,s)}else return this.control(e)}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var Kc=(()=>{let t=class t{static withConfig(e){return{ngModule:t,providers:[{provide:To,useValue:e.callSetDisabledState??Ao}]}}};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Zc]});let n=t;return n})(),Qc=(()=>{let t=class t{static withConfig(e){return{ngModule:t,providers:[{provide:qc,useValue:e.warnOnNgModelWithFormControl??"always"},{provide:To,useValue:e.callSetDisabledState??Ao}]}}};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Zc]});let n=t;return n})();var td=n=>["/Product-Stores",n];function Xf(n,t){if(n&1&&(x(0,"div",8)(1,"div",9)(2,"div")(3,"a",10),H(4,"img",11),_()(),x(5,"div")(6,"a",10),F(7),_()()()()),n&2){let o=t.$implicit;R(3),L("routerLink",Ni(5,td,o.productID)),R(),Ze("alt",o.productName),L("src",o.productImage,Se),R(2),L("routerLink",Ni(7,td,o.productID)),R(),te(o.productName)}}function Kf(n,t){n&1&&(x(0,"div",12)(1,"div",13),F(2,"No products found matching your search criteria. Please try again."),_()())}var ed=(()=>{let t=class t{constructor(e){this.productService=e,this.products=[],this.filteredProducts=[],this.searchFilter=""}ngOnInit(){this.getAllProducts()}getAllProducts(){this.productService.getAllProducts().subscribe({next:e=>{this.products=e,this.filteredProducts=[...this.products]},error:e=>{console.error("Error fetching products:",e)}})}filterProducts(){this.searchFilter&&this.products?this.filteredProducts=this.products.filter(e=>e.productName.toLowerCase().includes(this.searchFilter.toLowerCase())):this.filteredProducts=[...this.products]}};t.\u0275fac=function(i){return new(i||t)(u(fe))},t.\u0275cmp=P({type:t,selectors:[["app-home"]],decls:9,vars:3,consts:[[1,"container"],[1,"row","justify-content-center"],[1,"col-sm-8"],[1,"input-group","search-input-field"],["type","text","placeholder","Search Product",1,"form-control",3,"ngModelChange","input","ngModel"],[1,"row","mt-5"],["class","col-sm-3  mb-4",4,"ngFor","ngForOf"],["class","col-sm-12 text-center",4,"ngIf"],[1,"col-sm-3","mb-4"],[1,"products","text-center"],[3,"routerLink"],[1,"img-fluid","image-property",3,"src","alt"],[1,"col-sm-12","text-center"],["id","noDataMessage",1,"alert","alert-info"]],template:function(i,r){i&1&&(x(0,"div",0)(1,"div",1)(2,"div",2)(3,"div",3)(4,"input",4),Qa("ngModelChange",function(a){return Ka(r.searchFilter,a)||(r.searchFilter=a),a}),Z("input",function(){return r.filterProducts()}),_()()()()(),x(5,"div",0)(6,"div",5),ot(7,Xf,8,9,"div",6)(8,Kf,3,0,"div",7),_()()),i&2&&(R(4),Xa("ngModel",r.searchFilter),R(3),L("ngForOf",r.filteredProducts),R(),L("ngIf",r.filteredProducts.length===0))},dependencies:[Qe,Ht,ui,pi,Mo,Vs],styles:[".search-input-field[_ngcontent-%COMP%]{width:800px;margin-top:60px;margin-bottom:50px}.products[_ngcontent-%COMP%]{height:300px;padding:20px;border-radius:5px;font-weight:700;background-color:#f9f9f9;box-shadow:0 0 10px #0000001a;margin-bottom:10px}.image-property[_ngcontent-%COMP%]{height:200px;width:180px;margin-bottom:20px}.products[_ngcontent-%COMP%]:hover{box-shadow:0 0 15px #032cb133;background-color:#e9ebf5}#noDataMessage[_ngcontent-%COMP%]{text-align:center;margin:auto;width:fit-content}"]});let n=t;return n})();var Qf=new C("cdk-dir-doc",{providedIn:"root",factory:Jf});function Jf(){return g(T)}var tp=/^(ar|ckb|dv|he|iw|fa|nqo|ps|sd|ug|ur|yi|.*[-_](Adlm|Arab|Hebr|Nkoo|Rohg|Thaa))(?!.*[-_](Latn|Cyrl)($|-|_))($|-|_)/i;function ep(n){let t=n?.toLowerCase()||"";return t==="auto"&&typeof navigator<"u"&&navigator?.language?tp.test(navigator.language)?"rtl":"ltr":t==="rtl"?"rtl":"ltr"}var gi=(()=>{let t=class t{constructor(e){if(this.value="ltr",this.change=new it,e){let i=e.body?e.body.dir:null,r=e.documentElement?e.documentElement.dir:null;this.value=ep(i||r||"ltr")}}ngOnDestroy(){this.change.complete()}};t.\u0275fac=function(i){return new(i||t)(m(Qf,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var _e=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({});let n=t;return n})();var Fo=class{};function Oo(n){return n&&typeof n.connect=="function"&&!(n instanceof Ei)}var bi=function(n){return n[n.REPLACED=0]="REPLACED",n[n.INSERTED=1]="INSERTED",n[n.MOVED=2]="MOVED",n[n.REMOVED=3]="REMOVED",n}(bi||{}),fn=new C("_ViewRepeater"),vi=class{applyChanges(t,o,e,i,r){t.forEachOperation((s,a,l)=>{let c,d;if(s.previousIndex==null){let h=e(s,a,l);c=o.createEmbeddedView(h.templateRef,h.context,h.index),d=bi.INSERTED}else l==null?(o.remove(a),d=bi.REMOVED):(c=o.get(a),o.move(c,l),d=bi.MOVED);r&&r({context:c?.context,operation:d,record:s})})}detach(){}};var $s;try{$s=typeof Intl<"u"&&Intl.v8BreakIterator}catch{$s=!1}var J=(()=>{let t=class t{constructor(e){this._platformId=e,this.isBrowser=this._platformId?hl(this._platformId):typeof document=="object"&&!!document,this.EDGE=this.isBrowser&&/(edge)/i.test(navigator.userAgent),this.TRIDENT=this.isBrowser&&/(msie|trident)/i.test(navigator.userAgent),this.BLINK=this.isBrowser&&!!(window.chrome||$s)&&typeof CSS<"u"&&!this.EDGE&&!this.TRIDENT,this.WEBKIT=this.isBrowser&&/AppleWebKit/i.test(navigator.userAgent)&&!this.BLINK&&!this.EDGE&&!this.TRIDENT,this.IOS=this.isBrowser&&/iPad|iPhone|iPod/.test(navigator.userAgent)&&!("MSStream"in window),this.FIREFOX=this.isBrowser&&/(firefox|minefield)/i.test(navigator.userAgent),this.ANDROID=this.isBrowser&&/android/i.test(navigator.userAgent)&&!this.TRIDENT,this.SAFARI=this.isBrowser&&/safari/i.test(navigator.userAgent)&&this.WEBKIT}};t.\u0275fac=function(i){return new(i||t)(m(Qt))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var pn;function ip(){if(pn==null&&typeof window<"u")try{window.addEventListener("test",null,Object.defineProperty({},"passive",{get:()=>pn=!0}))}finally{pn=pn||!1}return pn}function ye(n){return ip()?n:!!n.capture}var Ve;function id(){if(Ve==null){if(typeof document!="object"||!document||typeof Element!="function"||!Element)return Ve=!1,Ve;if("scrollBehavior"in document.documentElement.style)Ve=!0;else{let n=Element.prototype.scrollTo;n?Ve=!/\{\s*\[native code\]\s*\}/.test(n.toString()):Ve=!1}}return Ve}var Hs;function np(){if(Hs==null){let n=typeof document<"u"?document.head:null;Hs=!!(n&&(n.createShadowRoot||n.attachShadow))}return Hs}function nd(n){if(np()){let t=n.getRootNode?n.getRootNode():null;if(typeof ShadowRoot<"u"&&ShadowRoot&&t instanceof ShadowRoot)return t}return null}function Lt(n){return n.composedPath?n.composedPath()[0]:n.target}function gn(){return typeof __karma__<"u"&&!!__karma__||typeof jasmine<"u"&&!!jasmine||typeof jest<"u"&&!!jest||typeof Mocha<"u"&&!!Mocha}function od(n){return!isNaN(parseFloat(n))&&!isNaN(Number(n))}function _i(n){return Array.isArray(n)?n:[n]}function ct(n){return n==null?"":typeof n=="string"?n:`${n}px`}function ie(n){return n instanceof A?n.nativeElement:n}var rp=20,sd=(()=>{let t=class t{constructor(e,i,r){this._ngZone=e,this._platform=i,this._scrolled=new N,this._globalSubscription=null,this._scrolledCount=0,this.scrollContainers=new Map,this._document=r}register(e){this.scrollContainers.has(e)||this.scrollContainers.set(e,e.elementScrolled().subscribe(()=>this._scrolled.next(e)))}deregister(e){let i=this.scrollContainers.get(e);i&&(i.unsubscribe(),this.scrollContainers.delete(e))}scrolled(e=rp){return this._platform.isBrowser?new $e(i=>{this._globalSubscription||this._addGlobalListener();let r=e>0?this._scrolled.pipe(cr(e)).subscribe(i):this._scrolled.subscribe(i);return this._scrolledCount++,()=>{r.unsubscribe(),this._scrolledCount--,this._scrolledCount||this._removeGlobalListener()}}):v()}ngOnDestroy(){this._removeGlobalListener(),this.scrollContainers.forEach((e,i)=>this.deregister(i)),this._scrolled.complete()}ancestorScrolled(e,i){let r=this.getAncestorScrollContainers(e);return this.scrolled(i).pipe(dt(s=>!s||r.indexOf(s)>-1))}getAncestorScrollContainers(e){let i=[];return this.scrollContainers.forEach((r,s)=>{this._scrollableContainsElement(s,e)&&i.push(s)}),i}_getWindow(){return this._document.defaultView||window}_scrollableContainsElement(e,i){let r=ie(i),s=e.getElementRef().nativeElement;do if(r==s)return!0;while(r=r.parentElement);return!1}_addGlobalListener(){this._globalSubscription=this._ngZone.runOutsideAngular(()=>{let e=this._getWindow();return ka(e.document,"scroll").subscribe(()=>this._scrolled.next())})}_removeGlobalListener(){this._globalSubscription&&(this._globalSubscription.unsubscribe(),this._globalSubscription=null)}};t.\u0275fac=function(i){return new(i||t)(m(I),m(J),m(T,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var sp=20,bn=(()=>{let t=class t{constructor(e,i,r){this._platform=e,this._change=new N,this._changeListener=s=>{this._change.next(s)},this._document=r,i.runOutsideAngular(()=>{if(e.isBrowser){let s=this._getWindow();s.addEventListener("resize",this._changeListener),s.addEventListener("orientationchange",this._changeListener)}this.change().subscribe(()=>this._viewportSize=null)})}ngOnDestroy(){if(this._platform.isBrowser){let e=this._getWindow();e.removeEventListener("resize",this._changeListener),e.removeEventListener("orientationchange",this._changeListener)}this._change.complete()}getViewportSize(){this._viewportSize||this._updateViewportSize();let e={width:this._viewportSize.width,height:this._viewportSize.height};return this._platform.isBrowser||(this._viewportSize=null),e}getViewportRect(){let e=this.getViewportScrollPosition(),{width:i,height:r}=this.getViewportSize();return{top:e.top,left:e.left,bottom:e.top+r,right:e.left+i,height:r,width:i}}getViewportScrollPosition(){if(!this._platform.isBrowser)return{top:0,left:0};let e=this._document,i=this._getWindow(),r=e.documentElement,s=r.getBoundingClientRect(),a=-s.top||e.body.scrollTop||i.scrollY||r.scrollTop||0,l=-s.left||e.body.scrollLeft||i.scrollX||r.scrollLeft||0;return{top:a,left:l}}change(e=sp){return e>0?this._change.pipe(cr(e)):this._change}_getWindow(){return this._document.defaultView||window}_updateViewportSize(){let e=this._getWindow();this._viewportSize=this._platform.isBrowser?{width:e.innerWidth,height:e.innerHeight}:{width:0,height:0}}};t.\u0275fac=function(i){return new(i||t)(m(J),m(I),m(T,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var No=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({});let n=t;return n})(),vn=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[_e,No,_e,No]});let n=t;return n})();var lp=[[["caption"]],[["colgroup"],["col"]],"*"],cp=["caption","colgroup, col","*"];function dp(n,t){n&1&&K(0,2)}function up(n,t){n&1&&(x(0,"thead",0),It(1,1),_(),x(2,"tbody",0),It(3,2)(4,3),_(),x(5,"tfoot",0),It(6,4),_())}function hp(n,t){n&1&&It(0,1)(1,2)(2,3)(3,4)}var jt=new C("CDK_TABLE");var Bo=(()=>{let t=class t{constructor(e){this.template=e}};t.\u0275fac=function(i){return new(i||t)(u(Ct))},t.\u0275dir=D({type:t,selectors:[["","cdkCellDef",""]],standalone:!0});let n=t;return n})(),Uo=(()=>{let t=class t{constructor(e){this.template=e}};t.\u0275fac=function(i){return new(i||t)(u(Ct))},t.\u0275dir=D({type:t,selectors:[["","cdkHeaderCellDef",""]],standalone:!0});let n=t;return n})(),dd=(()=>{let t=class t{constructor(e){this.template=e}};t.\u0275fac=function(i){return new(i||t)(u(Ct))},t.\u0275dir=D({type:t,selectors:[["","cdkFooterCellDef",""]],standalone:!0});let n=t;return n})(),yi=(()=>{let t=class t{get name(){return this._name}set name(e){this._setNameInput(e)}get sticky(){return this._sticky}set sticky(e){e!==this._sticky&&(this._sticky=e,this._hasStickyChanged=!0)}get stickyEnd(){return this._stickyEnd}set stickyEnd(e){e!==this._stickyEnd&&(this._stickyEnd=e,this._hasStickyChanged=!0)}constructor(e){this._table=e,this._hasStickyChanged=!1,this._sticky=!1,this._stickyEnd=!1}hasStickyChanged(){let e=this._hasStickyChanged;return this.resetStickyChanged(),e}resetStickyChanged(){this._hasStickyChanged=!1}_updateColumnCssClassName(){this._columnCssClassName=[`cdk-column-${this.cssClassFriendlyName}`]}_setNameInput(e){e&&(this._name=e,this.cssClassFriendlyName=e.replace(/[^a-z0-9_-]/gi,"-"),this._updateColumnCssClassName())}};t.\u0275fac=function(i){return new(i||t)(u(jt,8))},t.\u0275dir=D({type:t,selectors:[["","cdkColumnDef",""]],contentQueries:function(i,r,s){if(i&1&&(gt(s,Bo,5),gt(s,Uo,5),gt(s,dd,5)),i&2){let a;at(a=lt())&&(r.cell=a.first),at(a=lt())&&(r.headerCell=a.first),at(a=lt())&&(r.footerCell=a.first)}},inputs:{name:[y.None,"cdkColumnDef","name"],sticky:[y.HasDecoratorInputTransform,"sticky","sticky",W],stickyEnd:[y.HasDecoratorInputTransform,"stickyEnd","stickyEnd",W]},standalone:!0,features:[Q([{provide:"MAT_SORT_HEADER_COLUMN_DEF",useExisting:t}]),nt]});let n=t;return n})(),Lo=class{constructor(t,o){o.nativeElement.classList.add(...t._columnCssClassName)}},ud=(()=>{let t=class t extends Lo{constructor(e,i){super(e,i)}};t.\u0275fac=function(i){return new(i||t)(u(yi),u(A))},t.\u0275dir=D({type:t,selectors:[["cdk-header-cell"],["th","cdk-header-cell",""]],hostAttrs:["role","columnheader",1,"cdk-header-cell"],standalone:!0,features:[U]});let n=t;return n})();var hd=(()=>{let t=class t extends Lo{constructor(e,i){super(e,i);let r=e._table?._getCellRole();r&&i.nativeElement.setAttribute("role",r)}};t.\u0275fac=function(i){return new(i||t)(u(yi),u(A))},t.\u0275dir=D({type:t,selectors:[["cdk-cell"],["td","cdk-cell",""]],hostAttrs:[1,"cdk-cell"],standalone:!0,features:[U]});let n=t;return n})(),jo=class{constructor(){this.tasks=[],this.endTasks=[]}},Vo=new C("_COALESCED_STYLE_SCHEDULER"),Gs=(()=>{let t=class t{constructor(e){this._ngZone=e,this._currentSchedule=null,this._destroyed=new N}schedule(e){this._createScheduleIfNeeded(),this._currentSchedule.tasks.push(e)}scheduleEnd(e){this._createScheduleIfNeeded(),this._currentSchedule.endTasks.push(e)}ngOnDestroy(){this._destroyed.next(),this._destroyed.complete()}_createScheduleIfNeeded(){this._currentSchedule||(this._currentSchedule=new jo,this._getScheduleObservable().pipe(mt(this._destroyed)).subscribe(()=>{for(;this._currentSchedule.tasks.length||this._currentSchedule.endTasks.length;){let e=this._currentSchedule;this._currentSchedule=new jo;for(let i of e.tasks)i();for(let i of e.endTasks)i()}this._currentSchedule=null}))}_getScheduleObservable(){return this._ngZone.isStable?ht(Promise.resolve(void 0)):this._ngZone.onStable.pipe(ut(1))}};t.\u0275fac=function(i){return new(i||t)(m(I))},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})();var Ys=(()=>{let t=class t{constructor(e,i){this.template=e,this._differs=i}ngOnChanges(e){if(!this._columnsDiffer){let i=e.columns&&e.columns.currentValue||[];this._columnsDiffer=this._differs.find(i).create(),this._columnsDiffer.diff(i)}}getColumnsDiff(){return this._columnsDiffer.diff(this.columns)}extractCellTemplate(e){return this instanceof _n?e.headerCell.template:this instanceof qs?e.footerCell.template:e.cell.template}};t.\u0275fac=function(i){return new(i||t)(u(Ct),u(Me))},t.\u0275dir=D({type:t,features:[yt]});let n=t;return n})(),_n=(()=>{let t=class t extends Ys{get sticky(){return this._sticky}set sticky(e){e!==this._sticky&&(this._sticky=e,this._hasStickyChanged=!0)}constructor(e,i,r){super(e,i),this._table=r,this._hasStickyChanged=!1,this._sticky=!1}ngOnChanges(e){super.ngOnChanges(e)}hasStickyChanged(){let e=this._hasStickyChanged;return this.resetStickyChanged(),e}resetStickyChanged(){this._hasStickyChanged=!1}};t.\u0275fac=function(i){return new(i||t)(u(Ct),u(Me),u(jt,8))},t.\u0275dir=D({type:t,selectors:[["","cdkHeaderRowDef",""]],inputs:{columns:[y.None,"cdkHeaderRowDef","columns"],sticky:[y.HasDecoratorInputTransform,"cdkHeaderRowDefSticky","sticky",W]},standalone:!0,features:[nt,U,yt]});let n=t;return n})(),qs=(()=>{let t=class t extends Ys{get sticky(){return this._sticky}set sticky(e){e!==this._sticky&&(this._sticky=e,this._hasStickyChanged=!0)}constructor(e,i,r){super(e,i),this._table=r,this._hasStickyChanged=!1,this._sticky=!1}ngOnChanges(e){super.ngOnChanges(e)}hasStickyChanged(){let e=this._hasStickyChanged;return this.resetStickyChanged(),e}resetStickyChanged(){this._hasStickyChanged=!1}};t.\u0275fac=function(i){return new(i||t)(u(Ct),u(Me),u(jt,8))},t.\u0275dir=D({type:t,selectors:[["","cdkFooterRowDef",""]],inputs:{columns:[y.None,"cdkFooterRowDef","columns"],sticky:[y.HasDecoratorInputTransform,"cdkFooterRowDefSticky","sticky",W]},standalone:!0,features:[nt,U,yt]});let n=t;return n})(),Ho=(()=>{let t=class t extends Ys{constructor(e,i,r){super(e,i),this._table=r}};t.\u0275fac=function(i){return new(i||t)(u(Ct),u(Me),u(jt,8))},t.\u0275dir=D({type:t,selectors:[["","cdkRowDef",""]],inputs:{columns:[y.None,"cdkRowDefColumns","columns"],when:[y.None,"cdkRowDefWhen","when"]},standalone:!0,features:[U]});let n=t;return n})(),ze=(()=>{let t=class t{constructor(e){this._viewContainer=e,t.mostRecentCellOutlet=this}ngOnDestroy(){t.mostRecentCellOutlet===this&&(t.mostRecentCellOutlet=null)}};t.mostRecentCellOutlet=null,t.\u0275fac=function(i){return new(i||t)(u(kt))},t.\u0275dir=D({type:t,selectors:[["","cdkCellOutlet",""]],standalone:!0});let n=t;return n})(),Zs=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275cmp=P({type:t,selectors:[["cdk-header-row"],["tr","cdk-header-row",""]],hostAttrs:["role","row",1,"cdk-header-row"],standalone:!0,features:[tt],decls:1,vars:0,consts:[["cdkCellOutlet",""]],template:function(i,r){i&1&&It(0,0)},dependencies:[ze],encapsulation:2});let n=t;return n})();var Xs=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275cmp=P({type:t,selectors:[["cdk-row"],["tr","cdk-row",""]],hostAttrs:["role","row",1,"cdk-row"],standalone:!0,features:[tt],decls:1,vars:0,consts:[["cdkCellOutlet",""]],template:function(i,r){i&1&&It(0,0)},dependencies:[ze],encapsulation:2});let n=t;return n})(),md=(()=>{let t=class t{constructor(e){this.templateRef=e,this._contentClassName="cdk-no-data-row"}};t.\u0275fac=function(i){return new(i||t)(u(Ct))},t.\u0275dir=D({type:t,selectors:[["ng-template","cdkNoDataRow",""]],standalone:!0});let n=t;return n})(),ld=["top","bottom","left","right"],Ws=class{constructor(t,o,e,i,r=!0,s=!0,a){this._isNativeHtmlTable=t,this._stickCellCss=o,this.direction=e,this._coalescedStyleScheduler=i,this._isBrowser=r,this._needsPositionStickyOnElement=s,this._positionListener=a,this._cachedCellWidths=[],this._borderCellCss={top:`${o}-border-elem-top`,bottom:`${o}-border-elem-bottom`,left:`${o}-border-elem-left`,right:`${o}-border-elem-right`}}clearStickyPositioning(t,o){let e=[];for(let i of t)if(i.nodeType===i.ELEMENT_NODE){e.push(i);for(let r=0;r<i.children.length;r++)e.push(i.children[r])}this._coalescedStyleScheduler.schedule(()=>{for(let i of e)this._removeStickyStyle(i,o)})}updateStickyColumns(t,o,e,i=!0){if(!t.length||!this._isBrowser||!(o.some(r=>r)||e.some(r=>r))){this._positionListener&&(this._positionListener.stickyColumnsUpdated({sizes:[]}),this._positionListener.stickyEndColumnsUpdated({sizes:[]}));return}this._coalescedStyleScheduler.schedule(()=>{let r=t[0],s=r.children.length,a=this._getCellWidths(r,i),l=this._getStickyStartColumnPositions(a,o),c=this._getStickyEndColumnPositions(a,e),d=o.lastIndexOf(!0),h=e.indexOf(!0),f=this.direction==="rtl",w=f?"right":"left",j=f?"left":"right";for(let z of t)for(let k=0;k<s;k++){let V=z.children[k];o[k]&&this._addStickyStyle(V,w,l[k],k===d),e[k]&&this._addStickyStyle(V,j,c[k],k===h)}this._positionListener&&(this._positionListener.stickyColumnsUpdated({sizes:d===-1?[]:a.slice(0,d+1).map((z,k)=>o[k]?z:null)}),this._positionListener.stickyEndColumnsUpdated({sizes:h===-1?[]:a.slice(h).map((z,k)=>e[k+h]?z:null).reverse()}))})}stickRows(t,o,e){this._isBrowser&&this._coalescedStyleScheduler.schedule(()=>{let i=e==="bottom"?t.slice().reverse():t,r=e==="bottom"?o.slice().reverse():o,s=[],a=[],l=[];for(let d=0,h=0;d<i.length;d++){if(!r[d])continue;s[d]=h;let f=i[d];l[d]=this._isNativeHtmlTable?Array.from(f.children):[f];let w=f.getBoundingClientRect().height;h+=w,a[d]=w}let c=r.lastIndexOf(!0);for(let d=0;d<i.length;d++){if(!r[d])continue;let h=s[d],f=d===c;for(let w of l[d])this._addStickyStyle(w,e,h,f)}e==="top"?this._positionListener?.stickyHeaderRowsUpdated({sizes:a,offsets:s,elements:l}):this._positionListener?.stickyFooterRowsUpdated({sizes:a,offsets:s,elements:l})})}updateStickyFooterContainer(t,o){this._isNativeHtmlTable&&this._coalescedStyleScheduler.schedule(()=>{let e=t.querySelector("tfoot");e&&(o.some(i=>!i)?this._removeStickyStyle(e,["bottom"]):this._addStickyStyle(e,"bottom",0,!1))})}_removeStickyStyle(t,o){for(let i of o)t.style[i]="",t.classList.remove(this._borderCellCss[i]);ld.some(i=>o.indexOf(i)===-1&&t.style[i])?t.style.zIndex=this._getCalculatedZIndex(t):(t.style.zIndex="",this._needsPositionStickyOnElement&&(t.style.position=""),t.classList.remove(this._stickCellCss))}_addStickyStyle(t,o,e,i){t.classList.add(this._stickCellCss),i&&t.classList.add(this._borderCellCss[o]),t.style[o]=`${e}px`,t.style.zIndex=this._getCalculatedZIndex(t),this._needsPositionStickyOnElement&&(t.style.cssText+="position: -webkit-sticky; position: sticky; ")}_getCalculatedZIndex(t){let o={top:100,bottom:10,left:1,right:1},e=0;for(let i of ld)t.style[i]&&(e+=o[i]);return e?`${e}`:""}_getCellWidths(t,o=!0){if(!o&&this._cachedCellWidths.length)return this._cachedCellWidths;let e=[],i=t.children;for(let r=0;r<i.length;r++){let s=i[r];e.push(s.getBoundingClientRect().width)}return this._cachedCellWidths=e,e}_getStickyStartColumnPositions(t,o){let e=[],i=0;for(let r=0;r<t.length;r++)o[r]&&(e[r]=i,i+=t[r]);return e}_getStickyEndColumnPositions(t,o){let e=[],i=0;for(let r=t.length;r>0;r--)o[r]&&(e[r]=i,i+=t[r]);return e}};var zo=new C("CDK_SPL");var Ks=(()=>{let t=class t{constructor(e,i){this.viewContainer=e,this.elementRef=i;let r=g(jt);r._rowOutlet=this,r._outletAssigned()}};t.\u0275fac=function(i){return new(i||t)(u(kt),u(A))},t.\u0275dir=D({type:t,selectors:[["","rowOutlet",""]],standalone:!0});let n=t;return n})(),Qs=(()=>{let t=class t{constructor(e,i){this.viewContainer=e,this.elementRef=i;let r=g(jt);r._headerRowOutlet=this,r._outletAssigned()}};t.\u0275fac=function(i){return new(i||t)(u(kt),u(A))},t.\u0275dir=D({type:t,selectors:[["","headerRowOutlet",""]],standalone:!0});let n=t;return n})(),Js=(()=>{let t=class t{constructor(e,i){this.viewContainer=e,this.elementRef=i;let r=g(jt);r._footerRowOutlet=this,r._outletAssigned()}};t.\u0275fac=function(i){return new(i||t)(u(kt),u(A))},t.\u0275dir=D({type:t,selectors:[["","footerRowOutlet",""]],standalone:!0});let n=t;return n})(),ta=(()=>{let t=class t{constructor(e,i){this.viewContainer=e,this.elementRef=i;let r=g(jt);r._noDataRowOutlet=this,r._outletAssigned()}};t.\u0275fac=function(i){return new(i||t)(u(kt),u(A))},t.\u0275dir=D({type:t,selectors:[["","noDataRowOutlet",""]],standalone:!0});let n=t;return n})();var ea=(()=>{let t=class t{_getCellRole(){if(this._cellRoleInternal===void 0){let e=this._elementRef.nativeElement.getAttribute("role"),i=e==="grid"||e==="treegrid"?"gridcell":"cell";this._cellRoleInternal=this._isNativeHtmlTable&&i==="cell"?null:i}return this._cellRoleInternal}get trackBy(){return this._trackByFn}set trackBy(e){this._trackByFn=e}get dataSource(){return this._dataSource}set dataSource(e){this._dataSource!==e&&this._switchDataSource(e)}get multiTemplateDataRows(){return this._multiTemplateDataRows}set multiTemplateDataRows(e){this._multiTemplateDataRows=e,this._rowOutlet&&this._rowOutlet.viewContainer.length&&(this._forceRenderDataRows(),this.updateStickyColumnStyles())}get fixedLayout(){return this._fixedLayout}set fixedLayout(e){this._fixedLayout=e,this._forceRecalculateCellWidths=!0,this._stickyColumnStylesNeedReset=!0}constructor(e,i,r,s,a,l,c,d,h,f,w,j){this._differs=e,this._changeDetectorRef=i,this._elementRef=r,this._dir=a,this._platform=c,this._viewRepeater=d,this._coalescedStyleScheduler=h,this._viewportRuler=f,this._stickyPositioningListener=w,this._ngZone=j,this._onDestroy=new N,this._columnDefsByName=new Map,this._customColumnDefs=new Set,this._customRowDefs=new Set,this._customHeaderRowDefs=new Set,this._customFooterRowDefs=new Set,this._headerRowDefChanged=!0,this._footerRowDefChanged=!0,this._stickyColumnStylesNeedReset=!0,this._forceRecalculateCellWidths=!0,this._cachedRenderRowsMap=new Map,this.stickyCssClass="cdk-table-sticky",this.needsPositionStickyOnElement=!0,this._isShowingNoDataRow=!1,this._hasAllOutlets=!1,this._hasInitialized=!1,this._cellRoleInternal=void 0,this._multiTemplateDataRows=!1,this._fixedLayout=!1,this.contentChanged=new it,this.viewChange=new rt({start:0,end:Number.MAX_VALUE}),s||r.nativeElement.setAttribute("role","table"),this._document=l,this._isServer=!c.isBrowser,this._isNativeHtmlTable=r.nativeElement.nodeName==="TABLE"}ngOnInit(){this._setupStickyStyler(),this._dataDiffer=this._differs.find([]).create((e,i)=>this.trackBy?this.trackBy(i.dataIndex,i.data):i),this._viewportRuler.change().pipe(mt(this._onDestroy)).subscribe(()=>{this._forceRecalculateCellWidths=!0})}ngAfterContentInit(){this._hasInitialized=!0}ngAfterContentChecked(){this._canRender()&&this._render()}ngOnDestroy(){[this._rowOutlet?.viewContainer,this._headerRowOutlet?.viewContainer,this._footerRowOutlet?.viewContainer,this._cachedRenderRowsMap,this._customColumnDefs,this._customRowDefs,this._customHeaderRowDefs,this._customFooterRowDefs,this._columnDefsByName].forEach(e=>{e?.clear()}),this._headerRowDefs=[],this._footerRowDefs=[],this._defaultRowDef=null,this._onDestroy.next(),this._onDestroy.complete(),Oo(this.dataSource)&&this.dataSource.disconnect(this)}renderRows(){this._renderRows=this._getAllRenderRows();let e=this._dataDiffer.diff(this._renderRows);if(!e){this._updateNoDataRow(),this.contentChanged.next();return}let i=this._rowOutlet.viewContainer;this._viewRepeater.applyChanges(e,i,(r,s,a)=>this._getEmbeddedViewArgs(r.item,a),r=>r.item.data,r=>{r.operation===bi.INSERTED&&r.context&&this._renderCellTemplateForItem(r.record.item.rowDef,r.context)}),this._updateRowIndexContext(),e.forEachIdentityChange(r=>{let s=i.get(r.currentIndex);s.context.$implicit=r.item.data}),this._updateNoDataRow(),this._ngZone&&I.isInAngularZone()?this._ngZone.onStable.pipe(ut(1),mt(this._onDestroy)).subscribe(()=>{this.updateStickyColumnStyles()}):this.updateStickyColumnStyles(),this.contentChanged.next()}addColumnDef(e){this._customColumnDefs.add(e)}removeColumnDef(e){this._customColumnDefs.delete(e)}addRowDef(e){this._customRowDefs.add(e)}removeRowDef(e){this._customRowDefs.delete(e)}addHeaderRowDef(e){this._customHeaderRowDefs.add(e),this._headerRowDefChanged=!0}removeHeaderRowDef(e){this._customHeaderRowDefs.delete(e),this._headerRowDefChanged=!0}addFooterRowDef(e){this._customFooterRowDefs.add(e),this._footerRowDefChanged=!0}removeFooterRowDef(e){this._customFooterRowDefs.delete(e),this._footerRowDefChanged=!0}setNoDataRow(e){this._customNoDataRow=e}updateStickyHeaderRowStyles(){let e=this._getRenderedRows(this._headerRowOutlet);if(this._isNativeHtmlTable){let r=cd(this._headerRowOutlet,"thead");r&&(r.style.display=e.length?"":"none")}let i=this._headerRowDefs.map(r=>r.sticky);this._stickyStyler.clearStickyPositioning(e,["top"]),this._stickyStyler.stickRows(e,i,"top"),this._headerRowDefs.forEach(r=>r.resetStickyChanged())}updateStickyFooterRowStyles(){let e=this._getRenderedRows(this._footerRowOutlet);if(this._isNativeHtmlTable){let r=cd(this._footerRowOutlet,"tfoot");r&&(r.style.display=e.length?"":"none")}let i=this._footerRowDefs.map(r=>r.sticky);this._stickyStyler.clearStickyPositioning(e,["bottom"]),this._stickyStyler.stickRows(e,i,"bottom"),this._stickyStyler.updateStickyFooterContainer(this._elementRef.nativeElement,i),this._footerRowDefs.forEach(r=>r.resetStickyChanged())}updateStickyColumnStyles(){let e=this._getRenderedRows(this._headerRowOutlet),i=this._getRenderedRows(this._rowOutlet),r=this._getRenderedRows(this._footerRowOutlet);(this._isNativeHtmlTable&&!this._fixedLayout||this._stickyColumnStylesNeedReset)&&(this._stickyStyler.clearStickyPositioning([...e,...i,...r],["left","right"]),this._stickyColumnStylesNeedReset=!1),e.forEach((s,a)=>{this._addStickyColumnStyles([s],this._headerRowDefs[a])}),this._rowDefs.forEach(s=>{let a=[];for(let l=0;l<i.length;l++)this._renderRows[l].rowDef===s&&a.push(i[l]);this._addStickyColumnStyles(a,s)}),r.forEach((s,a)=>{this._addStickyColumnStyles([s],this._footerRowDefs[a])}),Array.from(this._columnDefsByName.values()).forEach(s=>s.resetStickyChanged())}_outletAssigned(){!this._hasAllOutlets&&this._rowOutlet&&this._headerRowOutlet&&this._footerRowOutlet&&this._noDataRowOutlet&&(this._hasAllOutlets=!0,this._canRender()&&this._render())}_canRender(){return this._hasAllOutlets&&this._hasInitialized}_render(){this._cacheRowDefs(),this._cacheColumnDefs(),!this._headerRowDefs.length&&!this._footerRowDefs.length&&this._rowDefs.length;let i=this._renderUpdatedColumns()||this._headerRowDefChanged||this._footerRowDefChanged;this._stickyColumnStylesNeedReset=this._stickyColumnStylesNeedReset||i,this._forceRecalculateCellWidths=i,this._headerRowDefChanged&&(this._forceRenderHeaderRows(),this._headerRowDefChanged=!1),this._footerRowDefChanged&&(this._forceRenderFooterRows(),this._footerRowDefChanged=!1),this.dataSource&&this._rowDefs.length>0&&!this._renderChangeSubscription?this._observeRenderChanges():this._stickyColumnStylesNeedReset&&this.updateStickyColumnStyles(),this._checkStickyStates()}_getAllRenderRows(){let e=[],i=this._cachedRenderRowsMap;this._cachedRenderRowsMap=new Map;for(let r=0;r<this._data.length;r++){let s=this._data[r],a=this._getRenderRowsForData(s,r,i.get(s));this._cachedRenderRowsMap.has(s)||this._cachedRenderRowsMap.set(s,new WeakMap);for(let l=0;l<a.length;l++){let c=a[l],d=this._cachedRenderRowsMap.get(c.data);d.has(c.rowDef)?d.get(c.rowDef).push(c):d.set(c.rowDef,[c]),e.push(c)}}return e}_getRenderRowsForData(e,i,r){return this._getRowDefs(e,i).map(a=>{let l=r&&r.has(a)?r.get(a):[];if(l.length){let c=l.shift();return c.dataIndex=i,c}else return{data:e,rowDef:a,dataIndex:i}})}_cacheColumnDefs(){this._columnDefsByName.clear(),Po(this._getOwnDefs(this._contentColumnDefs),this._customColumnDefs).forEach(i=>{this._columnDefsByName.has(i.name),this._columnDefsByName.set(i.name,i)})}_cacheRowDefs(){this._headerRowDefs=Po(this._getOwnDefs(this._contentHeaderRowDefs),this._customHeaderRowDefs),this._footerRowDefs=Po(this._getOwnDefs(this._contentFooterRowDefs),this._customFooterRowDefs),this._rowDefs=Po(this._getOwnDefs(this._contentRowDefs),this._customRowDefs);let e=this._rowDefs.filter(i=>!i.when);!this.multiTemplateDataRows&&e.length>1,this._defaultRowDef=e[0]}_renderUpdatedColumns(){let e=(a,l)=>a||!!l.getColumnsDiff(),i=this._rowDefs.reduce(e,!1);i&&this._forceRenderDataRows();let r=this._headerRowDefs.reduce(e,!1);r&&this._forceRenderHeaderRows();let s=this._footerRowDefs.reduce(e,!1);return s&&this._forceRenderFooterRows(),i||r||s}_switchDataSource(e){this._data=[],Oo(this.dataSource)&&this.dataSource.disconnect(this),this._renderChangeSubscription&&(this._renderChangeSubscription.unsubscribe(),this._renderChangeSubscription=null),e||(this._dataDiffer&&this._dataDiffer.diff([]),this._rowOutlet&&this._rowOutlet.viewContainer.clear()),this._dataSource=e}_observeRenderChanges(){if(!this.dataSource)return;let e;Oo(this.dataSource)?e=this.dataSource.connect(this):We(this.dataSource)?e=this.dataSource:Array.isArray(this.dataSource)&&(e=v(this.dataSource)),this._renderChangeSubscription=e.pipe(mt(this._onDestroy)).subscribe(i=>{this._data=i||[],this.renderRows()})}_forceRenderHeaderRows(){this._headerRowOutlet.viewContainer.length>0&&this._headerRowOutlet.viewContainer.clear(),this._headerRowDefs.forEach((e,i)=>this._renderRow(this._headerRowOutlet,e,i)),this.updateStickyHeaderRowStyles()}_forceRenderFooterRows(){this._footerRowOutlet.viewContainer.length>0&&this._footerRowOutlet.viewContainer.clear(),this._footerRowDefs.forEach((e,i)=>this._renderRow(this._footerRowOutlet,e,i)),this.updateStickyFooterRowStyles()}_addStickyColumnStyles(e,i){let r=Array.from(i.columns||[]).map(l=>{let c=this._columnDefsByName.get(l);return c}),s=r.map(l=>l.sticky),a=r.map(l=>l.stickyEnd);this._stickyStyler.updateStickyColumns(e,s,a,!this._fixedLayout||this._forceRecalculateCellWidths)}_getRenderedRows(e){let i=[];for(let r=0;r<e.viewContainer.length;r++){let s=e.viewContainer.get(r);i.push(s.rootNodes[0])}return i}_getRowDefs(e,i){if(this._rowDefs.length==1)return[this._rowDefs[0]];let r=[];if(this.multiTemplateDataRows)r=this._rowDefs.filter(s=>!s.when||s.when(i,e));else{let s=this._rowDefs.find(a=>a.when&&a.when(i,e))||this._defaultRowDef;s&&r.push(s)}return r.length,r}_getEmbeddedViewArgs(e,i){let r=e.rowDef,s={$implicit:e.data};return{templateRef:r.template,context:s,index:i}}_renderRow(e,i,r,s={}){let a=e.viewContainer.createEmbeddedView(i.template,s,r);return this._renderCellTemplateForItem(i,s),a}_renderCellTemplateForItem(e,i){for(let r of this._getCellTemplates(e))ze.mostRecentCellOutlet&&ze.mostRecentCellOutlet._viewContainer.createEmbeddedView(r,i);this._changeDetectorRef.markForCheck()}_updateRowIndexContext(){let e=this._rowOutlet.viewContainer;for(let i=0,r=e.length;i<r;i++){let a=e.get(i).context;a.count=r,a.first=i===0,a.last=i===r-1,a.even=i%2===0,a.odd=!a.even,this.multiTemplateDataRows?(a.dataIndex=this._renderRows[i].dataIndex,a.renderIndex=i):a.index=this._renderRows[i].dataIndex}}_getCellTemplates(e){return!e||!e.columns?[]:Array.from(e.columns,i=>{let r=this._columnDefsByName.get(i);return e.extractCellTemplate(r)})}_forceRenderDataRows(){this._dataDiffer.diff([]),this._rowOutlet.viewContainer.clear(),this.renderRows()}_checkStickyStates(){let e=(i,r)=>i||r.hasStickyChanged();this._headerRowDefs.reduce(e,!1)&&this.updateStickyHeaderRowStyles(),this._footerRowDefs.reduce(e,!1)&&this.updateStickyFooterRowStyles(),Array.from(this._columnDefsByName.values()).reduce(e,!1)&&(this._stickyColumnStylesNeedReset=!0,this.updateStickyColumnStyles())}_setupStickyStyler(){let e=this._dir?this._dir.value:"ltr";this._stickyStyler=new Ws(this._isNativeHtmlTable,this.stickyCssClass,e,this._coalescedStyleScheduler,this._platform.isBrowser,this.needsPositionStickyOnElement,this._stickyPositioningListener),(this._dir?this._dir.change:v()).pipe(mt(this._onDestroy)).subscribe(i=>{this._stickyStyler.direction=i,this.updateStickyColumnStyles()})}_getOwnDefs(e){return e.filter(i=>!i._table||i._table===this)}_updateNoDataRow(){let e=this._customNoDataRow||this._noDataRow;if(!e)return;let i=this._rowOutlet.viewContainer.length===0;if(i===this._isShowingNoDataRow)return;let r=this._noDataRowOutlet.viewContainer;if(i){let s=r.createEmbeddedView(e.templateRef),a=s.rootNodes[0];s.rootNodes.length===1&&a?.nodeType===this._document.ELEMENT_NODE&&(a.setAttribute("role","row"),a.classList.add(e._contentClassName))}else r.clear();this._isShowingNoDataRow=i,this._changeDetectorRef.markForCheck()}};t.\u0275fac=function(i){return new(i||t)(u(Me),u(Dt),u(A),De("role"),u(gi,8),u(T),u(J),u(fn),u(Vo),u(bn),u(zo,12),u(I,8))},t.\u0275cmp=P({type:t,selectors:[["cdk-table"],["table","cdk-table",""]],contentQueries:function(i,r,s){if(i&1&&(gt(s,md,5),gt(s,yi,5),gt(s,Ho,5),gt(s,_n,5),gt(s,qs,5)),i&2){let a;at(a=lt())&&(r._noDataRow=a.first),at(a=lt())&&(r._contentColumnDefs=a),at(a=lt())&&(r._contentRowDefs=a),at(a=lt())&&(r._contentHeaderRowDefs=a),at(a=lt())&&(r._contentFooterRowDefs=a)}},hostAttrs:[1,"cdk-table"],hostVars:2,hostBindings:function(i,r){i&2&&st("cdk-table-fixed-layout",r.fixedLayout)},inputs:{trackBy:"trackBy",dataSource:"dataSource",multiTemplateDataRows:[y.HasDecoratorInputTransform,"multiTemplateDataRows","multiTemplateDataRows",W],fixedLayout:[y.HasDecoratorInputTransform,"fixedLayout","fixedLayout",W]},outputs:{contentChanged:"contentChanged"},exportAs:["cdkTable"],standalone:!0,features:[Q([{provide:jt,useExisting:t},{provide:fn,useClass:vi},{provide:Vo,useClass:Gs},{provide:zo,useValue:null}]),nt,tt],ngContentSelectors:cp,decls:5,vars:2,consts:[["role","rowgroup"],["headerRowOutlet",""],["rowOutlet",""],["noDataRowOutlet",""],["footerRowOutlet",""]],template:function(i,r){i&1&&(pt(lp),K(0),K(1,1),ot(2,dp,1,0)(3,up,7,0)(4,hp,4,0)),i&2&&(R(2),Ut(2,r._isServer?2:-1),R(),Ut(3,r._isNativeHtmlTable?3:4))},dependencies:[Qs,Ks,ta,Js],styles:[".cdk-table-fixed-layout{table-layout:fixed}"],encapsulation:2});let n=t;return n})();function Po(n,t){return n.concat(Array.from(t))}function cd(n,t){let o=t.toUpperCase(),e=n.viewContainer.element.nativeElement;for(;e;){let i=e.nodeType===1?e.nodeName:null;if(i===o)return e;if(i==="TABLE")break;e=e.parentNode}return null}var fd=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[vn]});let n=t;return n})();function $o(n,...t){return t.length?t.some(o=>n[o]):n.altKey||n.shiftKey||n.ctrlKey||n.metaKey}var mp=(()=>{let t=class t{create(e){return typeof MutationObserver>"u"?null:new MutationObserver(e)}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var pd=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({providers:[mp]});let n=t;return n})();var gd=new Set,Be,fp=(()=>{let t=class t{constructor(e,i){this._platform=e,this._nonce=i,this._matchMedia=this._platform.isBrowser&&window.matchMedia?window.matchMedia.bind(window):gp}matchMedia(e){return(this._platform.WEBKIT||this._platform.BLINK)&&pp(e,this._nonce),this._matchMedia(e)}};t.\u0275fac=function(i){return new(i||t)(m(J),m(ki,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function pp(n,t){if(!gd.has(n))try{Be||(Be=document.createElement("style"),t&&Be.setAttribute("nonce",t),Be.setAttribute("type","text/css"),document.head.appendChild(Be)),Be.sheet&&(Be.sheet.insertRule(`@media ${n} {body{ }}`,0),gd.add(n))}catch(o){console.error(o)}}function gp(n){return{matches:n==="all"||n==="",media:n,addListener:()=>{},removeListener:()=>{}}}var vd=(()=>{let t=class t{constructor(e,i){this._mediaMatcher=e,this._zone=i,this._queries=new Map,this._destroySubject=new N}ngOnDestroy(){this._destroySubject.next(),this._destroySubject.complete()}isMatched(e){return bd(_i(e)).some(r=>this._registerQuery(r).mql.matches)}observe(e){let r=bd(_i(e)).map(a=>this._registerQuery(a).observable),s=Vt(r);return s=kn(s.pipe(ut(1)),s.pipe(Fn(1),An(0))),s.pipe(M(a=>{let l={matches:!1,breakpoints:{}};return a.forEach(({matches:c,query:d})=>{l.matches=l.matches||c,l.breakpoints[d]=c}),l}))}_registerQuery(e){if(this._queries.has(e))return this._queries.get(e);let i=this._mediaMatcher.matchMedia(e),s={observable:new $e(a=>{let l=c=>this._zone.run(()=>a.next(c));return i.addListener(l),()=>{i.removeListener(l)}}).pipe(Xt(i),M(({matches:a})=>({query:e,matches:a})),mt(this._destroySubject)),mql:i};return this._queries.set(e,s),s}};t.\u0275fac=function(i){return new(i||t)(m(fp),m(I))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function bd(n){return n.map(t=>t.split(",")).reduce((t,o)=>t.concat(o)).map(t=>t.trim())}var na=class{constructor(t,o){this._items=t,this._activeItemIndex=-1,this._activeItem=null,this._wrap=!1,this._letterKeyStream=new N,this._typeaheadSubscription=St.EMPTY,this._vertical=!0,this._allowedModifierKeys=[],this._homeAndEnd=!1,this._pageUpAndDown={enabled:!1,delta:10},this._skipPredicateFn=e=>e.disabled,this._pressedLetters=[],this.tabOut=new N,this.change=new N,t instanceof Ri?this._itemChangesSubscription=t.changes.subscribe(e=>this._itemsChanged(e.toArray())):vr(t)&&(this._effectRef=ol(()=>this._itemsChanged(t()),{injector:o}))}skipPredicate(t){return this._skipPredicateFn=t,this}withWrap(t=!0){return this._wrap=t,this}withVerticalOrientation(t=!0){return this._vertical=t,this}withHorizontalOrientation(t){return this._horizontal=t,this}withAllowedModifierKeys(t){return this._allowedModifierKeys=t,this}withTypeAhead(t=200){return this._typeaheadSubscription.unsubscribe(),this._typeaheadSubscription=this._letterKeyStream.pipe(et(o=>this._pressedLetters.push(o)),An(t),dt(()=>this._pressedLetters.length>0),M(()=>this._pressedLetters.join(""))).subscribe(o=>{let e=this._getItemsArray();for(let i=1;i<e.length+1;i++){let r=(this._activeItemIndex+i)%e.length,s=e[r];if(!this._skipPredicateFn(s)&&s.getLabel().toUpperCase().trim().indexOf(o)===0){this.setActiveItem(r);break}}this._pressedLetters=[]}),this}cancelTypeahead(){return this._pressedLetters=[],this}withHomeAndEnd(t=!0){return this._homeAndEnd=t,this}withPageUpDown(t=!0,o=10){return this._pageUpAndDown={enabled:t,delta:o},this}setActiveItem(t){let o=this._activeItem;this.updateActiveItem(t),this._activeItem!==o&&this.change.next(this._activeItemIndex)}onKeydown(t){let o=t.keyCode,i=["altKey","ctrlKey","metaKey","shiftKey"].every(r=>!t[r]||this._allowedModifierKeys.indexOf(r)>-1);switch(o){case 9:this.tabOut.next();return;case 40:if(this._vertical&&i){this.setNextItemActive();break}else return;case 38:if(this._vertical&&i){this.setPreviousItemActive();break}else return;case 39:if(this._horizontal&&i){this._horizontal==="rtl"?this.setPreviousItemActive():this.setNextItemActive();break}else return;case 37:if(this._horizontal&&i){this._horizontal==="rtl"?this.setNextItemActive():this.setPreviousItemActive();break}else return;case 36:if(this._homeAndEnd&&i){this.setFirstItemActive();break}else return;case 35:if(this._homeAndEnd&&i){this.setLastItemActive();break}else return;case 33:if(this._pageUpAndDown.enabled&&i){let r=this._activeItemIndex-this._pageUpAndDown.delta;this._setActiveItemByIndex(r>0?r:0,1);break}else return;case 34:if(this._pageUpAndDown.enabled&&i){let r=this._activeItemIndex+this._pageUpAndDown.delta,s=this._getItemsArray().length;this._setActiveItemByIndex(r<s?r:s-1,-1);break}else return;default:(i||$o(t,"shiftKey"))&&(t.key&&t.key.length===1?this._letterKeyStream.next(t.key.toLocaleUpperCase()):(o>=65&&o<=90||o>=48&&o<=57)&&this._letterKeyStream.next(String.fromCharCode(o)));return}this._pressedLetters=[],t.preventDefault()}get activeItemIndex(){return this._activeItemIndex}get activeItem(){return this._activeItem}isTyping(){return this._pressedLetters.length>0}setFirstItemActive(){this._setActiveItemByIndex(0,1)}setLastItemActive(){this._setActiveItemByIndex(this._getItemsArray().length-1,-1)}setNextItemActive(){this._activeItemIndex<0?this.setFirstItemActive():this._setActiveItemByDelta(1)}setPreviousItemActive(){this._activeItemIndex<0&&this._wrap?this.setLastItemActive():this._setActiveItemByDelta(-1)}updateActiveItem(t){let o=this._getItemsArray(),e=typeof t=="number"?t:o.indexOf(t),i=o[e];this._activeItem=i??null,this._activeItemIndex=e}destroy(){this._typeaheadSubscription.unsubscribe(),this._itemChangesSubscription?.unsubscribe(),this._effectRef?.destroy(),this._letterKeyStream.complete(),this.tabOut.complete(),this.change.complete(),this._pressedLetters=[]}_setActiveItemByDelta(t){this._wrap?this._setActiveInWrapMode(t):this._setActiveInDefaultMode(t)}_setActiveInWrapMode(t){let o=this._getItemsArray();for(let e=1;e<=o.length;e++){let i=(this._activeItemIndex+t*e+o.length)%o.length,r=o[i];if(!this._skipPredicateFn(r)){this.setActiveItem(i);return}}}_setActiveInDefaultMode(t){this._setActiveItemByIndex(this._activeItemIndex+t,t)}_setActiveItemByIndex(t,o){let e=this._getItemsArray();if(e[t]){for(;this._skipPredicateFn(e[t]);)if(t+=o,!e[t])return;this.setActiveItem(t)}}_getItemsArray(){return vr(this._items)?this._items():this._items instanceof Ri?this._items.toArray():this._items}_itemsChanged(t){if(this._activeItem){let o=t.indexOf(this._activeItem);o>-1&&o!==this._activeItemIndex&&(this._activeItemIndex=o)}}};var Yo=class extends na{constructor(){super(...arguments),this._origin="program"}setFocusOrigin(t){return this._origin=t,this}setActiveItem(t){super.setActiveItem(t),this.activeItem&&this.activeItem.focus(this._origin)}};function yn(n){return n.buttons===0||n.detail===0}function xn(n){let t=n.touches&&n.touches[0]||n.changedTouches&&n.changedTouches[0];return!!t&&t.identifier===-1&&(t.radiusX==null||t.radiusX===1)&&(t.radiusY==null||t.radiusY===1)}var Tp=new C("cdk-input-modality-detector-options"),Ap={ignoreKeys:[18,17,224,91,16]},xd=650,xi=ye({passive:!0,capture:!0}),Fp=(()=>{let t=class t{get mostRecentModality(){return this._modality.value}constructor(e,i,r,s){this._platform=e,this._mostRecentTarget=null,this._modality=new rt(null),this._lastTouchMs=0,this._onKeydown=a=>{this._options?.ignoreKeys?.some(l=>l===a.keyCode)||(this._modality.next("keyboard"),this._mostRecentTarget=Lt(a))},this._onMousedown=a=>{Date.now()-this._lastTouchMs<xd||(this._modality.next(yn(a)?"keyboard":"mouse"),this._mostRecentTarget=Lt(a))},this._onTouchstart=a=>{if(xn(a)){this._modality.next("keyboard");return}this._lastTouchMs=Date.now(),this._modality.next("touch"),this._mostRecentTarget=Lt(a)},this._options=p(p({},Ap),s),this.modalityDetected=this._modality.pipe(Fn(1)),this.modalityChanged=this.modalityDetected.pipe(hr()),e.isBrowser&&i.runOutsideAngular(()=>{r.addEventListener("keydown",this._onKeydown,xi),r.addEventListener("mousedown",this._onMousedown,xi),r.addEventListener("touchstart",this._onTouchstart,xi)})}ngOnDestroy(){this._modality.complete(),this._platform.isBrowser&&(document.removeEventListener("keydown",this._onKeydown,xi),document.removeEventListener("mousedown",this._onMousedown,xi),document.removeEventListener("touchstart",this._onTouchstart,xi))}};t.\u0275fac=function(i){return new(i||t)(m(J),m(I),m(T),m(Tp,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var Go=function(n){return n[n.IMMEDIATE=0]="IMMEDIATE",n[n.EVENTUAL=1]="EVENTUAL",n}(Go||{}),Op=new C("cdk-focus-monitor-default-options"),Wo=ye({passive:!0,capture:!0}),wn=(()=>{let t=class t{constructor(e,i,r,s,a){this._ngZone=e,this._platform=i,this._inputModalityDetector=r,this._origin=null,this._windowFocused=!1,this._originFromTouchInteraction=!1,this._elementInfo=new Map,this._monitoredElementCount=0,this._rootNodeFocusListenerCount=new Map,this._windowFocusListener=()=>{this._windowFocused=!0,this._windowFocusTimeoutId=window.setTimeout(()=>this._windowFocused=!1)},this._stopInputModalityDetector=new N,this._rootNodeFocusAndBlurListener=l=>{let c=Lt(l);for(let d=c;d;d=d.parentElement)l.type==="focus"?this._onFocus(l,d):this._onBlur(l,d)},this._document=s,this._detectionMode=a?.detectionMode||Go.IMMEDIATE}monitor(e,i=!1){let r=ie(e);if(!this._platform.isBrowser||r.nodeType!==1)return v();let s=nd(r)||this._getDocument(),a=this._elementInfo.get(r);if(a)return i&&(a.checkChildren=!0),a.subject;let l={checkChildren:i,subject:new N,rootNode:s};return this._elementInfo.set(r,l),this._registerGlobalListeners(l),l.subject}stopMonitoring(e){let i=ie(e),r=this._elementInfo.get(i);r&&(r.subject.complete(),this._setClasses(i),this._elementInfo.delete(i),this._removeGlobalListeners(r))}focusVia(e,i,r){let s=ie(e),a=this._getDocument().activeElement;s===a?this._getClosestElementsInfo(s).forEach(([l,c])=>this._originChanged(l,i,c)):(this._setOrigin(i),typeof s.focus=="function"&&s.focus(r))}ngOnDestroy(){this._elementInfo.forEach((e,i)=>this.stopMonitoring(i))}_getDocument(){return this._document||document}_getWindow(){return this._getDocument().defaultView||window}_getFocusOrigin(e){return this._origin?this._originFromTouchInteraction?this._shouldBeAttributedToTouch(e)?"touch":"program":this._origin:this._windowFocused&&this._lastFocusOrigin?this._lastFocusOrigin:e&&this._isLastInteractionFromInputLabel(e)?"mouse":"program"}_shouldBeAttributedToTouch(e){return this._detectionMode===Go.EVENTUAL||!!e?.contains(this._inputModalityDetector._mostRecentTarget)}_setClasses(e,i){e.classList.toggle("cdk-focused",!!i),e.classList.toggle("cdk-touch-focused",i==="touch"),e.classList.toggle("cdk-keyboard-focused",i==="keyboard"),e.classList.toggle("cdk-mouse-focused",i==="mouse"),e.classList.toggle("cdk-program-focused",i==="program")}_setOrigin(e,i=!1){this._ngZone.runOutsideAngular(()=>{if(this._origin=e,this._originFromTouchInteraction=e==="touch"&&i,this._detectionMode===Go.IMMEDIATE){clearTimeout(this._originTimeoutId);let r=this._originFromTouchInteraction?xd:1;this._originTimeoutId=setTimeout(()=>this._origin=null,r)}})}_onFocus(e,i){let r=this._elementInfo.get(i),s=Lt(e);!r||!r.checkChildren&&i!==s||this._originChanged(i,this._getFocusOrigin(s),r)}_onBlur(e,i){let r=this._elementInfo.get(i);!r||r.checkChildren&&e.relatedTarget instanceof Node&&i.contains(e.relatedTarget)||(this._setClasses(i),this._emitOrigin(r,null))}_emitOrigin(e,i){e.subject.observers.length&&this._ngZone.run(()=>e.subject.next(i))}_registerGlobalListeners(e){if(!this._platform.isBrowser)return;let i=e.rootNode,r=this._rootNodeFocusListenerCount.get(i)||0;r||this._ngZone.runOutsideAngular(()=>{i.addEventListener("focus",this._rootNodeFocusAndBlurListener,Wo),i.addEventListener("blur",this._rootNodeFocusAndBlurListener,Wo)}),this._rootNodeFocusListenerCount.set(i,r+1),++this._monitoredElementCount===1&&(this._ngZone.runOutsideAngular(()=>{this._getWindow().addEventListener("focus",this._windowFocusListener)}),this._inputModalityDetector.modalityDetected.pipe(mt(this._stopInputModalityDetector)).subscribe(s=>{this._setOrigin(s,!0)}))}_removeGlobalListeners(e){let i=e.rootNode;if(this._rootNodeFocusListenerCount.has(i)){let r=this._rootNodeFocusListenerCount.get(i);r>1?this._rootNodeFocusListenerCount.set(i,r-1):(i.removeEventListener("focus",this._rootNodeFocusAndBlurListener,Wo),i.removeEventListener("blur",this._rootNodeFocusAndBlurListener,Wo),this._rootNodeFocusListenerCount.delete(i))}--this._monitoredElementCount||(this._getWindow().removeEventListener("focus",this._windowFocusListener),this._stopInputModalityDetector.next(),clearTimeout(this._windowFocusTimeoutId),clearTimeout(this._originTimeoutId))}_originChanged(e,i,r){this._setClasses(e,i),this._emitOrigin(r,i),this._lastFocusOrigin=i}_getClosestElementsInfo(e){let i=[];return this._elementInfo.forEach((r,s)=>{(s===e||r.checkChildren&&s.contains(e))&&i.push([s,r])}),i}_isLastInteractionFromInputLabel(e){let{_mostRecentTarget:i,mostRecentModality:r}=this._inputModalityDetector;if(r!=="mouse"||!i||i===e||e.nodeName!=="INPUT"&&e.nodeName!=="TEXTAREA"||e.disabled)return!1;let s=e.labels;if(s){for(let a=0;a<s.length;a++)if(s[a].contains(i))return!0}return!1}};t.\u0275fac=function(i){return new(i||t)(m(I),m(J),m(Fp),m(T,8),m(Op,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var Ue=function(n){return n[n.NONE=0]="NONE",n[n.BLACK_ON_WHITE=1]="BLACK_ON_WHITE",n[n.WHITE_ON_BLACK=2]="WHITE_ON_BLACK",n}(Ue||{}),_d="cdk-high-contrast-black-on-white",yd="cdk-high-contrast-white-on-black",ia="cdk-high-contrast-active",wd=(()=>{let t=class t{constructor(e,i){this._platform=e,this._document=i,this._breakpointSubscription=g(vd).observe("(forced-colors: active)").subscribe(()=>{this._hasCheckedHighContrastMode&&(this._hasCheckedHighContrastMode=!1,this._applyBodyHighContrastModeCssClasses())})}getHighContrastMode(){if(!this._platform.isBrowser)return Ue.NONE;let e=this._document.createElement("div");e.style.backgroundColor="rgb(1,2,3)",e.style.position="absolute",this._document.body.appendChild(e);let i=this._document.defaultView||window,r=i&&i.getComputedStyle?i.getComputedStyle(e):null,s=(r&&r.backgroundColor||"").replace(/ /g,"");switch(e.remove(),s){case"rgb(0,0,0)":case"rgb(45,50,54)":case"rgb(32,32,32)":return Ue.WHITE_ON_BLACK;case"rgb(255,255,255)":case"rgb(255,250,239)":return Ue.BLACK_ON_WHITE}return Ue.NONE}ngOnDestroy(){this._breakpointSubscription.unsubscribe()}_applyBodyHighContrastModeCssClasses(){if(!this._hasCheckedHighContrastMode&&this._platform.isBrowser&&this._document.body){let e=this._document.body.classList;e.remove(ia,_d,yd),this._hasCheckedHighContrastMode=!0;let i=this.getHighContrastMode();i===Ue.BLACK_ON_WHITE?e.add(ia,_d):i===Ue.WHITE_ON_BLACK&&e.add(ia,yd)}}};t.\u0275fac=function(i){return new(i||t)(m(J),m(T))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function Np(){return!0}var Pp=new C("mat-sanity-checks",{providedIn:"root",factory:Np}),Y=(()=>{let t=class t{constructor(e,i,r){this._sanityChecks=i,this._document=r,this._hasDoneGlobalChecks=!1,e._applyBodyHighContrastModeCssClasses(),this._hasDoneGlobalChecks||(this._hasDoneGlobalChecks=!0)}_checkIsEnabled(e){return gn()?!1:typeof this._sanityChecks=="boolean"?this._sanityChecks:!!this._sanityChecks[e]}};t.\u0275fac=function(i){return new(i||t)(m(wd),m(Pp,8),m(T))},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[_e,_e]});let n=t;return n})();var ua=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,Y]});let n=t;return n})(),Nt=function(n){return n[n.FADING_IN=0]="FADING_IN",n[n.VISIBLE=1]="VISIBLE",n[n.FADING_OUT=2]="FADING_OUT",n[n.HIDDEN=3]="HIDDEN",n}(Nt||{}),la=class{constructor(t,o,e,i=!1){this._renderer=t,this.element=o,this.config=e,this._animationForciblyDisabledThroughCss=i,this.state=Nt.HIDDEN}fadeOut(){this._renderer.fadeOutRipple(this)}},Dd=ye({passive:!0,capture:!0}),ca=class{constructor(){this._events=new Map,this._delegateEventHandler=t=>{let o=Lt(t);o&&this._events.get(t.type)?.forEach((e,i)=>{(i===o||i.contains(o))&&e.forEach(r=>r.handleEvent(t))})}}addHandler(t,o,e,i){let r=this._events.get(o);if(r){let s=r.get(e);s?s.add(i):r.set(e,new Set([i]))}else this._events.set(o,new Map([[e,new Set([i])]])),t.runOutsideAngular(()=>{document.addEventListener(o,this._delegateEventHandler,Dd)})}removeHandler(t,o,e){let i=this._events.get(t);if(!i)return;let r=i.get(o);r&&(r.delete(e),r.size===0&&i.delete(o),i.size===0&&(this._events.delete(t),document.removeEventListener(t,this._delegateEventHandler,Dd)))}},Ed={enterDuration:225,exitDuration:150},Lp=800,Sd=ye({passive:!0,capture:!0}),Id=["mousedown","touchstart"],Rd=["mouseup","mouseleave","touchend","touchcancel"],Cn=class Cn{constructor(t,o,e,i){this._target=t,this._ngZone=o,this._platform=i,this._isPointerDown=!1,this._activeRipples=new Map,this._pointerUpEventsRegistered=!1,i.isBrowser&&(this._containerElement=ie(e))}fadeInRipple(t,o,e={}){let i=this._containerRect=this._containerRect||this._containerElement.getBoundingClientRect(),r=p(p({},Ed),e.animation);e.centered&&(t=i.left+i.width/2,o=i.top+i.height/2);let s=e.radius||jp(t,o,i),a=t-i.left,l=o-i.top,c=r.enterDuration,d=document.createElement("div");d.classList.add("mat-ripple-element"),d.style.left=`${a-s}px`,d.style.top=`${l-s}px`,d.style.height=`${s*2}px`,d.style.width=`${s*2}px`,e.color!=null&&(d.style.backgroundColor=e.color),d.style.transitionDuration=`${c}ms`,this._containerElement.appendChild(d);let h=window.getComputedStyle(d),f=h.transitionProperty,w=h.transitionDuration,j=f==="none"||w==="0s"||w==="0s, 0s"||i.width===0&&i.height===0,z=new la(this,d,e,j);d.style.transform="scale3d(1, 1, 1)",z.state=Nt.FADING_IN,e.persistent||(this._mostRecentTransientRipple=z);let k=null;return!j&&(c||r.exitDuration)&&this._ngZone.runOutsideAngular(()=>{let V=()=>this._finishRippleTransition(z),Pt=()=>this._destroyRipple(z);d.addEventListener("transitionend",V),d.addEventListener("transitioncancel",Pt),k={onTransitionEnd:V,onTransitionCancel:Pt}}),this._activeRipples.set(z,k),(j||!c)&&this._finishRippleTransition(z),z}fadeOutRipple(t){if(t.state===Nt.FADING_OUT||t.state===Nt.HIDDEN)return;let o=t.element,e=p(p({},Ed),t.config.animation);o.style.transitionDuration=`${e.exitDuration}ms`,o.style.opacity="0",t.state=Nt.FADING_OUT,(t._animationForciblyDisabledThroughCss||!e.exitDuration)&&this._finishRippleTransition(t)}fadeOutAll(){this._getActiveRipples().forEach(t=>t.fadeOut())}fadeOutAllNonPersistent(){this._getActiveRipples().forEach(t=>{t.config.persistent||t.fadeOut()})}setupTriggerEvents(t){let o=ie(t);!this._platform.isBrowser||!o||o===this._triggerElement||(this._removeTriggerEvents(),this._triggerElement=o,Id.forEach(e=>{Cn._eventManager.addHandler(this._ngZone,e,o,this)}))}handleEvent(t){t.type==="mousedown"?this._onMousedown(t):t.type==="touchstart"?this._onTouchStart(t):this._onPointerUp(),this._pointerUpEventsRegistered||(this._ngZone.runOutsideAngular(()=>{Rd.forEach(o=>{this._triggerElement.addEventListener(o,this,Sd)})}),this._pointerUpEventsRegistered=!0)}_finishRippleTransition(t){t.state===Nt.FADING_IN?this._startFadeOutTransition(t):t.state===Nt.FADING_OUT&&this._destroyRipple(t)}_startFadeOutTransition(t){let o=t===this._mostRecentTransientRipple,{persistent:e}=t.config;t.state=Nt.VISIBLE,!e&&(!o||!this._isPointerDown)&&t.fadeOut()}_destroyRipple(t){let o=this._activeRipples.get(t)??null;this._activeRipples.delete(t),this._activeRipples.size||(this._containerRect=null),t===this._mostRecentTransientRipple&&(this._mostRecentTransientRipple=null),t.state=Nt.HIDDEN,o!==null&&(t.element.removeEventListener("transitionend",o.onTransitionEnd),t.element.removeEventListener("transitioncancel",o.onTransitionCancel)),t.element.remove()}_onMousedown(t){let o=yn(t),e=this._lastTouchStartEvent&&Date.now()<this._lastTouchStartEvent+Lp;!this._target.rippleDisabled&&!o&&!e&&(this._isPointerDown=!0,this.fadeInRipple(t.clientX,t.clientY,this._target.rippleConfig))}_onTouchStart(t){if(!this._target.rippleDisabled&&!xn(t)){this._lastTouchStartEvent=Date.now(),this._isPointerDown=!0;let o=t.changedTouches;if(o)for(let e=0;e<o.length;e++)this.fadeInRipple(o[e].clientX,o[e].clientY,this._target.rippleConfig)}}_onPointerUp(){this._isPointerDown&&(this._isPointerDown=!1,this._getActiveRipples().forEach(t=>{let o=t.state===Nt.VISIBLE||t.config.terminateOnPointerUp&&t.state===Nt.FADING_IN;!t.config.persistent&&o&&t.fadeOut()}))}_getActiveRipples(){return Array.from(this._activeRipples.keys())}_removeTriggerEvents(){let t=this._triggerElement;t&&(Id.forEach(o=>Cn._eventManager.removeHandler(o,t,this)),this._pointerUpEventsRegistered&&(Rd.forEach(o=>t.removeEventListener(o,this,Sd)),this._pointerUpEventsRegistered=!1))}};Cn._eventManager=new ca;var da=Cn;function jp(n,t,o){let e=Math.max(Math.abs(n-o.left),Math.abs(n-o.right)),i=Math.max(Math.abs(t-o.top),Math.abs(t-o.bottom));return Math.sqrt(e*e+i*i)}var Fd=new C("mat-ripple-global-options"),ha=(()=>{let t=class t{get disabled(){return this._disabled}set disabled(e){e&&this.fadeOutAllNonPersistent(),this._disabled=e,this._setupTriggerEventsIfEnabled()}get trigger(){return this._trigger||this._elementRef.nativeElement}set trigger(e){this._trigger=e,this._setupTriggerEventsIfEnabled()}constructor(e,i,r,s,a){this._elementRef=e,this._animationMode=a,this.radius=0,this._disabled=!1,this._isInitialized=!1,this._globalOptions=s||{},this._rippleRenderer=new da(this,i,e,r)}ngOnInit(){this._isInitialized=!0,this._setupTriggerEventsIfEnabled()}ngOnDestroy(){this._rippleRenderer._removeTriggerEvents()}fadeOutAll(){this._rippleRenderer.fadeOutAll()}fadeOutAllNonPersistent(){this._rippleRenderer.fadeOutAllNonPersistent()}get rippleConfig(){return{centered:this.centered,radius:this.radius,color:this.color,animation:p(p(p({},this._globalOptions.animation),this._animationMode==="NoopAnimations"?{enterDuration:0,exitDuration:0}:{}),this.animation),terminateOnPointerUp:this._globalOptions.terminateOnPointerUp}}get rippleDisabled(){return this.disabled||!!this._globalOptions.disabled}_setupTriggerEventsIfEnabled(){!this.disabled&&this._isInitialized&&this._rippleRenderer.setupTriggerEvents(this.trigger)}launch(e,i=0,r){return typeof e=="number"?this._rippleRenderer.fadeInRipple(e,i,p(p({},this.rippleConfig),r)):this._rippleRenderer.fadeInRipple(0,0,p(p({},this.rippleConfig),e))}};t.\u0275fac=function(i){return new(i||t)(u(A),u(I),u(J),u(Fd,8),u(Bt,8))},t.\u0275dir=D({type:t,selectors:[["","mat-ripple",""],["","matRipple",""]],hostAttrs:[1,"mat-ripple"],hostVars:2,hostBindings:function(i,r){i&2&&st("mat-ripple-unbounded",r.unbounded)},inputs:{color:[y.None,"matRippleColor","color"],unbounded:[y.None,"matRippleUnbounded","unbounded"],centered:[y.None,"matRippleCentered","centered"],radius:[y.None,"matRippleRadius","radius"],animation:[y.None,"matRippleAnimation","animation"],disabled:[y.None,"matRippleDisabled","disabled"],trigger:[y.None,"matRippleTrigger","trigger"]},exportAs:["matRipple"],standalone:!0});let n=t;return n})(),Ko=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,Y]});let n=t;return n})();var Md={capture:!0},kd=["focus","click","mouseenter","touchstart"],sa="mat-ripple-loader-uninitialized",aa="mat-ripple-loader-class-name",Td="mat-ripple-loader-centered",Xo="mat-ripple-loader-disabled",Od=(()=>{let t=class t{constructor(){this._document=g(T,{optional:!0}),this._animationMode=g(Bt,{optional:!0}),this._globalRippleOptions=g(Fd,{optional:!0}),this._platform=g(J),this._ngZone=g(I),this._hosts=new Map,this._onInteraction=e=>{if(!(e.target instanceof HTMLElement))return;let r=e.target.closest(`[${sa}]`);r&&this._createRipple(r)},this._ngZone.runOutsideAngular(()=>{for(let e of kd)this._document?.addEventListener(e,this._onInteraction,Md)})}ngOnDestroy(){let e=this._hosts.keys();for(let i of e)this.destroyRipple(i);for(let i of kd)this._document?.removeEventListener(i,this._onInteraction,Md)}configureRipple(e,i){e.setAttribute(sa,""),(i.className||!e.hasAttribute(aa))&&e.setAttribute(aa,i.className||""),i.centered&&e.setAttribute(Td,""),i.disabled&&e.setAttribute(Xo,"")}getRipple(e){return this._hosts.get(e)||this._createRipple(e)}setDisabled(e,i){let r=this._hosts.get(e);if(r){r.disabled=i;return}i?e.setAttribute(Xo,""):e.removeAttribute(Xo)}_createRipple(e){if(!this._document)return;let i=this._hosts.get(e);if(i)return i;e.querySelector(".mat-ripple")?.remove();let r=this._document.createElement("span");r.classList.add("mat-ripple",e.getAttribute(aa)),e.append(r);let s=new ha(new A(r),this._ngZone,this._platform,this._globalRippleOptions?this._globalRippleOptions:void 0,this._animationMode?this._animationMode:void 0);return s._isInitialized=!0,s.trigger=e,s.centered=e.hasAttribute(Td),s.disabled=e.hasAttribute(Xo),this.attachRipple(e,s),s}attachRipple(e,i){e.removeAttribute(sa),this._hosts.set(e,i)}destroyRipple(e){let i=this._hosts.get(e);i&&(i.ngOnDestroy(),this._hosts.delete(e))}};t.\u0275fac=function(i){return new(i||t)},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var Vp=[[["caption"]],[["colgroup"],["col"]],"*"],zp=["caption","colgroup, col","*"];function Bp(n,t){n&1&&K(0,2)}function Up(n,t){n&1&&(x(0,"thead",0),It(1,1),_(),x(2,"tbody",2),It(3,3)(4,4),_(),x(5,"tfoot",0),It(6,5),_())}function Hp(n,t){n&1&&It(0,1)(1,3)(2,4)(3,5)}var Nd=(()=>{let t=class t extends ea{constructor(){super(...arguments),this.stickyCssClass="mat-mdc-table-sticky",this.needsPositionStickyOnElement=!1}};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275cmp=P({type:t,selectors:[["mat-table"],["table","mat-table",""]],hostAttrs:[1,"mat-mdc-table","mdc-data-table__table"],hostVars:2,hostBindings:function(i,r){i&2&&st("mdc-table-fixed-layout",r.fixedLayout)},exportAs:["matTable"],standalone:!0,features:[Q([{provide:ea,useExisting:t},{provide:jt,useExisting:t},{provide:Vo,useClass:Gs},{provide:fn,useClass:vi},{provide:zo,useValue:null}]),U,tt],ngContentSelectors:zp,decls:5,vars:2,consts:[["role","rowgroup"],["headerRowOutlet",""],["role","rowgroup",1,"mdc-data-table__content"],["rowOutlet",""],["noDataRowOutlet",""],["footerRowOutlet",""]],template:function(i,r){i&1&&(pt(Vp),K(0),K(1,1),ot(2,Bp,1,0)(3,Up,7,0)(4,Hp,4,0)),i&2&&(R(2),Ut(2,r._isServer?2:-1),R(),Ut(3,r._isNativeHtmlTable?3:4))},dependencies:[Qs,Ks,ta,Js],styles:[".mat-mdc-table-sticky{position:sticky !important}.mdc-data-table{-webkit-overflow-scrolling:touch;display:inline-flex;flex-direction:column;box-sizing:border-box;position:relative}.mdc-data-table__table-container{-webkit-overflow-scrolling:touch;overflow-x:auto;width:100%}.mdc-data-table__table{min-width:100%;border:0;white-space:nowrap;border-spacing:0;table-layout:fixed}.mdc-data-table__cell{box-sizing:border-box;overflow:hidden;text-align:left;text-overflow:ellipsis}[dir=rtl] .mdc-data-table__cell,.mdc-data-table__cell[dir=rtl]{text-align:right}.mdc-data-table__cell--numeric{text-align:right}[dir=rtl] .mdc-data-table__cell--numeric,.mdc-data-table__cell--numeric[dir=rtl]{text-align:left}.mdc-data-table__header-cell{box-sizing:border-box;text-overflow:ellipsis;overflow:hidden;outline:none;text-align:left}[dir=rtl] .mdc-data-table__header-cell,.mdc-data-table__header-cell[dir=rtl]{text-align:right}.mdc-data-table__header-cell--numeric{text-align:right}[dir=rtl] .mdc-data-table__header-cell--numeric,.mdc-data-table__header-cell--numeric[dir=rtl]{text-align:left}.mdc-data-table__header-cell-wrapper{align-items:center;display:inline-flex;vertical-align:middle}.mdc-data-table__cell,.mdc-data-table__header-cell{padding:0 16px 0 16px}.mdc-data-table__header-cell--checkbox,.mdc-data-table__cell--checkbox{padding-left:4px;padding-right:0}[dir=rtl] .mdc-data-table__header-cell--checkbox,[dir=rtl] .mdc-data-table__cell--checkbox,.mdc-data-table__header-cell--checkbox[dir=rtl],.mdc-data-table__cell--checkbox[dir=rtl]{padding-left:0;padding-right:4px}mat-table{display:block}mat-header-row{min-height:56px}mat-row,mat-footer-row{min-height:48px}mat-row,mat-header-row,mat-footer-row{display:flex;border-width:0;border-bottom-width:1px;border-style:solid;align-items:center;box-sizing:border-box}mat-cell:first-of-type,mat-header-cell:first-of-type,mat-footer-cell:first-of-type{padding-left:24px}[dir=rtl] mat-cell:first-of-type:not(:only-of-type),[dir=rtl] mat-header-cell:first-of-type:not(:only-of-type),[dir=rtl] mat-footer-cell:first-of-type:not(:only-of-type){padding-left:0;padding-right:24px}mat-cell:last-of-type,mat-header-cell:last-of-type,mat-footer-cell:last-of-type{padding-right:24px}[dir=rtl] mat-cell:last-of-type:not(:only-of-type),[dir=rtl] mat-header-cell:last-of-type:not(:only-of-type),[dir=rtl] mat-footer-cell:last-of-type:not(:only-of-type){padding-right:0;padding-left:24px}mat-cell,mat-header-cell,mat-footer-cell{flex:1;display:flex;align-items:center;overflow:hidden;word-wrap:break-word;min-height:inherit}.mat-mdc-table{table-layout:auto;white-space:normal;background-color:var(--mat-table-background-color)}.mat-mdc-header-row{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;height:var(--mat-table-header-container-height, 56px);color:var(--mat-table-header-headline-color, rgba(0, 0, 0, 0.87));font-family:var(--mat-table-header-headline-font, Roboto, sans-serif);line-height:var(--mat-table-header-headline-line-height);font-size:var(--mat-table-header-headline-size, 14px);font-weight:var(--mat-table-header-headline-weight, 500)}.mat-mdc-row{height:var(--mat-table-row-item-container-height, 52px);color:var(--mat-table-row-item-label-text-color, rgba(0, 0, 0, 0.87))}.mat-mdc-row,.mdc-data-table__content{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:var(--mat-table-row-item-label-text-font, Roboto, sans-serif);line-height:var(--mat-table-row-item-label-text-line-height);font-size:var(--mat-table-row-item-label-text-size, 14px);font-weight:var(--mat-table-row-item-label-text-weight)}.mat-mdc-footer-row{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;height:var(--mat-table-footer-container-height, 52px);color:var(--mat-table-row-item-label-text-color, rgba(0, 0, 0, 0.87));font-family:var(--mat-table-footer-supporting-text-font, Roboto, sans-serif);line-height:var(--mat-table-footer-supporting-text-line-height);font-size:var(--mat-table-footer-supporting-text-size, 14px);font-weight:var(--mat-table-footer-supporting-text-weight);letter-spacing:var(--mat-table-footer-supporting-text-tracking)}.mat-mdc-header-cell{border-bottom-color:var(--mat-table-row-item-outline-color, rgba(0, 0, 0, 0.12));border-bottom-width:var(--mat-table-row-item-outline-width, 1px);border-bottom-style:solid;letter-spacing:var(--mat-table-header-headline-tracking);font-weight:inherit;line-height:inherit}.mat-mdc-cell{border-bottom-color:var(--mat-table-row-item-outline-color, rgba(0, 0, 0, 0.12));border-bottom-width:var(--mat-table-row-item-outline-width, 1px);border-bottom-style:solid;letter-spacing:var(--mat-table-row-item-label-text-tracking);line-height:inherit}.mdc-data-table__row:last-child .mat-mdc-cell{border-bottom:none}.mat-mdc-footer-cell{letter-spacing:var(--mat-table-row-item-label-text-tracking)}mat-row.mat-mdc-row,mat-header-row.mat-mdc-header-row,mat-footer-row.mat-mdc-footer-row{border-bottom:none}.mat-mdc-table tbody,.mat-mdc-table tfoot,.mat-mdc-table thead,.mat-mdc-cell,.mat-mdc-footer-cell,.mat-mdc-header-row,.mat-mdc-row,.mat-mdc-footer-row,.mat-mdc-table .mat-mdc-header-cell{background:inherit}.mat-mdc-table mat-header-row.mat-mdc-header-row,.mat-mdc-table mat-row.mat-mdc-row,.mat-mdc-table mat-footer-row.mat-mdc-footer-cell{height:unset}mat-header-cell.mat-mdc-header-cell,mat-cell.mat-mdc-cell,mat-footer-cell.mat-mdc-footer-cell{align-self:stretch}"],encapsulation:2});let n=t;return n})(),Pd=(()=>{let t=class t extends Bo{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,selectors:[["","matCellDef",""]],standalone:!0,features:[Q([{provide:Bo,useExisting:t}]),U]});let n=t;return n})(),Ld=(()=>{let t=class t extends Uo{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,selectors:[["","matHeaderCellDef",""]],standalone:!0,features:[Q([{provide:Uo,useExisting:t}]),U]});let n=t;return n})();var jd=(()=>{let t=class t extends yi{get name(){return this._name}set name(e){this._setNameInput(e)}_updateColumnCssClassName(){super._updateColumnCssClassName(),this._columnCssClassName.push(`mat-column-${this.cssClassFriendlyName}`)}};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,selectors:[["","matColumnDef",""]],inputs:{name:[y.None,"matColumnDef","name"]},standalone:!0,features:[Q([{provide:yi,useExisting:t},{provide:"MAT_SORT_HEADER_COLUMN_DEF",useExisting:t}]),U]});let n=t;return n})(),Vd=(()=>{let t=class t extends ud{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,selectors:[["mat-header-cell"],["th","mat-header-cell",""]],hostAttrs:["role","columnheader",1,"mat-mdc-header-cell","mdc-data-table__header-cell"],standalone:!0,features:[U]});let n=t;return n})();var zd=(()=>{let t=class t extends hd{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,selectors:[["mat-cell"],["td","mat-cell",""]],hostAttrs:[1,"mat-mdc-cell","mdc-data-table__cell"],standalone:!0,features:[U]});let n=t;return n})();var Bd=(()=>{let t=class t extends _n{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,selectors:[["","matHeaderRowDef",""]],inputs:{columns:[y.None,"matHeaderRowDef","columns"],sticky:[y.HasDecoratorInputTransform,"matHeaderRowDefSticky","sticky",W]},standalone:!0,features:[Q([{provide:_n,useExisting:t}]),nt,U]});let n=t;return n})();var Ud=(()=>{let t=class t extends Ho{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275dir=D({type:t,selectors:[["","matRowDef",""]],inputs:{columns:[y.None,"matRowDefColumns","columns"],when:[y.None,"matRowDefWhen","when"]},standalone:!0,features:[Q([{provide:Ho,useExisting:t}]),U]});let n=t;return n})(),Hd=(()=>{let t=class t extends Zs{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275cmp=P({type:t,selectors:[["mat-header-row"],["tr","mat-header-row",""]],hostAttrs:["role","row",1,"mat-mdc-header-row","mdc-data-table__header-row"],exportAs:["matHeaderRow"],standalone:!0,features:[Q([{provide:Zs,useExisting:t}]),U,tt],decls:1,vars:0,consts:[["cdkCellOutlet",""]],template:function(i,r){i&1&&It(0,0)},dependencies:[ze],encapsulation:2});let n=t;return n})();var $d=(()=>{let t=class t extends Xs{};t.\u0275fac=(()=>{let e;return function(r){return(e||(e=_t(t)))(r||t)}})(),t.\u0275cmp=P({type:t,selectors:[["mat-row"],["tr","mat-row",""]],hostAttrs:["role","row",1,"mat-mdc-row","mdc-data-table__row"],exportAs:["matRow"],standalone:!0,features:[Q([{provide:Xs,useExisting:t}]),U,tt],decls:1,vars:0,consts:[["cdkCellOutlet",""]],template:function(i,r){i&1&&It(0,0)},dependencies:[ze],encapsulation:2});let n=t;return n})();var Wd=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,fd,Y]});let n=t;return n})(),$p=9007199254740991,wi=class extends Fo{get data(){return this._data.value}set data(t){t=Array.isArray(t)?t:[],this._data.next(t),this._renderChangesSubscription||this._filterData(t)}get filter(){return this._filter.value}set filter(t){this._filter.next(t),this._renderChangesSubscription||this._filterData(this.data)}get sort(){return this._sort}set sort(t){this._sort=t,this._updateChangeSubscription()}get paginator(){return this._paginator}set paginator(t){this._paginator=t,this._updateChangeSubscription()}constructor(t=[]){super(),this._renderData=new rt([]),this._filter=new rt(""),this._internalPageChanges=new N,this._renderChangesSubscription=null,this.sortingDataAccessor=(o,e)=>{let i=o[e];if(od(i)){let r=Number(i);return r<$p?r:i}return i},this.sortData=(o,e)=>{let i=e.active,r=e.direction;return!i||r==""?o:o.sort((s,a)=>{let l=this.sortingDataAccessor(s,i),c=this.sortingDataAccessor(a,i),d=typeof l,h=typeof c;d!==h&&(d==="number"&&(l+=""),h==="number"&&(c+=""));let f=0;return l!=null&&c!=null?l>c?f=1:l<c&&(f=-1):l!=null?f=1:c!=null&&(f=-1),f*(r=="asc"?1:-1)})},this.filterPredicate=(o,e)=>{let i=Object.keys(o).reduce((s,a)=>s+o[a]+"\u25EC","").toLowerCase(),r=e.trim().toLowerCase();return i.indexOf(r)!=-1},this._data=new rt(t),this._updateChangeSubscription()}_updateChangeSubscription(){let t=this._sort?qt(this._sort.sortChange,this._sort.initialized):v(null),o=this._paginator?qt(this._paginator.page,this._internalPageChanges,this._paginator.initialized):v(null),e=this._data,i=Vt([e,this._filter]).pipe(M(([a])=>this._filterData(a))),r=Vt([i,t]).pipe(M(([a])=>this._orderData(a))),s=Vt([r,o]).pipe(M(([a])=>this._pageData(a)));this._renderChangesSubscription?.unsubscribe(),this._renderChangesSubscription=s.subscribe(a=>this._renderData.next(a))}_filterData(t){return this.filteredData=this.filter==null||this.filter===""?t:t.filter(o=>this.filterPredicate(o,this.filter)),this.paginator&&this._updatePaginator(this.filteredData.length),this.filteredData}_orderData(t){return this.sort?this.sortData(t.slice(),this.sort):t}_pageData(t){if(!this.paginator)return t;let o=this.paginator.pageIndex*this.paginator.pageSize;return t.slice(o,o+this.paginator.pageSize)}_updatePaginator(t){Promise.resolve().then(()=>{let o=this.paginator;if(o&&(o.length=t,o.pageIndex>0)){let e=Math.ceil(o.length/o.pageSize)-1||0,i=Math.min(o.pageIndex,e);i!==o.pageIndex&&(o.pageIndex=i,this._internalPageChanges.next())}})}connect(){return this._renderChangesSubscription||this._updateChangeSubscription(),this._renderData}disconnect(){this._renderChangesSubscription?.unsubscribe(),this._renderChangesSubscription=null}};var Gp=n=>["/Product-Stores",n];function Yp(n,t){if(n&1){let o=Ft();x(0,"tr")(1,"td"),H(2,"img",9),_(),x(3,"td")(4,"a",10),F(5),_()(),x(6,"td")(7,"button",11),Z("click",function(){let i=xt(o).$implicit,r=X(2);return wt(r.deleteOneProductFromSFL(i.productID))}),F(8,"Remove"),_()()()}if(n&2){let o=t.$implicit;R(2),Ze("alt",o.productName),L("src",o.productImage,Se),R(2),L("routerLink",Ni(4,Gp,o.productID)),R(),te(o.productName)}}function qp(n,t){if(n&1){let o=Ft();de(0),x(1,"div",3),H(2,"div"),x(3,"button",4),Z("click",function(){xt(o);let i=X();return wt(i.deleteAllProductsFromSFL())}),F(4,"Clear All"),_()(),x(5,"table",5)(6,"thead",6)(7,"tr")(8,"th",7),F(9,"Image"),_(),x(10,"th",7),F(11,"Product Name"),_(),x(12,"th",7),F(13,"Actions"),_()()(),x(14,"tbody"),ot(15,Yp,9,6,"tr",8),_()(),ue()}if(n&2){let o=X();R(15),L("ngForOf",o.tableDataProductNames.data)}}function Zp(n,t){n&1&&(x(0,"div",12),F(1,"No products saved for later."),_())}var Gd=(()=>{let t=class t{constructor(e){this.productService=e,this.product=null,this.tableDataProductNames=new wi}ngOnInit(){this.getFromSavedForLater()}getFromSavedForLater(){this.productService.getSaveForLater().subscribe(e=>{e&&e.saveForLater&&(this.product=e,this.tableDataProductNames.data=e.saveForLater)})}deleteOneProductFromSFL(e){this.product&&this.productService.deleteSflProduct(e).subscribe(()=>{this.product.saveForLater=this.product.saveForLater.filter(i=>i.productID!==e),this.tableDataProductNames.data=this.product.saveForLater})}deleteAllProductsFromSFL(){this.product&&this.productService.deleteAllSflProducts().subscribe(()=>{this.product.saveForLater=[],this.tableDataProductNames.data=[]})}};t.\u0275fac=function(i){return new(i||t)(u(fe))},t.\u0275cmp=P({type:t,selectors:[["app-save-for-later"]],decls:4,vars:2,consts:[["noData",""],[1,"container","mt-5"],[4,"ngIf","ngIfElse"],[1,"d-flex","justify-content-between","mb-3"],[1,"btn","btn-warning",3,"click"],[1,"table","table-bordered","table-hover"],[1,"thead-light"],["scope","col"],[4,"ngFor","ngForOf"],[1,"img-thumbnail",2,"width","100px",3,"src","alt"],[3,"routerLink"],[1,"btn","btn-danger","btn-sm",3,"click"],["id","noDataMessage",1,"alert","alert-info"]],template:function(i,r){if(i&1&&(x(0,"div",1),ot(1,qp,16,1,"ng-container",2)(2,Zp,2,0,"ng-template",null,0,Ke),_()),i&2){let s=he(3);R(),L("ngIf",r.tableDataProductNames.data&&r.tableDataProductNames.data.length>0)("ngIfElse",s)}},dependencies:[Qe,Ht,ui],styles:[".save-for-later[_ngcontent-%COMP%]{margin-top:20px;padding:20px;border:1px solid #ccc;border-radius:5px;background-color:#f9f9f9}#noDataMessage[_ngcontent-%COMP%]{text-align:center;margin:auto;width:fit-content}"]});let n=t;return n})();var Qo=(()=>{let t=class t{constructor(e,i){this.http=e,this.router=i,this.authUrl="https://pricepinion.azurewebsites.net/",this.userSubject=new rt(null),this.user=this.userSubject.asObservable(),this.fetchUserData()}login(){window.location.href=`${this.authUrl}auth/google`,console.log("Logged in",this.user)}logout(){localStorage.removeItem("user"),this.http.get(`${this.authUrl}auth/logout`,{withCredentials:!0}).subscribe(()=>{console.log("Logged out"),this.userSubject.next(null)})}setUser(e){localStorage.setItem("user",JSON.stringify(e)),this.userSubject.next(e)}getUser(){return this.userSubject.value}isLoggedIn(){return!!this.userSubject.value}fetchUserData(){this.http.get(`${this.authUrl}auth/user`,{withCredentials:!0}).subscribe(e=>{this.setUser(e)},e=>{console.error("Failed to fetch user data",e),this.userSubject.next(null)})}};t.\u0275fac=function(i){return new(i||t)(m(Oe),m(Yt))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function Xp(n,t){n&1&&(x(0,"div")(1,"label",11),F(2,"Password"),_(),H(3,"input",12),_())}var qd=(()=>{let t=class t{constructor(e,i){this.authService=e,this.fb=i,this.isGoogleUser=!1,this.customerForm=this.fb.group({name:[{value:"",disabled:!0},[]],email:[{value:"",disabled:!0},[]],password:[""]}),this.statusText=this.fb.group({text:[""]})}ngOnInit(){this.authService.user.subscribe(e=>{this.user=e,this.isGoogleUser=!!e?.googleId,console.log("user data:",this.user),e&&this.customerForm.patchValue({name:e.displayName,email:e.customerEmail})}),this.authService.fetchUserData()}onSubmit(){this.customerForm.valid&&this.isGoogleUser}logout(){this.authService.logout()}};t.\u0275fac=function(i){return new(i||t)(u(Qo),u(Xc))},t.\u0275cmp=P({type:t,selectors:[["app-account"]],decls:20,vars:4,consts:[[1,"title"],[1,"customer-form-container",3,"ngSubmit","formGroup"],["for","name",1,"labels"],["id","name","type","text","formControlName","name",1,"input-fields"],["for","email",1,"labels"],["id","email","type","email","formControlName","email",1,"input-fields"],[4,"ngIf"],["type","submit",1,"button",3,"disabled"],[3,"formGroup"],["id","text","type","text","formControlName","text",1,"status-text"],[1,"button",3,"click"],["for","password",1,"labels"],["id","password","type","password","formControlName","password",1,"input-fields"]],template:function(i,r){i&1&&(x(0,"h3",0),F(1,"Account Information"),_(),x(2,"form",1),Z("ngSubmit",function(){return r.onSubmit()}),x(3,"div")(4,"label",2),F(5,"Name"),_(),H(6,"input",3),_(),x(7,"div")(8,"label",4),F(9,"Email"),_(),H(10,"input",5),_(),ot(11,Xp,4,0,"div",6),x(12,"button",7),F(13,"Save Changes"),_()(),x(14,"form",8)(15,"div"),H(16,"input",9),_()(),x(17,"div")(18,"button",10),Z("click",function(){return r.logout()}),F(19,"Logout"),_()()),i&2&&(R(2),L("formGroup",r.customerForm),R(9),L("ngIf",!r.isGoogleUser),R(),L("disabled",r.isGoogleUser),R(2),L("formGroup",r.statusText))},dependencies:[Ht,Yc,pi,Mo,zc,zs,Bs],styles:[".title[_ngcontent-%COMP%]{margin-top:35px;margin-left:30px;font-size:24px;margin-bottom:35px}.customer-form-container[_ngcontent-%COMP%]{margin-left:80px;margin-right:80px;background-color:#f9f9f9;border:3px solid #ddd;padding:30px;border-radius:10px;margin-bottom:20px}.labels[_ngcontent-%COMP%]{display:block;margin-bottom:10px;font-size:18px}.input-fields[_ngcontent-%COMP%]{width:100%;padding:15px;border:1px solid #ccc;border-radius:4px;box-sizing:border-box;font-size:15px;margin-bottom:20px}.button[_ngcontent-%COMP%]{font-weight:100;margin-top:30px;font-size:18px;background-color:#4848e8;color:#fff;padding:15px 25px;border-radius:5px;cursor:pointer}.status-text[_ngcontent-%COMP%]{width:50%;padding:15px;font-size:16px;border:none;color:#15980c;margin-left:80px}"]});let n=t;return n})();var Kp=["*"],Jo;function Qp(){if(Jo===void 0&&(Jo=null,typeof window<"u")){let n=window;n.trustedTypes!==void 0&&(Jo=n.trustedTypes.createPolicy("angular#components",{createHTML:t=>t}))}return Jo}function Dn(n){return Qp()?.createHTML(n)||n}function Zd(n){return Error(`Unable to find icon with the name "${n}"`)}function Jp(){return Error("Could not find HttpClient provider for use with Angular Material icons. Please include the HttpClientModule from @angular/common/http in your app imports.")}function Xd(n){return Error(`The URL provided to MatIconRegistry was not trusted as a resource URL via Angular's DomSanitizer. Attempted URL was "${n}".`)}function Kd(n){return Error(`The literal provided to MatIconRegistry was not trusted as safe HTML by Angular's DomSanitizer. Attempted literal was "${n}".`)}var ne=class{constructor(t,o,e){this.url=t,this.svgText=o,this.options=e}},tg=(()=>{let t=class t{constructor(e,i,r,s){this._httpClient=e,this._sanitizer=i,this._errorHandler=s,this._svgIconConfigs=new Map,this._iconSetConfigs=new Map,this._cachedIconsByUrl=new Map,this._inProgressUrlFetches=new Map,this._fontCssClassesByAlias=new Map,this._resolvers=[],this._defaultFontSetClass=["material-icons","mat-ligature-font"],this._document=r}addSvgIcon(e,i,r){return this.addSvgIconInNamespace("",e,i,r)}addSvgIconLiteral(e,i,r){return this.addSvgIconLiteralInNamespace("",e,i,r)}addSvgIconInNamespace(e,i,r,s){return this._addSvgIconConfig(e,i,new ne(r,null,s))}addSvgIconResolver(e){return this._resolvers.push(e),this}addSvgIconLiteralInNamespace(e,i,r,s){let a=this._sanitizer.sanitize(Mt.HTML,r);if(!a)throw Kd(r);let l=Dn(a);return this._addSvgIconConfig(e,i,new ne("",l,s))}addSvgIconSet(e,i){return this.addSvgIconSetInNamespace("",e,i)}addSvgIconSetLiteral(e,i){return this.addSvgIconSetLiteralInNamespace("",e,i)}addSvgIconSetInNamespace(e,i,r){return this._addSvgIconSetConfig(e,new ne(i,null,r))}addSvgIconSetLiteralInNamespace(e,i,r){let s=this._sanitizer.sanitize(Mt.HTML,i);if(!s)throw Kd(i);let a=Dn(s);return this._addSvgIconSetConfig(e,new ne("",a,r))}registerFontClassAlias(e,i=e){return this._fontCssClassesByAlias.set(e,i),this}classNameForFontAlias(e){return this._fontCssClassesByAlias.get(e)||e}setDefaultFontSetClass(...e){return this._defaultFontSetClass=e,this}getDefaultFontSetClass(){return this._defaultFontSetClass}getSvgIconFromUrl(e){let i=this._sanitizer.sanitize(Mt.RESOURCE_URL,e);if(!i)throw Xd(e);let r=this._cachedIconsByUrl.get(i);return r?v(tr(r)):this._loadSvgIconFromConfig(new ne(e,null)).pipe(et(s=>this._cachedIconsByUrl.set(i,s)),M(s=>tr(s)))}getNamedSvgIcon(e,i=""){let r=Qd(i,e),s=this._svgIconConfigs.get(r);if(s)return this._getSvgFromConfig(s);if(s=this._getIconConfigFromResolvers(i,e),s)return this._svgIconConfigs.set(r,s),this._getSvgFromConfig(s);let a=this._iconSetConfigs.get(i);return a?this._getSvgFromIconSetConfigs(e,a):Ce(Zd(r))}ngOnDestroy(){this._resolvers=[],this._svgIconConfigs.clear(),this._iconSetConfigs.clear(),this._cachedIconsByUrl.clear()}_getSvgFromConfig(e){return e.svgText?v(tr(this._svgElementFromConfig(e))):this._loadSvgIconFromConfig(e).pipe(M(i=>tr(i)))}_getSvgFromIconSetConfigs(e,i){let r=this._extractIconWithNameFromAnySet(e,i);if(r)return v(r);let s=i.filter(a=>!a.svgText).map(a=>this._loadSvgIconSetFromConfig(a).pipe(re(l=>{let d=`Loading icon set URL: ${this._sanitizer.sanitize(Mt.RESOURCE_URL,a.url)} failed: ${l.message}`;return this._errorHandler.handleError(new Error(d)),v(null)})));return Tn(s).pipe(M(()=>{let a=this._extractIconWithNameFromAnySet(e,i);if(!a)throw Zd(e);return a}))}_extractIconWithNameFromAnySet(e,i){for(let r=i.length-1;r>=0;r--){let s=i[r];if(s.svgText&&s.svgText.toString().indexOf(e)>-1){let a=this._svgElementFromConfig(s),l=this._extractSvgIconFromSet(a,e,s.options);if(l)return l}}return null}_loadSvgIconFromConfig(e){return this._fetchIcon(e).pipe(et(i=>e.svgText=i),M(()=>this._svgElementFromConfig(e)))}_loadSvgIconSetFromConfig(e){return e.svgText?v(null):this._fetchIcon(e).pipe(et(i=>e.svgText=i))}_extractSvgIconFromSet(e,i,r){let s=e.querySelector(`[id="${i}"]`);if(!s)return null;let a=s.cloneNode(!0);if(a.removeAttribute("id"),a.nodeName.toLowerCase()==="svg")return this._setSvgAttributes(a,r);if(a.nodeName.toLowerCase()==="symbol")return this._setSvgAttributes(this._toSvgElement(a),r);let l=this._svgElementFromString(Dn("<svg></svg>"));return l.appendChild(a),this._setSvgAttributes(l,r)}_svgElementFromString(e){let i=this._document.createElement("DIV");i.innerHTML=e;let r=i.querySelector("svg");if(!r)throw Error("<svg> tag not found");return r}_toSvgElement(e){let i=this._svgElementFromString(Dn("<svg></svg>")),r=e.attributes;for(let s=0;s<r.length;s++){let{name:a,value:l}=r[s];a!=="id"&&i.setAttribute(a,l)}for(let s=0;s<e.childNodes.length;s++)e.childNodes[s].nodeType===this._document.ELEMENT_NODE&&i.appendChild(e.childNodes[s].cloneNode(!0));return i}_setSvgAttributes(e,i){return e.setAttribute("fit",""),e.setAttribute("height","100%"),e.setAttribute("width","100%"),e.setAttribute("preserveAspectRatio","xMidYMid meet"),e.setAttribute("focusable","false"),i&&i.viewBox&&e.setAttribute("viewBox",i.viewBox),e}_fetchIcon(e){let{url:i,options:r}=e,s=r?.withCredentials??!1;if(!this._httpClient)throw Jp();if(i==null)throw Error(`Cannot fetch icon from URL "${i}".`);let a=this._sanitizer.sanitize(Mt.RESOURCE_URL,i);if(!a)throw Xd(i);let l=this._inProgressUrlFetches.get(a);if(l)return l;let c=this._httpClient.get(a,{responseType:"text",withCredentials:s}).pipe(M(d=>Dn(d)),Zt(()=>this._inProgressUrlFetches.delete(a)),Oa());return this._inProgressUrlFetches.set(a,c),c}_addSvgIconConfig(e,i,r){return this._svgIconConfigs.set(Qd(e,i),r),this}_addSvgIconSetConfig(e,i){let r=this._iconSetConfigs.get(e);return r?r.push(i):this._iconSetConfigs.set(e,[i]),this}_svgElementFromConfig(e){if(!e.svgElement){let i=this._svgElementFromString(e.svgText);this._setSvgAttributes(i,e.options),e.svgElement=i}return e.svgElement}_getIconConfigFromResolvers(e,i){for(let r=0;r<this._resolvers.length;r++){let s=this._resolvers[r](i,e);if(s)return eg(s)?new ne(s.url,null,s.options):new ne(s,null)}}};t.\u0275fac=function(i){return new(i||t)(m(Oe,8),m(zr),m(T,8),m(Ee))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();function tr(n){return n.cloneNode(!0)}function Qd(n,t){return n+":"+t}function eg(n){return!!(n.url&&n.options)}var ig=new C("MAT_ICON_DEFAULT_OPTIONS"),ng=new C("mat-icon-location",{providedIn:"root",factory:og});function og(){let n=g(T),t=n?n.location:null;return{getPathname:()=>t?t.pathname+t.search:""}}var Jd=["clip-path","color-profile","src","cursor","fill","filter","marker","marker-start","marker-mid","marker-end","mask","stroke"],rg=Jd.map(n=>`[${n}]`).join(", "),sg=/^url\(['"]?#(.*?)['"]?\)$/,er=(()=>{let t=class t{get color(){return this._color||this._defaultColor}set color(e){this._color=e}get svgIcon(){return this._svgIcon}set svgIcon(e){e!==this._svgIcon&&(e?this._updateSvgIcon(e):this._svgIcon&&this._clearSvgElement(),this._svgIcon=e)}get fontSet(){return this._fontSet}set fontSet(e){let i=this._cleanupFontValue(e);i!==this._fontSet&&(this._fontSet=i,this._updateFontIconClasses())}get fontIcon(){return this._fontIcon}set fontIcon(e){let i=this._cleanupFontValue(e);i!==this._fontIcon&&(this._fontIcon=i,this._updateFontIconClasses())}constructor(e,i,r,s,a,l){this._elementRef=e,this._iconRegistry=i,this._location=s,this._errorHandler=a,this.inline=!1,this._previousFontSetClass=[],this._currentIconFetch=St.EMPTY,l&&(l.color&&(this.color=this._defaultColor=l.color),l.fontSet&&(this.fontSet=l.fontSet)),r||e.nativeElement.setAttribute("aria-hidden","true")}_splitIconName(e){if(!e)return["",""];let i=e.split(":");switch(i.length){case 1:return["",i[0]];case 2:return i;default:throw Error(`Invalid icon name: "${e}"`)}}ngOnInit(){this._updateFontIconClasses()}ngAfterViewChecked(){let e=this._elementsWithExternalReferences;if(e&&e.size){let i=this._location.getPathname();i!==this._previousPath&&(this._previousPath=i,this._prependPathToReferences(i))}}ngOnDestroy(){this._currentIconFetch.unsubscribe(),this._elementsWithExternalReferences&&this._elementsWithExternalReferences.clear()}_usingFontIcon(){return!this.svgIcon}_setSvgElement(e){this._clearSvgElement();let i=this._location.getPathname();this._previousPath=i,this._cacheChildrenWithExternalReferences(e),this._prependPathToReferences(i),this._elementRef.nativeElement.appendChild(e)}_clearSvgElement(){let e=this._elementRef.nativeElement,i=e.childNodes.length;for(this._elementsWithExternalReferences&&this._elementsWithExternalReferences.clear();i--;){let r=e.childNodes[i];(r.nodeType!==1||r.nodeName.toLowerCase()==="svg")&&r.remove()}}_updateFontIconClasses(){if(!this._usingFontIcon())return;let e=this._elementRef.nativeElement,i=(this.fontSet?this._iconRegistry.classNameForFontAlias(this.fontSet).split(/ +/):this._iconRegistry.getDefaultFontSetClass()).filter(r=>r.length>0);this._previousFontSetClass.forEach(r=>e.classList.remove(r)),i.forEach(r=>e.classList.add(r)),this._previousFontSetClass=i,this.fontIcon!==this._previousFontIconClass&&!i.includes("mat-ligature-font")&&(this._previousFontIconClass&&e.classList.remove(this._previousFontIconClass),this.fontIcon&&e.classList.add(this.fontIcon),this._previousFontIconClass=this.fontIcon)}_cleanupFontValue(e){return typeof e=="string"?e.trim().split(" ")[0]:e}_prependPathToReferences(e){let i=this._elementsWithExternalReferences;i&&i.forEach((r,s)=>{r.forEach(a=>{s.setAttribute(a.name,`url('${e}#${a.value}')`)})})}_cacheChildrenWithExternalReferences(e){let i=e.querySelectorAll(rg),r=this._elementsWithExternalReferences=this._elementsWithExternalReferences||new Map;for(let s=0;s<i.length;s++)Jd.forEach(a=>{let l=i[s],c=l.getAttribute(a),d=c?c.match(sg):null;if(d){let h=r.get(l);h||(h=[],r.set(l,h)),h.push({name:a,value:d[1]})}})}_updateSvgIcon(e){if(this._svgNamespace=null,this._svgName=null,this._currentIconFetch.unsubscribe(),e){let[i,r]=this._splitIconName(e);i&&(this._svgNamespace=i),r&&(this._svgName=r),this._currentIconFetch=this._iconRegistry.getNamedSvgIcon(r,i).pipe(ut(1)).subscribe(s=>this._setSvgElement(s),s=>{let a=`Error retrieving icon ${i}:${r}! ${s.message}`;this._errorHandler.handleError(new Error(a))})}}};t.\u0275fac=function(i){return new(i||t)(u(A),u(tg),De("aria-hidden"),u(ng),u(Ee),u(ig,8))},t.\u0275cmp=P({type:t,selectors:[["mat-icon"]],hostAttrs:["role","img",1,"mat-icon","notranslate"],hostVars:10,hostBindings:function(i,r){i&2&&(ft("data-mat-icon-type",r._usingFontIcon()?"font":"svg")("data-mat-icon-name",r._svgName||r.fontIcon)("data-mat-icon-namespace",r._svgNamespace||r.fontSet)("fontIcon",r._usingFontIcon()?r.fontIcon:null),Jt(r.color?"mat-"+r.color:""),st("mat-icon-inline",r.inline)("mat-icon-no-color",r.color!=="primary"&&r.color!=="accent"&&r.color!=="warn"))},inputs:{color:"color",inline:[y.HasDecoratorInputTransform,"inline","inline",W],svgIcon:"svgIcon",fontSet:"fontSet",fontIcon:"fontIcon"},exportAs:["matIcon"],standalone:!0,features:[nt,tt],ngContentSelectors:Kp,decls:1,vars:0,template:function(i,r){i&1&&(pt(),K(0))},styles:["mat-icon,mat-icon.mat-primary,mat-icon.mat-accent,mat-icon.mat-warn{color:var(--mat-icon-color)}.mat-icon{-webkit-user-select:none;user-select:none;background-repeat:no-repeat;display:inline-block;fill:currentColor;height:24px;width:24px;overflow:hidden}.mat-icon.mat-icon-inline{font-size:inherit;height:inherit;line-height:inherit;width:inherit}.mat-icon.mat-ligature-font[fontIcon]::before{content:attr(fontIcon)}[dir=rtl] .mat-icon-rtl-mirror{transform:scale(-1, 1)}.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-prefix .mat-icon,.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-suffix .mat-icon{display:block}.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-prefix .mat-icon-button .mat-icon,.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-suffix .mat-icon-button .mat-icon{margin:auto}"],encapsulation:2,changeDetection:0});let n=t;return n})(),tu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,Y]});let n=t;return n})();function ag(n,t){if(n&1){let o=Ft();de(0),x(1,"button",12),Z("click",function(){xt(o);let i=X();return wt(i.toggleSaveForLater())}),x(2,"mat-icon",13),F(3,"delete"),_(),F(4," Delete From Save For Later "),_(),ue()}}function lg(n,t){if(n&1){let o=Ft();x(0,"button",14),Z("click",function(){xt(o);let i=X();return wt(i.toggleSaveForLater())}),x(1,"mat-icon",13),F(2,"favorite"),_(),F(3," Save For Later "),_()}}function cg(n,t){if(n&1&&(x(0,"th",18),F(1),_()),n&2){let o=X().$implicit;R(),te(o==="ShopNow"?"Shop Now":o)}}function dg(n,t){if(n&1&&(de(0),F(1),ue()),n&2){let o=X().$implicit,e=X().$implicit;R(),Oi(" ",o[e]," ")}}function ug(n,t){if(n&1&&(x(0,"a",20),F(1,"Visit Store"),_()),n&2){let o=X().$implicit,e=X().$implicit;L("href",o[e],Se)}}function hg(n,t){if(n&1&&(x(0,"td",19),ot(1,dg,2,1,"ng-container",5)(2,ug,2,1,"ng-template",null,1,Ke),_()),n&2){let o=he(3),e=X().$implicit;R(),L("ngIf",e!=="ShopNow")("ngIfElse",o)}}function mg(n,t){if(n&1&&(de(0,15),ot(1,cg,2,1,"th",16)(2,hg,4,2,"td",17),ue()),n&2){let o=t.$implicit;L("matColumnDef",o)}}function fg(n,t){n&1&&H(0,"tr",21)}function pg(n,t){n&1&&H(0,"tr",22)}var iu=(()=>{let t=class t{constructor(e,i){this.productService=e,this.route=i,this.productID="",this.tableColumns=["Store","Price","ShopNow"],this.statusMessage="",this.sflStatus=!1}ngOnInit(){this.route.paramMap.subscribe(e=>{this.productID=e.get("productID")??""}),this.getOneProduct(),this.checkSFLStatus()}getOneProduct(){this.productService.getOneProduct(this.productID).subscribe({next:e=>{this.productStores=e,this.generateTableData()},error:e=>{console.error("Error fetching stores:",e)}})}generateTableData(){let i=[this.productStores,...this.productStores.productComparison].map(r=>({Store:r.storeName,Price:r.productPrice,ShopNow:r.productLink}));this.tableData=new wi(i)}checkSFLStatus(){this.productService.getSaveForLater().subscribe({next:e=>{e.saveForLater.length>0&&(this.sflStatus=e.saveForLater.some(i=>i.productID===this.productID))},error:e=>{console.error("Error fetching stores:",e)}})}setMsgTimeOut(){setTimeout(()=>{this.statusMessage=""},3e3)}toggleSaveForLater(){this.sflStatus?this.removeSaveForLater():this.setSaveForLater()}setSaveForLater(){this.productService.setSaveForLater(this.productID).subscribe({next:e=>{e&&(this.statusMessage="Data is saved successfully!",this.sflStatus=!0,this.setMsgTimeOut()),this.checkSFLStatus()},error:e=>{console.error("Error saving data",e)}})}removeSaveForLater(){this.productService.deleteSflProduct(this.productID).subscribe({next:e=>{e&&(this.statusMessage="Product is removed successfully!",this.sflStatus=!1,this.setMsgTimeOut()),this.checkSFLStatus()},error:e=>{console.error("Error removing data",e)}})}};t.\u0275fac=function(i){return new(i||t)(u(fe),u(ee))},t.\u0275cmp=P({type:t,selectors:[["app-product-stores"]],decls:17,vars:10,consts:[["saveForLaterBtn",""],["storeLink",""],[1,"product-details-container"],[1,"left-column"],[1,"image",3,"src","alt"],[4,"ngIf","ngIfElse"],[1,"status-message"],[1,"right-column"],["mat-table","",1,"table",3,"dataSource"],["class","description-cell",3,"matColumnDef",4,"ngFor","ngForOf"],["mat-header-row","",4,"matHeaderRowDef"],["mat-row","",4,"matRowDef","matRowDefColumns"],["type","button",1,"button","delete-button",3,"click"],[1,"icon"],["type","submit",1,"button",3,"click"],[1,"description-cell",3,"matColumnDef"],["mat-header-cell","",4,"matHeaderCellDef"],["mat-cell","",4,"matCellDef"],["mat-header-cell",""],["mat-cell",""],["target","_blank",3,"href"],["mat-header-row",""],["mat-row",""]],template:function(i,r){if(i&1&&(x(0,"div",2)(1,"div",3)(2,"h1")(3,"strong"),F(4),_()(),H(5,"img",4),x(6,"div"),ot(7,ag,5,0,"ng-container",5)(8,lg,4,0,"ng-template",null,0,Ke),_(),x(10,"div",6),F(11),_()(),x(12,"div",7)(13,"table",8),ot(14,mg,3,1,"ng-container",9)(15,fg,1,0,"tr",10)(16,pg,1,0,"tr",11),_()()()),i&2){let s=he(9);R(4),te(r.productStores==null?null:r.productStores.productName),R(),Ze("alt",r.productStores==null?null:r.productStores.productName),L("src",r.productStores==null?null:r.productStores.productImage,Se),R(2),L("ngIf",r.sflStatus)("ngIfElse",s),R(4),te(r.statusMessage),R(2),L("dataSource",r.tableData),R(),L("ngForOf",r.tableColumns),R(),L("matHeaderRowDef",r.tableColumns),R(),L("matRowDefColumns",r.tableColumns)}},dependencies:[Qe,Ht,er,Nd,Ld,Bd,jd,Pd,Ud,Vd,zd,Hd,$d],styles:[".product-details-container[_ngcontent-%COMP%]{display:flex;color:#578413}.left-column[_ngcontent-%COMP%]{flex:1;padding:20px;border-right:1px solid #ccc}.right-column[_ngcontent-%COMP%]{flex:2;padding:20px}.table[_ngcontent-%COMP%]{width:100%;border-spacing:0}.button[_ngcontent-%COMP%]{font-weight:100;font-size:1rem;background-color:#5f7cd1;color:#fff;padding:.75rem 1rem;border-radius:10px;cursor:pointer;display:flex;align-items:center}.delete-button[_ngcontent-%COMP%]{background-color:tomato}.icon[_ngcontent-%COMP%]{margin-right:.5rem}.description-cell[_ngcontent-%COMP%]{overflow:hidden;text-overflow:ellipsis;font-size:1rem}.image[_ngcontent-%COMP%]{margin-top:50px;max-width:100%;height:auto;margin-bottom:70px}.status-message[_ngcontent-%COMP%]{margin-top:20px}.success[_ngcontent-%COMP%]{color:green}.error[_ngcontent-%COMP%]{color:red}"]});let n=t;return n})();var gg=[{path:"",component:ed},{path:"SFL",component:Gd},{path:"Account",component:qd},{path:"Product-Stores/:productID",component:iu}],nu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Rs.forRoot(gg),Rs]});let n=t;return n})();var bg="@",vg=(()=>{let t=class t{constructor(e,i,r,s,a){this.doc=e,this.delegate=i,this.zone=r,this.animationType=s,this.moduleImpl=a,this._rendererFactoryPromise=null,this.scheduler=g(qa,{optional:!0})}ngOnDestroy(){this._engine?.flush()}loadImpl(){return(this.moduleImpl??import("./chunk-LWJOV7RA.js")).catch(i=>{throw new $(5300,!1)}).then(({\u0275createEngine:i,\u0275AnimationRendererFactory:r})=>{this._engine=i(this.animationType,this.doc,this.scheduler);let s=new r(this.delegate,this._engine,this.zone);return this.delegate=s,s})}createRenderer(e,i){let r=this.delegate.createRenderer(e,i);if(r.\u0275type===0)return r;typeof r.throwOnSyntheticProps=="boolean"&&(r.throwOnSyntheticProps=!1);let s=new ma(r);return i?.data?.animation&&!this._rendererFactoryPromise&&(this._rendererFactoryPromise=this.loadImpl()),this._rendererFactoryPromise?.then(a=>{let l=a.createRenderer(e,i);s.use(l)}).catch(a=>{s.use(r)}),s}begin(){this.delegate.begin?.()}end(){this.delegate.end?.()}whenRenderingDone(){return this.delegate.whenRenderingDone?.()??Promise.resolve()}};t.\u0275fac=function(i){Ie()},t.\u0275prov=b({token:t,factory:t.\u0275fac});let n=t;return n})(),ma=class{constructor(t){this.delegate=t,this.replay=[],this.\u0275type=1}use(t){if(this.delegate=t,this.replay!==null){for(let o of this.replay)o(t);this.replay=null}}get data(){return this.delegate.data}destroy(){this.replay=null,this.delegate.destroy()}createElement(t,o){return this.delegate.createElement(t,o)}createComment(t){return this.delegate.createComment(t)}createText(t){return this.delegate.createText(t)}get destroyNode(){return this.delegate.destroyNode}appendChild(t,o){this.delegate.appendChild(t,o)}insertBefore(t,o,e,i){this.delegate.insertBefore(t,o,e,i)}removeChild(t,o,e){this.delegate.removeChild(t,o,e)}selectRootElement(t,o){return this.delegate.selectRootElement(t,o)}parentNode(t){return this.delegate.parentNode(t)}nextSibling(t){return this.delegate.nextSibling(t)}setAttribute(t,o,e,i){this.delegate.setAttribute(t,o,e,i)}removeAttribute(t,o,e){this.delegate.removeAttribute(t,o,e)}addClass(t,o){this.delegate.addClass(t,o)}removeClass(t,o){this.delegate.removeClass(t,o)}setStyle(t,o,e,i){this.delegate.setStyle(t,o,e,i)}removeStyle(t,o,e){this.delegate.removeStyle(t,o,e)}setProperty(t,o,e){this.shouldReplay(o)&&this.replay.push(i=>i.setProperty(t,o,e)),this.delegate.setProperty(t,o,e)}setValue(t,o){this.delegate.setValue(t,o)}listen(t,o,e){return this.shouldReplay(o)&&this.replay.push(i=>i.listen(t,o,e)),this.delegate.listen(t,o,e)}shouldReplay(t){return this.replay!==null&&t.startsWith(bg)}};function ou(n="animations"){return gr("NgAsyncAnimations"),Ge([{provide:Pn,useFactory:(t,o,e)=>new vg(t,o,e,n),deps:[T,to,I]},{provide:Bt,useValue:n==="noop"?"NoopAnimations":"BrowserAnimations"}])}var _g=["*",[["mat-toolbar-row"]]],yg=["*","mat-toolbar-row"],xg=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275dir=D({type:t,selectors:[["mat-toolbar-row"]],hostAttrs:[1,"mat-toolbar-row"],exportAs:["matToolbarRow"],standalone:!0});let n=t;return n})(),ru=(()=>{let t=class t{constructor(e,i,r){this._elementRef=e,this._platform=i,this._document=r}ngAfterViewInit(){this._platform.isBrowser&&(this._checkToolbarMixedModes(),this._toolbarRows.changes.subscribe(()=>this._checkToolbarMixedModes()))}_checkToolbarMixedModes(){this._toolbarRows.length}};t.\u0275fac=function(i){return new(i||t)(u(A),u(J),u(T))},t.\u0275cmp=P({type:t,selectors:[["mat-toolbar"]],contentQueries:function(i,r,s){if(i&1&&gt(s,xg,5),i&2){let a;at(a=lt())&&(r._toolbarRows=a)}},hostAttrs:[1,"mat-toolbar"],hostVars:6,hostBindings:function(i,r){i&2&&(Jt(r.color?"mat-"+r.color:""),st("mat-toolbar-multiple-rows",r._toolbarRows.length>0)("mat-toolbar-single-row",r._toolbarRows.length===0))},inputs:{color:"color"},exportAs:["matToolbar"],standalone:!0,features:[tt],ngContentSelectors:yg,decls:2,vars:0,template:function(i,r){i&1&&(pt(_g),K(0),K(1,1))},styles:[".mat-toolbar{background:var(--mat-toolbar-container-background-color);color:var(--mat-toolbar-container-text-color)}.mat-toolbar,.mat-toolbar h1,.mat-toolbar h2,.mat-toolbar h3,.mat-toolbar h4,.mat-toolbar h5,.mat-toolbar h6{font-family:var(--mat-toolbar-title-text-font);font-size:var(--mat-toolbar-title-text-size);line-height:var(--mat-toolbar-title-text-line-height);font-weight:var(--mat-toolbar-title-text-weight);letter-spacing:var(--mat-toolbar-title-text-tracking);margin:0}.cdk-high-contrast-active .mat-toolbar{outline:solid 1px}.mat-toolbar .mat-form-field-underline,.mat-toolbar .mat-form-field-ripple,.mat-toolbar .mat-focused .mat-form-field-ripple{background-color:currentColor}.mat-toolbar .mat-form-field-label,.mat-toolbar .mat-focused .mat-form-field-label,.mat-toolbar .mat-select-value,.mat-toolbar .mat-select-arrow,.mat-toolbar .mat-form-field.mat-focused .mat-select-arrow{color:inherit}.mat-toolbar .mat-input-element{caret-color:currentColor}.mat-toolbar .mat-mdc-button-base.mat-mdc-button-base.mat-unthemed{--mdc-text-button-label-text-color:var(--mat-toolbar-container-text-color);--mdc-outlined-button-label-text-color:var(--mat-toolbar-container-text-color)}.mat-toolbar-row,.mat-toolbar-single-row{display:flex;box-sizing:border-box;padding:0 16px;width:100%;flex-direction:row;align-items:center;white-space:nowrap;height:var(--mat-toolbar-standard-height)}@media(max-width: 599px){.mat-toolbar-row,.mat-toolbar-single-row{height:var(--mat-toolbar-mobile-height)}}.mat-toolbar-multiple-rows{display:flex;box-sizing:border-box;flex-direction:column;width:100%;min-height:var(--mat-toolbar-standard-height)}@media(max-width: 599px){.mat-toolbar-multiple-rows{min-height:var(--mat-toolbar-mobile-height)}}"],encapsulation:2,changeDetection:0});let n=t;return n})();var su=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,Y]});let n=t;return n})();var Cg=["mat-button",""],Dg=[[["",8,"material-icons",3,"iconPositionEnd",""],["mat-icon",3,"iconPositionEnd",""],["","matButtonIcon","",3,"iconPositionEnd",""]],"*",[["","iconPositionEnd","",8,"material-icons"],["mat-icon","iconPositionEnd",""],["","matButtonIcon","","iconPositionEnd",""]]],Eg=[".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])","*",".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]"],Sg='.mdc-touch-target-wrapper{display:inline}.mdc-elevation-overlay{position:absolute;border-radius:inherit;pointer-events:none;opacity:var(--mdc-elevation-overlay-opacity, 0);transition:opacity 280ms cubic-bezier(0.4, 0, 0.2, 1)}.mdc-button{position:relative;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box;min-width:64px;border:none;outline:none;line-height:inherit;user-select:none;-webkit-appearance:none;overflow:visible;vertical-align:middle;background:rgba(0,0,0,0)}.mdc-button .mdc-elevation-overlay{width:100%;height:100%;top:0;left:0}.mdc-button::-moz-focus-inner{padding:0;border:0}.mdc-button:active{outline:none}.mdc-button:hover{cursor:pointer}.mdc-button:disabled{cursor:default;pointer-events:none}.mdc-button[hidden]{display:none}.mdc-button .mdc-button__icon{margin-left:0;margin-right:8px;display:inline-block;position:relative;vertical-align:top}[dir=rtl] .mdc-button .mdc-button__icon,.mdc-button .mdc-button__icon[dir=rtl]{margin-left:8px;margin-right:0}.mdc-button .mdc-button__progress-indicator{font-size:0;position:absolute;transform:translate(-50%, -50%);top:50%;left:50%;line-height:initial}.mdc-button .mdc-button__label{position:relative}.mdc-button .mdc-button__focus-ring{pointer-events:none;border:2px solid rgba(0,0,0,0);border-radius:6px;box-sizing:content-box;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:calc(100% + 4px);width:calc(100% + 4px);display:none}@media screen and (forced-colors: active){.mdc-button .mdc-button__focus-ring{border-color:CanvasText}}.mdc-button .mdc-button__focus-ring::after{content:"";border:2px solid rgba(0,0,0,0);border-radius:8px;display:block;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:calc(100% + 4px);width:calc(100% + 4px)}@media screen and (forced-colors: active){.mdc-button .mdc-button__focus-ring::after{border-color:CanvasText}}@media screen and (forced-colors: active){.mdc-button.mdc-ripple-upgraded--background-focused .mdc-button__focus-ring,.mdc-button:not(.mdc-ripple-upgraded):focus .mdc-button__focus-ring{display:block}}.mdc-button .mdc-button__touch{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%)}.mdc-button__label+.mdc-button__icon{margin-left:8px;margin-right:0}[dir=rtl] .mdc-button__label+.mdc-button__icon,.mdc-button__label+.mdc-button__icon[dir=rtl]{margin-left:0;margin-right:8px}svg.mdc-button__icon{fill:currentColor}.mdc-button--touch{margin-top:6px;margin-bottom:6px}.mdc-button{padding:0 8px 0 8px}.mdc-button--unelevated{transition:box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1);padding:0 16px 0 16px}.mdc-button--unelevated.mdc-button--icon-trailing{padding:0 12px 0 16px}.mdc-button--unelevated.mdc-button--icon-leading{padding:0 16px 0 12px}.mdc-button--raised{transition:box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1);padding:0 16px 0 16px}.mdc-button--raised.mdc-button--icon-trailing{padding:0 12px 0 16px}.mdc-button--raised.mdc-button--icon-leading{padding:0 16px 0 12px}.mdc-button--outlined{border-style:solid;transition:border 280ms cubic-bezier(0.4, 0, 0.2, 1)}.mdc-button--outlined .mdc-button__ripple{border-style:solid;border-color:rgba(0,0,0,0)}.mat-mdc-button{font-family:var(--mdc-text-button-label-text-font);font-size:var(--mdc-text-button-label-text-size);letter-spacing:var(--mdc-text-button-label-text-tracking);font-weight:var(--mdc-text-button-label-text-weight);text-transform:var(--mdc-text-button-label-text-transform);height:var(--mdc-text-button-container-height);border-radius:var(--mdc-text-button-container-shape);padding:0 var(--mat-text-button-horizontal-padding, 8px)}.mat-mdc-button:not(:disabled){color:var(--mdc-text-button-label-text-color)}.mat-mdc-button:disabled{color:var(--mdc-text-button-disabled-label-text-color)}.mat-mdc-button .mdc-button__ripple{border-radius:var(--mdc-text-button-container-shape)}.mat-mdc-button:has(.material-icons,mat-icon,[matButtonIcon]){padding:0 var(--mat-text-button-with-icon-horizontal-padding, 8px)}.mat-mdc-button>.mat-icon{margin-right:var(--mat-text-button-icon-spacing, 8px);margin-left:var(--mat-text-button-icon-offset, 0)}[dir=rtl] .mat-mdc-button>.mat-icon{margin-right:var(--mat-text-button-icon-offset, 0);margin-left:var(--mat-text-button-icon-spacing, 8px)}.mat-mdc-button .mdc-button__label+.mat-icon{margin-right:var(--mat-text-button-icon-offset, 0);margin-left:var(--mat-text-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-button .mdc-button__label+.mat-icon{margin-right:var(--mat-text-button-icon-spacing, 8px);margin-left:var(--mat-text-button-icon-offset, 0)}.mat-mdc-button .mat-ripple-element{background-color:var(--mat-text-button-ripple-color)}.mat-mdc-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-text-button-state-layer-color)}.mat-mdc-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-text-button-disabled-state-layer-color)}.mat-mdc-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-text-button-hover-state-layer-opacity)}.mat-mdc-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-text-button-focus-state-layer-opacity)}.mat-mdc-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-text-button-pressed-state-layer-opacity)}.mat-mdc-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-text-button-touch-target-display)}.mat-mdc-button[disabled],.mat-mdc-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-text-button-disabled-label-text-color)}.mat-mdc-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-unelevated-button{font-family:var(--mdc-filled-button-label-text-font);font-size:var(--mdc-filled-button-label-text-size);letter-spacing:var(--mdc-filled-button-label-text-tracking);font-weight:var(--mdc-filled-button-label-text-weight);text-transform:var(--mdc-filled-button-label-text-transform);height:var(--mdc-filled-button-container-height);border-radius:var(--mdc-filled-button-container-shape);padding:0 var(--mat-filled-button-horizontal-padding, 16px)}.mat-mdc-unelevated-button:not(:disabled){background-color:var(--mdc-filled-button-container-color)}.mat-mdc-unelevated-button:disabled{background-color:var(--mdc-filled-button-disabled-container-color)}.mat-mdc-unelevated-button:not(:disabled){color:var(--mdc-filled-button-label-text-color)}.mat-mdc-unelevated-button:disabled{color:var(--mdc-filled-button-disabled-label-text-color)}.mat-mdc-unelevated-button .mdc-button__ripple{border-radius:var(--mdc-filled-button-container-shape)}.mat-mdc-unelevated-button>.mat-icon{margin-right:var(--mat-filled-button-icon-spacing, 8px);margin-left:var(--mat-filled-button-icon-offset, -4px)}[dir=rtl] .mat-mdc-unelevated-button>.mat-icon{margin-right:var(--mat-filled-button-icon-offset, -4px);margin-left:var(--mat-filled-button-icon-spacing, 8px)}.mat-mdc-unelevated-button .mdc-button__label+.mat-icon{margin-right:var(--mat-filled-button-icon-offset, -4px);margin-left:var(--mat-filled-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-unelevated-button .mdc-button__label+.mat-icon{margin-right:var(--mat-filled-button-icon-spacing, 8px);margin-left:var(--mat-filled-button-icon-offset, -4px)}.mat-mdc-unelevated-button .mat-ripple-element{background-color:var(--mat-filled-button-ripple-color)}.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-filled-button-state-layer-color)}.mat-mdc-unelevated-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-filled-button-disabled-state-layer-color)}.mat-mdc-unelevated-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-filled-button-hover-state-layer-opacity)}.mat-mdc-unelevated-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-filled-button-focus-state-layer-opacity)}.mat-mdc-unelevated-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-filled-button-pressed-state-layer-opacity)}.mat-mdc-unelevated-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-filled-button-touch-target-display)}.mat-mdc-unelevated-button[disabled],.mat-mdc-unelevated-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-filled-button-disabled-label-text-color);background-color:var(--mdc-filled-button-disabled-container-color)}.mat-mdc-unelevated-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-raised-button{font-family:var(--mdc-protected-button-label-text-font);font-size:var(--mdc-protected-button-label-text-size);letter-spacing:var(--mdc-protected-button-label-text-tracking);font-weight:var(--mdc-protected-button-label-text-weight);text-transform:var(--mdc-protected-button-label-text-transform);height:var(--mdc-protected-button-container-height);border-radius:var(--mdc-protected-button-container-shape);padding:0 var(--mat-protected-button-horizontal-padding, 16px);box-shadow:var(--mdc-protected-button-container-elevation-shadow)}.mat-mdc-raised-button:not(:disabled){background-color:var(--mdc-protected-button-container-color)}.mat-mdc-raised-button:disabled{background-color:var(--mdc-protected-button-disabled-container-color)}.mat-mdc-raised-button:not(:disabled){color:var(--mdc-protected-button-label-text-color)}.mat-mdc-raised-button:disabled{color:var(--mdc-protected-button-disabled-label-text-color)}.mat-mdc-raised-button .mdc-button__ripple{border-radius:var(--mdc-protected-button-container-shape)}.mat-mdc-raised-button>.mat-icon{margin-right:var(--mat-protected-button-icon-spacing, 8px);margin-left:var(--mat-protected-button-icon-offset, -4px)}[dir=rtl] .mat-mdc-raised-button>.mat-icon{margin-right:var(--mat-protected-button-icon-offset, -4px);margin-left:var(--mat-protected-button-icon-spacing, 8px)}.mat-mdc-raised-button .mdc-button__label+.mat-icon{margin-right:var(--mat-protected-button-icon-offset, -4px);margin-left:var(--mat-protected-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-raised-button .mdc-button__label+.mat-icon{margin-right:var(--mat-protected-button-icon-spacing, 8px);margin-left:var(--mat-protected-button-icon-offset, -4px)}.mat-mdc-raised-button .mat-ripple-element{background-color:var(--mat-protected-button-ripple-color)}.mat-mdc-raised-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-protected-button-state-layer-color)}.mat-mdc-raised-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-protected-button-disabled-state-layer-color)}.mat-mdc-raised-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-protected-button-hover-state-layer-opacity)}.mat-mdc-raised-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-protected-button-focus-state-layer-opacity)}.mat-mdc-raised-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-protected-button-pressed-state-layer-opacity)}.mat-mdc-raised-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-protected-button-touch-target-display)}.mat-mdc-raised-button:hover{box-shadow:var(--mdc-protected-button-hover-container-elevation-shadow)}.mat-mdc-raised-button:focus{box-shadow:var(--mdc-protected-button-focus-container-elevation-shadow)}.mat-mdc-raised-button:active,.mat-mdc-raised-button:focus:active{box-shadow:var(--mdc-protected-button-pressed-container-elevation-shadow)}.mat-mdc-raised-button[disabled],.mat-mdc-raised-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-protected-button-disabled-label-text-color);background-color:var(--mdc-protected-button-disabled-container-color)}.mat-mdc-raised-button[disabled].mat-mdc-button-disabled,.mat-mdc-raised-button.mat-mdc-button-disabled.mat-mdc-button-disabled{box-shadow:var(--mdc-protected-button-disabled-container-elevation-shadow)}.mat-mdc-raised-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-outlined-button{font-family:var(--mdc-outlined-button-label-text-font);font-size:var(--mdc-outlined-button-label-text-size);letter-spacing:var(--mdc-outlined-button-label-text-tracking);font-weight:var(--mdc-outlined-button-label-text-weight);text-transform:var(--mdc-outlined-button-label-text-transform);height:var(--mdc-outlined-button-container-height);border-radius:var(--mdc-outlined-button-container-shape);padding:0 15px 0 15px;border-width:var(--mdc-outlined-button-outline-width);padding:0 var(--mat-outlined-button-horizontal-padding, 15px)}.mat-mdc-outlined-button:not(:disabled){color:var(--mdc-outlined-button-label-text-color)}.mat-mdc-outlined-button:disabled{color:var(--mdc-outlined-button-disabled-label-text-color)}.mat-mdc-outlined-button .mdc-button__ripple{border-radius:var(--mdc-outlined-button-container-shape)}.mat-mdc-outlined-button:not(:disabled){border-color:var(--mdc-outlined-button-outline-color)}.mat-mdc-outlined-button:disabled{border-color:var(--mdc-outlined-button-disabled-outline-color)}.mat-mdc-outlined-button.mdc-button--icon-trailing{padding:0 11px 0 15px}.mat-mdc-outlined-button.mdc-button--icon-leading{padding:0 15px 0 11px}.mat-mdc-outlined-button .mdc-button__ripple{top:-1px;left:-1px;bottom:-1px;right:-1px;border-width:var(--mdc-outlined-button-outline-width)}.mat-mdc-outlined-button .mdc-button__touch{left:calc(-1 * var(--mdc-outlined-button-outline-width));width:calc(100% + 2 * var(--mdc-outlined-button-outline-width))}.mat-mdc-outlined-button>.mat-icon{margin-right:var(--mat-outlined-button-icon-spacing, 8px);margin-left:var(--mat-outlined-button-icon-offset, -4px)}[dir=rtl] .mat-mdc-outlined-button>.mat-icon{margin-right:var(--mat-outlined-button-icon-offset, -4px);margin-left:var(--mat-outlined-button-icon-spacing, 8px)}.mat-mdc-outlined-button .mdc-button__label+.mat-icon{margin-right:var(--mat-outlined-button-icon-offset, -4px);margin-left:var(--mat-outlined-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-outlined-button .mdc-button__label+.mat-icon{margin-right:var(--mat-outlined-button-icon-spacing, 8px);margin-left:var(--mat-outlined-button-icon-offset, -4px)}.mat-mdc-outlined-button .mat-ripple-element{background-color:var(--mat-outlined-button-ripple-color)}.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-outlined-button-state-layer-color)}.mat-mdc-outlined-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-outlined-button-disabled-state-layer-color)}.mat-mdc-outlined-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-outlined-button-hover-state-layer-opacity)}.mat-mdc-outlined-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-outlined-button-focus-state-layer-opacity)}.mat-mdc-outlined-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-outlined-button-pressed-state-layer-opacity)}.mat-mdc-outlined-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-outlined-button-touch-target-display)}.mat-mdc-outlined-button[disabled],.mat-mdc-outlined-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-outlined-button-disabled-label-text-color);border-color:var(--mdc-outlined-button-disabled-outline-color)}.mat-mdc-outlined-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-button-base{text-decoration:none}.mat-mdc-button,.mat-mdc-unelevated-button,.mat-mdc-raised-button,.mat-mdc-outlined-button{-webkit-tap-highlight-color:rgba(0,0,0,0)}.mat-mdc-button .mat-mdc-button-ripple,.mat-mdc-button .mat-mdc-button-persistent-ripple,.mat-mdc-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button .mat-mdc-button-ripple,.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple,.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button .mat-mdc-button-ripple,.mat-mdc-raised-button .mat-mdc-button-persistent-ripple,.mat-mdc-raised-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button .mat-mdc-button-ripple,.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple,.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple::before{top:0;left:0;right:0;bottom:0;position:absolute;pointer-events:none;border-radius:inherit}.mat-mdc-button .mat-mdc-button-ripple,.mat-mdc-unelevated-button .mat-mdc-button-ripple,.mat-mdc-raised-button .mat-mdc-button-ripple,.mat-mdc-outlined-button .mat-mdc-button-ripple{overflow:hidden}.mat-mdc-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple::before{content:"";opacity:0}.mat-mdc-button .mdc-button__label,.mat-mdc-unelevated-button .mdc-button__label,.mat-mdc-raised-button .mdc-button__label,.mat-mdc-outlined-button .mdc-button__label{z-index:1}.mat-mdc-button .mat-mdc-focus-indicator,.mat-mdc-unelevated-button .mat-mdc-focus-indicator,.mat-mdc-raised-button .mat-mdc-focus-indicator,.mat-mdc-outlined-button .mat-mdc-focus-indicator{top:0;left:0;right:0;bottom:0;position:absolute}.mat-mdc-button:focus .mat-mdc-focus-indicator::before,.mat-mdc-unelevated-button:focus .mat-mdc-focus-indicator::before,.mat-mdc-raised-button:focus .mat-mdc-focus-indicator::before,.mat-mdc-outlined-button:focus .mat-mdc-focus-indicator::before{content:""}.mat-mdc-button._mat-animation-noopable,.mat-mdc-unelevated-button._mat-animation-noopable,.mat-mdc-raised-button._mat-animation-noopable,.mat-mdc-outlined-button._mat-animation-noopable{transition:none !important;animation:none !important}.mat-mdc-button>.mat-icon,.mat-mdc-unelevated-button>.mat-icon,.mat-mdc-raised-button>.mat-icon,.mat-mdc-outlined-button>.mat-icon{display:inline-block;position:relative;vertical-align:top;font-size:1.125rem;height:1.125rem;width:1.125rem}.mat-mdc-outlined-button .mat-mdc-button-ripple,.mat-mdc-outlined-button .mdc-button__ripple{top:-1px;left:-1px;bottom:-1px;right:-1px;border-width:-1px}.mat-mdc-unelevated-button .mat-mdc-focus-indicator::before,.mat-mdc-raised-button .mat-mdc-focus-indicator::before{margin:calc(calc(var(--mat-mdc-focus-indicator-border-width, 3px) + 2px)*-1)}.mat-mdc-outlined-button .mat-mdc-focus-indicator::before{margin:calc(calc(var(--mat-mdc-focus-indicator-border-width, 3px) + 3px)*-1)}',au=".cdk-high-contrast-active .mat-mdc-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-unelevated-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-raised-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-outlined-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-icon-button{outline:solid 1px}";var Ig=["mat-icon-button",""],Rg=["*"],Mg='.mdc-icon-button{display:inline-block;position:relative;box-sizing:border-box;border:none;outline:none;background-color:rgba(0,0,0,0);fill:currentColor;color:inherit;text-decoration:none;cursor:pointer;user-select:none;z-index:0;overflow:visible}.mdc-icon-button .mdc-icon-button__touch{position:absolute;top:50%;height:48px;left:50%;width:48px;transform:translate(-50%, -50%)}@media screen and (forced-colors: active){.mdc-icon-button.mdc-ripple-upgraded--background-focused .mdc-icon-button__focus-ring,.mdc-icon-button:not(.mdc-ripple-upgraded):focus .mdc-icon-button__focus-ring{display:block}}.mdc-icon-button:disabled{cursor:default;pointer-events:none}.mdc-icon-button[hidden]{display:none}.mdc-icon-button--display-flex{align-items:center;display:inline-flex;justify-content:center}.mdc-icon-button__focus-ring{pointer-events:none;border:2px solid rgba(0,0,0,0);border-radius:6px;box-sizing:content-box;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:100%;width:100%;display:none}@media screen and (forced-colors: active){.mdc-icon-button__focus-ring{border-color:CanvasText}}.mdc-icon-button__focus-ring::after{content:"";border:2px solid rgba(0,0,0,0);border-radius:8px;display:block;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:calc(100% + 4px);width:calc(100% + 4px)}@media screen and (forced-colors: active){.mdc-icon-button__focus-ring::after{border-color:CanvasText}}.mdc-icon-button__icon{display:inline-block}.mdc-icon-button__icon.mdc-icon-button__icon--on{display:none}.mdc-icon-button--on .mdc-icon-button__icon{display:none}.mdc-icon-button--on .mdc-icon-button__icon.mdc-icon-button__icon--on{display:inline-block}.mdc-icon-button__link{height:100%;left:0;outline:none;position:absolute;top:0;width:100%}.mat-mdc-icon-button{color:var(--mdc-icon-button-icon-color)}.mat-mdc-icon-button .mdc-button__icon{font-size:var(--mdc-icon-button-icon-size)}.mat-mdc-icon-button svg,.mat-mdc-icon-button img{width:var(--mdc-icon-button-icon-size);height:var(--mdc-icon-button-icon-size)}.mat-mdc-icon-button:disabled{color:var(--mdc-icon-button-disabled-icon-color)}.mat-mdc-icon-button{border-radius:50%;flex-shrink:0;text-align:center;width:var(--mdc-icon-button-state-layer-size, 48px);height:var(--mdc-icon-button-state-layer-size, 48px);padding:calc(calc(var(--mdc-icon-button-state-layer-size, 48px) - var(--mdc-icon-button-icon-size, 24px)) / 2);font-size:var(--mdc-icon-button-icon-size);-webkit-tap-highlight-color:rgba(0,0,0,0)}.mat-mdc-icon-button svg{vertical-align:baseline}.mat-mdc-icon-button[disabled],.mat-mdc-icon-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-icon-button-disabled-icon-color)}.mat-mdc-icon-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-icon-button .mat-mdc-button-ripple,.mat-mdc-icon-button .mat-mdc-button-persistent-ripple,.mat-mdc-icon-button .mat-mdc-button-persistent-ripple::before{top:0;left:0;right:0;bottom:0;position:absolute;pointer-events:none;border-radius:inherit}.mat-mdc-icon-button .mat-mdc-button-ripple{overflow:hidden}.mat-mdc-icon-button .mat-mdc-button-persistent-ripple::before{content:"";opacity:0}.mat-mdc-icon-button .mdc-button__label{z-index:1}.mat-mdc-icon-button .mat-mdc-focus-indicator{top:0;left:0;right:0;bottom:0;position:absolute}.mat-mdc-icon-button:focus .mat-mdc-focus-indicator::before{content:""}.mat-mdc-icon-button .mat-ripple-element{background-color:var(--mat-icon-button-ripple-color)}.mat-mdc-icon-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-icon-button-state-layer-color)}.mat-mdc-icon-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-icon-button-disabled-state-layer-color)}.mat-mdc-icon-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-icon-button-hover-state-layer-opacity)}.mat-mdc-icon-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-icon-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-icon-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-icon-button-focus-state-layer-opacity)}.mat-mdc-icon-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-icon-button-pressed-state-layer-opacity)}.mat-mdc-icon-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:50%;width:48px;transform:translate(-50%, -50%);display:var(--mat-icon-button-touch-target-display)}.mat-mdc-icon-button._mat-animation-noopable{transition:none !important;animation:none !important}.mat-mdc-icon-button .mat-mdc-button-persistent-ripple{border-radius:50%}.mat-mdc-icon-button.mat-unthemed:not(.mdc-ripple-upgraded):focus::before,.mat-mdc-icon-button.mat-primary:not(.mdc-ripple-upgraded):focus::before,.mat-mdc-icon-button.mat-accent:not(.mdc-ripple-upgraded):focus::before,.mat-mdc-icon-button.mat-warn:not(.mdc-ripple-upgraded):focus::before{background:rgba(0,0,0,0);opacity:1}',kg=new C("MAT_BUTTON_CONFIG");var Tg=[{attribute:"mat-button",mdcClasses:["mdc-button","mat-mdc-button"]},{attribute:"mat-flat-button",mdcClasses:["mdc-button","mdc-button--unelevated","mat-mdc-unelevated-button"]},{attribute:"mat-raised-button",mdcClasses:["mdc-button","mdc-button--raised","mat-mdc-raised-button"]},{attribute:"mat-stroked-button",mdcClasses:["mdc-button","mdc-button--outlined","mat-mdc-outlined-button"]},{attribute:"mat-fab",mdcClasses:["mdc-fab","mat-mdc-fab"]},{attribute:"mat-mini-fab",mdcClasses:["mdc-fab","mdc-fab--mini","mat-mdc-mini-fab"]},{attribute:"mat-icon-button",mdcClasses:["mdc-icon-button","mat-mdc-icon-button"]}],Ag=(()=>{let t=class t{get ripple(){return this._rippleLoader?.getRipple(this._elementRef.nativeElement)}set ripple(e){this._rippleLoader?.attachRipple(this._elementRef.nativeElement,e)}get disableRipple(){return this._disableRipple}set disableRipple(e){this._disableRipple=e,this._updateRippleDisabled()}get disabled(){return this._disabled}set disabled(e){this._disabled=e,this._updateRippleDisabled()}constructor(e,i,r,s){this._elementRef=e,this._platform=i,this._ngZone=r,this._animationMode=s,this._focusMonitor=g(wn),this._rippleLoader=g(Od),this._isFab=!1,this._disableRipple=!1,this._disabled=!1;let a=g(kg,{optional:!0}),l=e.nativeElement,c=l.classList;this.disabledInteractive=a?.disabledInteractive??!1,this._rippleLoader?.configureRipple(l,{className:"mat-mdc-button-ripple"});for(let{attribute:d,mdcClasses:h}of Tg)l.hasAttribute(d)&&c.add(...h)}ngAfterViewInit(){this._focusMonitor.monitor(this._elementRef,!0)}ngOnDestroy(){this._focusMonitor.stopMonitoring(this._elementRef),this._rippleLoader?.destroyRipple(this._elementRef.nativeElement)}focus(e="program",i){e?this._focusMonitor.focusVia(this._elementRef.nativeElement,e,i):this._elementRef.nativeElement.focus(i)}_getAriaDisabled(){return this.ariaDisabled!=null?this.ariaDisabled:this.disabled&&this.disabledInteractive?!0:null}_getDisabledAttribute(){return this.disabledInteractive||!this.disabled?null:!0}_updateRippleDisabled(){this._rippleLoader?.setDisabled(this._elementRef.nativeElement,this.disableRipple||this.disabled)}};t.\u0275fac=function(i){Ie()},t.\u0275dir=D({type:t,inputs:{color:"color",disableRipple:[y.HasDecoratorInputTransform,"disableRipple","disableRipple",W],disabled:[y.HasDecoratorInputTransform,"disabled","disabled",W],ariaDisabled:[y.HasDecoratorInputTransform,"aria-disabled","ariaDisabled",W],disabledInteractive:[y.HasDecoratorInputTransform,"disabledInteractive","disabledInteractive",W]},features:[nt]});let n=t;return n})();var lu=(()=>{let t=class t extends Ag{constructor(e,i,r,s){super(e,i,r,s),this._haltDisabledEvents=a=>{this.disabled&&(a.preventDefault(),a.stopImmediatePropagation())}}ngOnInit(){this._ngZone.runOutsideAngular(()=>{this._elementRef.nativeElement.addEventListener("click",this._haltDisabledEvents)})}ngOnDestroy(){super.ngOnDestroy(),this._elementRef.nativeElement.removeEventListener("click",this._haltDisabledEvents)}_getAriaDisabled(){return this.ariaDisabled==null?this.disabled:this.ariaDisabled}};t.\u0275fac=function(i){Ie()},t.\u0275dir=D({type:t,inputs:{tabIndex:[y.HasDecoratorInputTransform,"tabIndex","tabIndex",e=>e==null?void 0:nl(e)]},features:[nt,U]});let n=t;return n})();var cu=(()=>{let t=class t extends lu{constructor(e,i,r,s){super(e,i,r,s)}};t.\u0275fac=function(i){return new(i||t)(u(A),u(J),u(I),u(Bt,8))},t.\u0275cmp=P({type:t,selectors:[["a","mat-button",""],["a","mat-raised-button",""],["a","mat-flat-button",""],["a","mat-stroked-button",""]],hostVars:15,hostBindings:function(i,r){i&2&&(ft("disabled",r._getDisabledAttribute())("tabindex",r.disabled&&!r.disabledInteractive?-1:r.tabIndex)("aria-disabled",r._getDisabledAttribute()),Jt(r.color?"mat-"+r.color:""),st("mat-mdc-button-disabled",r.disabled)("mat-mdc-button-disabled-interactive",r.disabledInteractive)("_mat-animation-noopable",r._animationMode==="NoopAnimations")("mat-unthemed",!r.color)("mat-mdc-button-base",!0))},exportAs:["matButton","matAnchor"],standalone:!0,features:[U,tt],attrs:Cg,ngContentSelectors:Eg,decls:7,vars:4,consts:[[1,"mat-mdc-button-persistent-ripple"],[1,"mdc-button__label"],[1,"mat-mdc-focus-indicator"],[1,"mat-mdc-button-touch-target"]],template:function(i,r){i&1&&(pt(Dg),H(0,"span",0),K(1),x(2,"span",1),K(3,1),_(),K(4,2),H(5,"span",2)(6,"span",3)),i&2&&st("mdc-button__ripple",!r._isFab)("mdc-fab__ripple",r._isFab)},styles:[Sg,au],encapsulation:2,changeDetection:0});let n=t;return n})();var du=(()=>{let t=class t extends lu{constructor(e,i,r,s){super(e,i,r,s)}};t.\u0275fac=function(i){return new(i||t)(u(A),u(J),u(I),u(Bt,8))},t.\u0275cmp=P({type:t,selectors:[["a","mat-icon-button",""]],hostVars:15,hostBindings:function(i,r){i&2&&(ft("disabled",r._getDisabledAttribute())("tabindex",r.disabled&&!r.disabledInteractive?-1:r.tabIndex)("aria-disabled",r._getDisabledAttribute()),Jt(r.color?"mat-"+r.color:""),st("mat-mdc-button-disabled",r.disabled)("mat-mdc-button-disabled-interactive",r.disabledInteractive)("_mat-animation-noopable",r._animationMode==="NoopAnimations")("mat-unthemed",!r.color)("mat-mdc-button-base",!0))},exportAs:["matButton","matAnchor"],standalone:!0,features:[U,tt],attrs:Ig,ngContentSelectors:Rg,decls:4,vars:0,consts:[[1,"mat-mdc-button-persistent-ripple","mdc-icon-button__ripple"],[1,"mat-mdc-focus-indicator"],[1,"mat-mdc-button-touch-target"]],template:function(i,r){i&1&&(pt(),H(0,"span",0),K(1),H(2,"span",1)(3,"span",2))},styles:[Mg,au],encapsulation:2,changeDetection:0});let n=t;return n})(),uu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,Ko,Y]});let n=t;return n})();var En=class{attach(t){return this._attachedHost=t,t.attach(this)}detach(){let t=this._attachedHost;t!=null&&(this._attachedHost=null,t.detach())}get isAttached(){return this._attachedHost!=null}setAttachedHost(t){this._attachedHost=t}},fa=class extends En{constructor(t,o,e,i,r){super(),this.component=t,this.viewContainerRef=o,this.injector=e,this.componentFactoryResolver=i,this.projectableNodes=r}},Ci=class extends En{constructor(t,o,e,i){super(),this.templateRef=t,this.viewContainerRef=o,this.context=e,this.injector=i}get origin(){return this.templateRef.elementRef}attach(t,o=this.context){return this.context=o,super.attach(t)}detach(){return this.context=void 0,super.detach()}},pa=class extends En{constructor(t){super(),this.element=t instanceof A?t.nativeElement:t}},ga=class{constructor(){this._isDisposed=!1,this.attachDomPortal=null}hasAttached(){return!!this._attachedPortal}attach(t){if(t instanceof fa)return this._attachedPortal=t,this.attachComponentPortal(t);if(t instanceof Ci)return this._attachedPortal=t,this.attachTemplatePortal(t);if(this.attachDomPortal&&t instanceof pa)return this._attachedPortal=t,this.attachDomPortal(t)}detach(){this._attachedPortal&&(this._attachedPortal.setAttachedHost(null),this._attachedPortal=null),this._invokeDisposeFn()}dispose(){this.hasAttached()&&this.detach(),this._invokeDisposeFn(),this._isDisposed=!0}setDisposeFn(t){this._disposeFn=t}_invokeDisposeFn(){this._disposeFn&&(this._disposeFn(),this._disposeFn=null)}};var Sn=class extends ga{constructor(t,o,e,i,r){super(),this.outletElement=t,this._componentFactoryResolver=o,this._appRef=e,this._defaultInjector=i,this.attachDomPortal=s=>{this._document;let a=s.element;a.parentNode;let l=this._document.createComment("dom-portal");a.parentNode.insertBefore(l,a),this.outletElement.appendChild(a),this._attachedPortal=s,super.setDisposeFn(()=>{l.parentNode&&l.parentNode.replaceChild(a,l)})},this._document=r}attachComponentPortal(t){let e=(t.componentFactoryResolver||this._componentFactoryResolver).resolveComponentFactory(t.component),i;return t.viewContainerRef?(i=t.viewContainerRef.createComponent(e,t.viewContainerRef.length,t.injector||t.viewContainerRef.injector,t.projectableNodes||void 0),this.setDisposeFn(()=>i.destroy())):(i=e.create(t.injector||this._defaultInjector||Kt.NULL),this._appRef.attachView(i.hostView),this.setDisposeFn(()=>{this._appRef.viewCount>0&&this._appRef.detachView(i.hostView),i.destroy()})),this.outletElement.appendChild(this._getComponentRootNode(i)),this._attachedPortal=t,i}attachTemplatePortal(t){let o=t.viewContainerRef,e=o.createEmbeddedView(t.templateRef,t.context,{injector:t.injector});return e.rootNodes.forEach(i=>this.outletElement.appendChild(i)),e.detectChanges(),this.setDisposeFn(()=>{let i=o.indexOf(e);i!==-1&&o.remove(i)}),this._attachedPortal=t,e}dispose(){super.dispose(),this.outletElement.remove()}_getComponentRootNode(t){return t.hostView.rootNodes[0]}};var hu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({});let n=t;return n})();var mu=id(),ba=class{constructor(t,o){this._viewportRuler=t,this._previousHTMLStyles={top:"",left:""},this._isEnabled=!1,this._document=o}attach(){}enable(){if(this._canBeEnabled()){let t=this._document.documentElement;this._previousScrollPosition=this._viewportRuler.getViewportScrollPosition(),this._previousHTMLStyles.left=t.style.left||"",this._previousHTMLStyles.top=t.style.top||"",t.style.left=ct(-this._previousScrollPosition.left),t.style.top=ct(-this._previousScrollPosition.top),t.classList.add("cdk-global-scrollblock"),this._isEnabled=!0}}disable(){if(this._isEnabled){let t=this._document.documentElement,o=this._document.body,e=t.style,i=o.style,r=e.scrollBehavior||"",s=i.scrollBehavior||"";this._isEnabled=!1,e.left=this._previousHTMLStyles.left,e.top=this._previousHTMLStyles.top,t.classList.remove("cdk-global-scrollblock"),mu&&(e.scrollBehavior=i.scrollBehavior="auto"),window.scroll(this._previousScrollPosition.left,this._previousScrollPosition.top),mu&&(e.scrollBehavior=r,i.scrollBehavior=s)}}_canBeEnabled(){if(this._document.documentElement.classList.contains("cdk-global-scrollblock")||this._isEnabled)return!1;let o=this._document.body,e=this._viewportRuler.getViewportSize();return o.scrollHeight>e.height||o.scrollWidth>e.width}};var va=class{constructor(t,o,e,i){this._scrollDispatcher=t,this._ngZone=o,this._viewportRuler=e,this._config=i,this._scrollSubscription=null,this._detach=()=>{this.disable(),this._overlayRef.hasAttached()&&this._ngZone.run(()=>this._overlayRef.detach())}}attach(t){this._overlayRef,this._overlayRef=t}enable(){if(this._scrollSubscription)return;let t=this._scrollDispatcher.scrolled(0).pipe(dt(o=>!o||!this._overlayRef.overlayElement.contains(o.getElementRef().nativeElement)));this._config&&this._config.threshold&&this._config.threshold>1?(this._initialScrollPosition=this._viewportRuler.getViewportScrollPosition().top,this._scrollSubscription=t.subscribe(()=>{let o=this._viewportRuler.getViewportScrollPosition().top;Math.abs(o-this._initialScrollPosition)>this._config.threshold?this._detach():this._overlayRef.updatePosition()})):this._scrollSubscription=t.subscribe(this._detach)}disable(){this._scrollSubscription&&(this._scrollSubscription.unsubscribe(),this._scrollSubscription=null)}detach(){this.disable(),this._overlayRef=null}},ir=class{enable(){}disable(){}attach(){}};function _a(n,t){return t.some(o=>{let e=n.bottom<o.top,i=n.top>o.bottom,r=n.right<o.left,s=n.left>o.right;return e||i||r||s})}function fu(n,t){return t.some(o=>{let e=n.top<o.top,i=n.bottom>o.bottom,r=n.left<o.left,s=n.right>o.right;return e||i||r||s})}var ya=class{constructor(t,o,e,i){this._scrollDispatcher=t,this._viewportRuler=o,this._ngZone=e,this._config=i,this._scrollSubscription=null}attach(t){this._overlayRef,this._overlayRef=t}enable(){if(!this._scrollSubscription){let t=this._config?this._config.scrollThrottle:0;this._scrollSubscription=this._scrollDispatcher.scrolled(t).subscribe(()=>{if(this._overlayRef.updatePosition(),this._config&&this._config.autoClose){let o=this._overlayRef.overlayElement.getBoundingClientRect(),{width:e,height:i}=this._viewportRuler.getViewportSize();_a(o,[{width:e,height:i,bottom:i,right:e,top:0,left:0}])&&(this.disable(),this._ngZone.run(()=>this._overlayRef.detach()))}})}}disable(){this._scrollSubscription&&(this._scrollSubscription.unsubscribe(),this._scrollSubscription=null)}detach(){this.disable(),this._overlayRef=null}},Og=(()=>{let t=class t{constructor(e,i,r,s){this._scrollDispatcher=e,this._viewportRuler=i,this._ngZone=r,this.noop=()=>new ir,this.close=a=>new va(this._scrollDispatcher,this._ngZone,this._viewportRuler,a),this.block=()=>new ba(this._viewportRuler,this._document),this.reposition=a=>new ya(this._scrollDispatcher,this._viewportRuler,this._ngZone,a),this._document=s}};t.\u0275fac=function(i){return new(i||t)(m(sd),m(bn),m(I),m(T))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),In=class{constructor(t){if(this.scrollStrategy=new ir,this.panelClass="",this.hasBackdrop=!1,this.backdropClass="cdk-overlay-dark-backdrop",this.disposeOnNavigation=!1,t){let o=Object.keys(t);for(let e of o)t[e]!==void 0&&(this[e]=t[e])}}};var xa=class{constructor(t,o){this.connectionPair=t,this.scrollableViewProperties=o}};var _u=(()=>{let t=class t{constructor(e){this._attachedOverlays=[],this._document=e}ngOnDestroy(){this.detach()}add(e){this.remove(e),this._attachedOverlays.push(e)}remove(e){let i=this._attachedOverlays.indexOf(e);i>-1&&this._attachedOverlays.splice(i,1),this._attachedOverlays.length===0&&this.detach()}};t.\u0275fac=function(i){return new(i||t)(m(T))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),Ng=(()=>{let t=class t extends _u{constructor(e,i){super(e),this._ngZone=i,this._keydownListener=r=>{let s=this._attachedOverlays;for(let a=s.length-1;a>-1;a--)if(s[a]._keydownEvents.observers.length>0){let l=s[a]._keydownEvents;this._ngZone?this._ngZone.run(()=>l.next(r)):l.next(r);break}}}add(e){super.add(e),this._isAttached||(this._ngZone?this._ngZone.runOutsideAngular(()=>this._document.body.addEventListener("keydown",this._keydownListener)):this._document.body.addEventListener("keydown",this._keydownListener),this._isAttached=!0)}detach(){this._isAttached&&(this._document.body.removeEventListener("keydown",this._keydownListener),this._isAttached=!1)}};t.\u0275fac=function(i){return new(i||t)(m(T),m(I,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),Pg=(()=>{let t=class t extends _u{constructor(e,i,r){super(e),this._platform=i,this._ngZone=r,this._cursorStyleIsSet=!1,this._pointerDownListener=s=>{this._pointerDownEventTarget=Lt(s)},this._clickListener=s=>{let a=Lt(s),l=s.type==="click"&&this._pointerDownEventTarget?this._pointerDownEventTarget:a;this._pointerDownEventTarget=null;let c=this._attachedOverlays.slice();for(let d=c.length-1;d>-1;d--){let h=c[d];if(h._outsidePointerEvents.observers.length<1||!h.hasAttached())continue;if(h.overlayElement.contains(a)||h.overlayElement.contains(l))break;let f=h._outsidePointerEvents;this._ngZone?this._ngZone.run(()=>f.next(s)):f.next(s)}}}add(e){if(super.add(e),!this._isAttached){let i=this._document.body;this._ngZone?this._ngZone.runOutsideAngular(()=>this._addEventListeners(i)):this._addEventListeners(i),this._platform.IOS&&!this._cursorStyleIsSet&&(this._cursorOriginalValue=i.style.cursor,i.style.cursor="pointer",this._cursorStyleIsSet=!0),this._isAttached=!0}}detach(){if(this._isAttached){let e=this._document.body;e.removeEventListener("pointerdown",this._pointerDownListener,!0),e.removeEventListener("click",this._clickListener,!0),e.removeEventListener("auxclick",this._clickListener,!0),e.removeEventListener("contextmenu",this._clickListener,!0),this._platform.IOS&&this._cursorStyleIsSet&&(e.style.cursor=this._cursorOriginalValue,this._cursorStyleIsSet=!1),this._isAttached=!1}}_addEventListeners(e){e.addEventListener("pointerdown",this._pointerDownListener,!0),e.addEventListener("click",this._clickListener,!0),e.addEventListener("auxclick",this._clickListener,!0),e.addEventListener("contextmenu",this._clickListener,!0)}};t.\u0275fac=function(i){return new(i||t)(m(T),m(J),m(I,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),yu=(()=>{let t=class t{constructor(e,i){this._platform=i,this._document=e}ngOnDestroy(){this._containerElement?.remove()}getContainerElement(){return this._containerElement||this._createContainer(),this._containerElement}_createContainer(){let e="cdk-overlay-container";if(this._platform.isBrowser||gn()){let r=this._document.querySelectorAll(`.${e}[platform="server"], .${e}[platform="test"]`);for(let s=0;s<r.length;s++)r[s].remove()}let i=this._document.createElement("div");i.classList.add(e),gn()?i.setAttribute("platform","test"):this._platform.isBrowser||i.setAttribute("platform","server"),this._document.body.appendChild(i),this._containerElement=i}};t.\u0275fac=function(i){return new(i||t)(m(T),m(J))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),wa=class{constructor(t,o,e,i,r,s,a,l,c,d=!1){this._portalOutlet=t,this._host=o,this._pane=e,this._config=i,this._ngZone=r,this._keyboardDispatcher=s,this._document=a,this._location=l,this._outsideClickDispatcher=c,this._animationsDisabled=d,this._backdropElement=null,this._backdropClick=new N,this._attachments=new N,this._detachments=new N,this._locationChanges=St.EMPTY,this._backdropClickHandler=h=>this._backdropClick.next(h),this._backdropTransitionendHandler=h=>{this._disposeBackdrop(h.target)},this._keydownEvents=new N,this._outsidePointerEvents=new N,i.scrollStrategy&&(this._scrollStrategy=i.scrollStrategy,this._scrollStrategy.attach(this)),this._positionStrategy=i.positionStrategy}get overlayElement(){return this._pane}get backdropElement(){return this._backdropElement}get hostElement(){return this._host}attach(t){!this._host.parentElement&&this._previousHostParent&&this._previousHostParent.appendChild(this._host);let o=this._portalOutlet.attach(t);return this._positionStrategy&&this._positionStrategy.attach(this),this._updateStackingOrder(),this._updateElementSize(),this._updateElementDirection(),this._scrollStrategy&&this._scrollStrategy.enable(),this._ngZone.onStable.pipe(ut(1)).subscribe(()=>{this.hasAttached()&&this.updatePosition()}),this._togglePointerEvents(!0),this._config.hasBackdrop&&this._attachBackdrop(),this._config.panelClass&&this._toggleClasses(this._pane,this._config.panelClass,!0),this._attachments.next(),this._keyboardDispatcher.add(this),this._config.disposeOnNavigation&&(this._locationChanges=this._location.subscribe(()=>this.dispose())),this._outsideClickDispatcher.add(this),typeof o?.onDestroy=="function"&&o.onDestroy(()=>{this.hasAttached()&&this._ngZone.runOutsideAngular(()=>Promise.resolve().then(()=>this.detach()))}),o}detach(){if(!this.hasAttached())return;this.detachBackdrop(),this._togglePointerEvents(!1),this._positionStrategy&&this._positionStrategy.detach&&this._positionStrategy.detach(),this._scrollStrategy&&this._scrollStrategy.disable();let t=this._portalOutlet.detach();return this._detachments.next(),this._keyboardDispatcher.remove(this),this._detachContentWhenStable(),this._locationChanges.unsubscribe(),this._outsideClickDispatcher.remove(this),t}dispose(){let t=this.hasAttached();this._positionStrategy&&this._positionStrategy.dispose(),this._disposeScrollStrategy(),this._disposeBackdrop(this._backdropElement),this._locationChanges.unsubscribe(),this._keyboardDispatcher.remove(this),this._portalOutlet.dispose(),this._attachments.complete(),this._backdropClick.complete(),this._keydownEvents.complete(),this._outsidePointerEvents.complete(),this._outsideClickDispatcher.remove(this),this._host?.remove(),this._previousHostParent=this._pane=this._host=null,t&&this._detachments.next(),this._detachments.complete()}hasAttached(){return this._portalOutlet.hasAttached()}backdropClick(){return this._backdropClick}attachments(){return this._attachments}detachments(){return this._detachments}keydownEvents(){return this._keydownEvents}outsidePointerEvents(){return this._outsidePointerEvents}getConfig(){return this._config}updatePosition(){this._positionStrategy&&this._positionStrategy.apply()}updatePositionStrategy(t){t!==this._positionStrategy&&(this._positionStrategy&&this._positionStrategy.dispose(),this._positionStrategy=t,this.hasAttached()&&(t.attach(this),this.updatePosition()))}updateSize(t){this._config=p(p({},this._config),t),this._updateElementSize()}setDirection(t){this._config=q(p({},this._config),{direction:t}),this._updateElementDirection()}addPanelClass(t){this._pane&&this._toggleClasses(this._pane,t,!0)}removePanelClass(t){this._pane&&this._toggleClasses(this._pane,t,!1)}getDirection(){let t=this._config.direction;return t?typeof t=="string"?t:t.value:"ltr"}updateScrollStrategy(t){t!==this._scrollStrategy&&(this._disposeScrollStrategy(),this._scrollStrategy=t,this.hasAttached()&&(t.attach(this),t.enable()))}_updateElementDirection(){this._host.setAttribute("dir",this.getDirection())}_updateElementSize(){if(!this._pane)return;let t=this._pane.style;t.width=ct(this._config.width),t.height=ct(this._config.height),t.minWidth=ct(this._config.minWidth),t.minHeight=ct(this._config.minHeight),t.maxWidth=ct(this._config.maxWidth),t.maxHeight=ct(this._config.maxHeight)}_togglePointerEvents(t){this._pane.style.pointerEvents=t?"":"none"}_attachBackdrop(){let t="cdk-overlay-backdrop-showing";this._backdropElement=this._document.createElement("div"),this._backdropElement.classList.add("cdk-overlay-backdrop"),this._animationsDisabled&&this._backdropElement.classList.add("cdk-overlay-backdrop-noop-animation"),this._config.backdropClass&&this._toggleClasses(this._backdropElement,this._config.backdropClass,!0),this._host.parentElement.insertBefore(this._backdropElement,this._host),this._backdropElement.addEventListener("click",this._backdropClickHandler),!this._animationsDisabled&&typeof requestAnimationFrame<"u"?this._ngZone.runOutsideAngular(()=>{requestAnimationFrame(()=>{this._backdropElement&&this._backdropElement.classList.add(t)})}):this._backdropElement.classList.add(t)}_updateStackingOrder(){this._host.nextSibling&&this._host.parentNode.appendChild(this._host)}detachBackdrop(){let t=this._backdropElement;if(t){if(this._animationsDisabled){this._disposeBackdrop(t);return}t.classList.remove("cdk-overlay-backdrop-showing"),this._ngZone.runOutsideAngular(()=>{t.addEventListener("transitionend",this._backdropTransitionendHandler)}),t.style.pointerEvents="none",this._backdropTimeout=this._ngZone.runOutsideAngular(()=>setTimeout(()=>{this._disposeBackdrop(t)},500))}}_toggleClasses(t,o,e){let i=_i(o||[]).filter(r=>!!r);i.length&&(e?t.classList.add(...i):t.classList.remove(...i))}_detachContentWhenStable(){this._ngZone.runOutsideAngular(()=>{let t=this._ngZone.onStable.pipe(mt(qt(this._attachments,this._detachments))).subscribe(()=>{(!this._pane||!this._host||this._pane.children.length===0)&&(this._pane&&this._config.panelClass&&this._toggleClasses(this._pane,this._config.panelClass,!1),this._host&&this._host.parentElement&&(this._previousHostParent=this._host.parentElement,this._host.remove()),t.unsubscribe())})})}_disposeScrollStrategy(){let t=this._scrollStrategy;t&&(t.disable(),t.detach&&t.detach())}_disposeBackdrop(t){t&&(t.removeEventListener("click",this._backdropClickHandler),t.removeEventListener("transitionend",this._backdropTransitionendHandler),t.remove(),this._backdropElement===t&&(this._backdropElement=null)),this._backdropTimeout&&(clearTimeout(this._backdropTimeout),this._backdropTimeout=void 0)}},pu="cdk-overlay-connected-position-bounding-box",Lg=/([A-Za-z%]+)$/,Ca=class{get positions(){return this._preferredPositions}constructor(t,o,e,i,r){this._viewportRuler=o,this._document=e,this._platform=i,this._overlayContainer=r,this._lastBoundingBoxSize={width:0,height:0},this._isPushed=!1,this._canPush=!0,this._growAfterOpen=!1,this._hasFlexibleDimensions=!0,this._positionLocked=!1,this._viewportMargin=0,this._scrollables=[],this._preferredPositions=[],this._positionChanges=new N,this._resizeSubscription=St.EMPTY,this._offsetX=0,this._offsetY=0,this._appliedPanelClasses=[],this.positionChanges=this._positionChanges,this.setOrigin(t)}attach(t){this._overlayRef&&this._overlayRef,this._validatePositions(),t.hostElement.classList.add(pu),this._overlayRef=t,this._boundingBox=t.hostElement,this._pane=t.overlayElement,this._isDisposed=!1,this._isInitialRender=!0,this._lastPosition=null,this._resizeSubscription.unsubscribe(),this._resizeSubscription=this._viewportRuler.change().subscribe(()=>{this._isInitialRender=!0,this.apply()})}apply(){if(this._isDisposed||!this._platform.isBrowser)return;if(!this._isInitialRender&&this._positionLocked&&this._lastPosition){this.reapplyLastPosition();return}this._clearPanelClasses(),this._resetOverlayElementStyles(),this._resetBoundingBoxStyles(),this._viewportRect=this._getNarrowedViewportRect(),this._originRect=this._getOriginRect(),this._overlayRect=this._pane.getBoundingClientRect(),this._containerRect=this._overlayContainer.getContainerElement().getBoundingClientRect();let t=this._originRect,o=this._overlayRect,e=this._viewportRect,i=this._containerRect,r=[],s;for(let a of this._preferredPositions){let l=this._getOriginPoint(t,i,a),c=this._getOverlayPoint(l,o,a),d=this._getOverlayFit(c,o,e,a);if(d.isCompletelyWithinViewport){this._isPushed=!1,this._applyPosition(a,l);return}if(this._canFitWithFlexibleDimensions(d,c,e)){r.push({position:a,origin:l,overlayRect:o,boundingBoxRect:this._calculateBoundingBoxRect(l,a)});continue}(!s||s.overlayFit.visibleArea<d.visibleArea)&&(s={overlayFit:d,overlayPoint:c,originPoint:l,position:a,overlayRect:o})}if(r.length){let a=null,l=-1;for(let c of r){let d=c.boundingBoxRect.width*c.boundingBoxRect.height*(c.position.weight||1);d>l&&(l=d,a=c)}this._isPushed=!1,this._applyPosition(a.position,a.origin);return}if(this._canPush){this._isPushed=!0,this._applyPosition(s.position,s.originPoint);return}this._applyPosition(s.position,s.originPoint)}detach(){this._clearPanelClasses(),this._lastPosition=null,this._previousPushAmount=null,this._resizeSubscription.unsubscribe()}dispose(){this._isDisposed||(this._boundingBox&&He(this._boundingBox.style,{top:"",left:"",right:"",bottom:"",height:"",width:"",alignItems:"",justifyContent:""}),this._pane&&this._resetOverlayElementStyles(),this._overlayRef&&this._overlayRef.hostElement.classList.remove(pu),this.detach(),this._positionChanges.complete(),this._overlayRef=this._boundingBox=null,this._isDisposed=!0)}reapplyLastPosition(){if(this._isDisposed||!this._platform.isBrowser)return;let t=this._lastPosition;if(t){this._originRect=this._getOriginRect(),this._overlayRect=this._pane.getBoundingClientRect(),this._viewportRect=this._getNarrowedViewportRect(),this._containerRect=this._overlayContainer.getContainerElement().getBoundingClientRect();let o=this._getOriginPoint(this._originRect,this._containerRect,t);this._applyPosition(t,o)}else this.apply()}withScrollableContainers(t){return this._scrollables=t,this}withPositions(t){return this._preferredPositions=t,t.indexOf(this._lastPosition)===-1&&(this._lastPosition=null),this._validatePositions(),this}withViewportMargin(t){return this._viewportMargin=t,this}withFlexibleDimensions(t=!0){return this._hasFlexibleDimensions=t,this}withGrowAfterOpen(t=!0){return this._growAfterOpen=t,this}withPush(t=!0){return this._canPush=t,this}withLockedPosition(t=!0){return this._positionLocked=t,this}setOrigin(t){return this._origin=t,this}withDefaultOffsetX(t){return this._offsetX=t,this}withDefaultOffsetY(t){return this._offsetY=t,this}withTransformOriginOn(t){return this._transformOriginSelector=t,this}_getOriginPoint(t,o,e){let i;if(e.originX=="center")i=t.left+t.width/2;else{let s=this._isRtl()?t.right:t.left,a=this._isRtl()?t.left:t.right;i=e.originX=="start"?s:a}o.left<0&&(i-=o.left);let r;return e.originY=="center"?r=t.top+t.height/2:r=e.originY=="top"?t.top:t.bottom,o.top<0&&(r-=o.top),{x:i,y:r}}_getOverlayPoint(t,o,e){let i;e.overlayX=="center"?i=-o.width/2:e.overlayX==="start"?i=this._isRtl()?-o.width:0:i=this._isRtl()?0:-o.width;let r;return e.overlayY=="center"?r=-o.height/2:r=e.overlayY=="top"?0:-o.height,{x:t.x+i,y:t.y+r}}_getOverlayFit(t,o,e,i){let r=bu(o),{x:s,y:a}=t,l=this._getOffset(i,"x"),c=this._getOffset(i,"y");l&&(s+=l),c&&(a+=c);let d=0-s,h=s+r.width-e.width,f=0-a,w=a+r.height-e.height,j=this._subtractOverflows(r.width,d,h),z=this._subtractOverflows(r.height,f,w),k=j*z;return{visibleArea:k,isCompletelyWithinViewport:r.width*r.height===k,fitsInViewportVertically:z===r.height,fitsInViewportHorizontally:j==r.width}}_canFitWithFlexibleDimensions(t,o,e){if(this._hasFlexibleDimensions){let i=e.bottom-o.y,r=e.right-o.x,s=gu(this._overlayRef.getConfig().minHeight),a=gu(this._overlayRef.getConfig().minWidth),l=t.fitsInViewportVertically||s!=null&&s<=i,c=t.fitsInViewportHorizontally||a!=null&&a<=r;return l&&c}return!1}_pushOverlayOnScreen(t,o,e){if(this._previousPushAmount&&this._positionLocked)return{x:t.x+this._previousPushAmount.x,y:t.y+this._previousPushAmount.y};let i=bu(o),r=this._viewportRect,s=Math.max(t.x+i.width-r.width,0),a=Math.max(t.y+i.height-r.height,0),l=Math.max(r.top-e.top-t.y,0),c=Math.max(r.left-e.left-t.x,0),d=0,h=0;return i.width<=r.width?d=c||-s:d=t.x<this._viewportMargin?r.left-e.left-t.x:0,i.height<=r.height?h=l||-a:h=t.y<this._viewportMargin?r.top-e.top-t.y:0,this._previousPushAmount={x:d,y:h},{x:t.x+d,y:t.y+h}}_applyPosition(t,o){if(this._setTransformOrigin(t),this._setOverlayElementStyles(o,t),this._setBoundingBoxStyles(o,t),t.panelClass&&this._addPanelClasses(t.panelClass),this._positionChanges.observers.length){let e=this._getScrollVisibility();if(t!==this._lastPosition||!this._lastScrollVisibility||!jg(this._lastScrollVisibility,e)){let i=new xa(t,e);this._positionChanges.next(i)}this._lastScrollVisibility=e}this._lastPosition=t,this._isInitialRender=!1}_setTransformOrigin(t){if(!this._transformOriginSelector)return;let o=this._boundingBox.querySelectorAll(this._transformOriginSelector),e,i=t.overlayY;t.overlayX==="center"?e="center":this._isRtl()?e=t.overlayX==="start"?"right":"left":e=t.overlayX==="start"?"left":"right";for(let r=0;r<o.length;r++)o[r].style.transformOrigin=`${e} ${i}`}_calculateBoundingBoxRect(t,o){let e=this._viewportRect,i=this._isRtl(),r,s,a;if(o.overlayY==="top")s=t.y,r=e.height-s+this._viewportMargin;else if(o.overlayY==="bottom")a=e.height-t.y+this._viewportMargin*2,r=e.height-a+this._viewportMargin;else{let w=Math.min(e.bottom-t.y+e.top,t.y),j=this._lastBoundingBoxSize.height;r=w*2,s=t.y-w,r>j&&!this._isInitialRender&&!this._growAfterOpen&&(s=t.y-j/2)}let l=o.overlayX==="start"&&!i||o.overlayX==="end"&&i,c=o.overlayX==="end"&&!i||o.overlayX==="start"&&i,d,h,f;if(c)f=e.width-t.x+this._viewportMargin*2,d=t.x-this._viewportMargin;else if(l)h=t.x,d=e.right-t.x;else{let w=Math.min(e.right-t.x+e.left,t.x),j=this._lastBoundingBoxSize.width;d=w*2,h=t.x-w,d>j&&!this._isInitialRender&&!this._growAfterOpen&&(h=t.x-j/2)}return{top:s,left:h,bottom:a,right:f,width:d,height:r}}_setBoundingBoxStyles(t,o){let e=this._calculateBoundingBoxRect(t,o);!this._isInitialRender&&!this._growAfterOpen&&(e.height=Math.min(e.height,this._lastBoundingBoxSize.height),e.width=Math.min(e.width,this._lastBoundingBoxSize.width));let i={};if(this._hasExactPosition())i.top=i.left="0",i.bottom=i.right=i.maxHeight=i.maxWidth="",i.width=i.height="100%";else{let r=this._overlayRef.getConfig().maxHeight,s=this._overlayRef.getConfig().maxWidth;i.height=ct(e.height),i.top=ct(e.top),i.bottom=ct(e.bottom),i.width=ct(e.width),i.left=ct(e.left),i.right=ct(e.right),o.overlayX==="center"?i.alignItems="center":i.alignItems=o.overlayX==="end"?"flex-end":"flex-start",o.overlayY==="center"?i.justifyContent="center":i.justifyContent=o.overlayY==="bottom"?"flex-end":"flex-start",r&&(i.maxHeight=ct(r)),s&&(i.maxWidth=ct(s))}this._lastBoundingBoxSize=e,He(this._boundingBox.style,i)}_resetBoundingBoxStyles(){He(this._boundingBox.style,{top:"0",left:"0",right:"0",bottom:"0",height:"",width:"",alignItems:"",justifyContent:""})}_resetOverlayElementStyles(){He(this._pane.style,{top:"",left:"",bottom:"",right:"",position:"",transform:""})}_setOverlayElementStyles(t,o){let e={},i=this._hasExactPosition(),r=this._hasFlexibleDimensions,s=this._overlayRef.getConfig();if(i){let d=this._viewportRuler.getViewportScrollPosition();He(e,this._getExactOverlayY(o,t,d)),He(e,this._getExactOverlayX(o,t,d))}else e.position="static";let a="",l=this._getOffset(o,"x"),c=this._getOffset(o,"y");l&&(a+=`translateX(${l}px) `),c&&(a+=`translateY(${c}px)`),e.transform=a.trim(),s.maxHeight&&(i?e.maxHeight=ct(s.maxHeight):r&&(e.maxHeight="")),s.maxWidth&&(i?e.maxWidth=ct(s.maxWidth):r&&(e.maxWidth="")),He(this._pane.style,e)}_getExactOverlayY(t,o,e){let i={top:"",bottom:""},r=this._getOverlayPoint(o,this._overlayRect,t);if(this._isPushed&&(r=this._pushOverlayOnScreen(r,this._overlayRect,e)),t.overlayY==="bottom"){let s=this._document.documentElement.clientHeight;i.bottom=`${s-(r.y+this._overlayRect.height)}px`}else i.top=ct(r.y);return i}_getExactOverlayX(t,o,e){let i={left:"",right:""},r=this._getOverlayPoint(o,this._overlayRect,t);this._isPushed&&(r=this._pushOverlayOnScreen(r,this._overlayRect,e));let s;if(this._isRtl()?s=t.overlayX==="end"?"left":"right":s=t.overlayX==="end"?"right":"left",s==="right"){let a=this._document.documentElement.clientWidth;i.right=`${a-(r.x+this._overlayRect.width)}px`}else i.left=ct(r.x);return i}_getScrollVisibility(){let t=this._getOriginRect(),o=this._pane.getBoundingClientRect(),e=this._scrollables.map(i=>i.getElementRef().nativeElement.getBoundingClientRect());return{isOriginClipped:fu(t,e),isOriginOutsideView:_a(t,e),isOverlayClipped:fu(o,e),isOverlayOutsideView:_a(o,e)}}_subtractOverflows(t,...o){return o.reduce((e,i)=>e-Math.max(i,0),t)}_getNarrowedViewportRect(){let t=this._document.documentElement.clientWidth,o=this._document.documentElement.clientHeight,e=this._viewportRuler.getViewportScrollPosition();return{top:e.top+this._viewportMargin,left:e.left+this._viewportMargin,right:e.left+t-this._viewportMargin,bottom:e.top+o-this._viewportMargin,width:t-2*this._viewportMargin,height:o-2*this._viewportMargin}}_isRtl(){return this._overlayRef.getDirection()==="rtl"}_hasExactPosition(){return!this._hasFlexibleDimensions||this._isPushed}_getOffset(t,o){return o==="x"?t.offsetX==null?this._offsetX:t.offsetX:t.offsetY==null?this._offsetY:t.offsetY}_validatePositions(){}_addPanelClasses(t){this._pane&&_i(t).forEach(o=>{o!==""&&this._appliedPanelClasses.indexOf(o)===-1&&(this._appliedPanelClasses.push(o),this._pane.classList.add(o))})}_clearPanelClasses(){this._pane&&(this._appliedPanelClasses.forEach(t=>{this._pane.classList.remove(t)}),this._appliedPanelClasses=[])}_getOriginRect(){let t=this._origin;if(t instanceof A)return t.nativeElement.getBoundingClientRect();if(t instanceof Element)return t.getBoundingClientRect();let o=t.width||0,e=t.height||0;return{top:t.y,bottom:t.y+e,left:t.x,right:t.x+o,height:e,width:o}}};function He(n,t){for(let o in t)t.hasOwnProperty(o)&&(n[o]=t[o]);return n}function gu(n){if(typeof n!="number"&&n!=null){let[t,o]=n.split(Lg);return!o||o==="px"?parseFloat(t):null}return n||null}function bu(n){return{top:Math.floor(n.top),right:Math.floor(n.right),bottom:Math.floor(n.bottom),left:Math.floor(n.left),width:Math.floor(n.width),height:Math.floor(n.height)}}function jg(n,t){return n===t?!0:n.isOriginClipped===t.isOriginClipped&&n.isOriginOutsideView===t.isOriginOutsideView&&n.isOverlayClipped===t.isOverlayClipped&&n.isOverlayOutsideView===t.isOverlayOutsideView}var vu="cdk-global-overlay-wrapper",Da=class{constructor(){this._cssPosition="static",this._topOffset="",this._bottomOffset="",this._alignItems="",this._xPosition="",this._xOffset="",this._width="",this._height="",this._isDisposed=!1}attach(t){let o=t.getConfig();this._overlayRef=t,this._width&&!o.width&&t.updateSize({width:this._width}),this._height&&!o.height&&t.updateSize({height:this._height}),t.hostElement.classList.add(vu),this._isDisposed=!1}top(t=""){return this._bottomOffset="",this._topOffset=t,this._alignItems="flex-start",this}left(t=""){return this._xOffset=t,this._xPosition="left",this}bottom(t=""){return this._topOffset="",this._bottomOffset=t,this._alignItems="flex-end",this}right(t=""){return this._xOffset=t,this._xPosition="right",this}start(t=""){return this._xOffset=t,this._xPosition="start",this}end(t=""){return this._xOffset=t,this._xPosition="end",this}width(t=""){return this._overlayRef?this._overlayRef.updateSize({width:t}):this._width=t,this}height(t=""){return this._overlayRef?this._overlayRef.updateSize({height:t}):this._height=t,this}centerHorizontally(t=""){return this.left(t),this._xPosition="center",this}centerVertically(t=""){return this.top(t),this._alignItems="center",this}apply(){if(!this._overlayRef||!this._overlayRef.hasAttached())return;let t=this._overlayRef.overlayElement.style,o=this._overlayRef.hostElement.style,e=this._overlayRef.getConfig(),{width:i,height:r,maxWidth:s,maxHeight:a}=e,l=(i==="100%"||i==="100vw")&&(!s||s==="100%"||s==="100vw"),c=(r==="100%"||r==="100vh")&&(!a||a==="100%"||a==="100vh"),d=this._xPosition,h=this._xOffset,f=this._overlayRef.getConfig().direction==="rtl",w="",j="",z="";l?z="flex-start":d==="center"?(z="center",f?j=h:w=h):f?d==="left"||d==="end"?(z="flex-end",w=h):(d==="right"||d==="start")&&(z="flex-start",j=h):d==="left"||d==="start"?(z="flex-start",w=h):(d==="right"||d==="end")&&(z="flex-end",j=h),t.position=this._cssPosition,t.marginLeft=l?"0":w,t.marginTop=c?"0":this._topOffset,t.marginBottom=this._bottomOffset,t.marginRight=l?"0":j,o.justifyContent=z,o.alignItems=c?"flex-start":this._alignItems}dispose(){if(this._isDisposed||!this._overlayRef)return;let t=this._overlayRef.overlayElement.style,o=this._overlayRef.hostElement,e=o.style;o.classList.remove(vu),e.justifyContent=e.alignItems=t.marginTop=t.marginBottom=t.marginLeft=t.marginRight=t.position="",this._overlayRef=null,this._isDisposed=!0}},Vg=(()=>{let t=class t{constructor(e,i,r,s){this._viewportRuler=e,this._document=i,this._platform=r,this._overlayContainer=s}global(){return new Da}flexibleConnectedTo(e){return new Ca(e,this._viewportRuler,this._document,this._platform,this._overlayContainer)}};t.\u0275fac=function(i){return new(i||t)(m(bn),m(T),m(J),m(yu))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})(),zg=0,we=(()=>{let t=class t{constructor(e,i,r,s,a,l,c,d,h,f,w,j){this.scrollStrategies=e,this._overlayContainer=i,this._componentFactoryResolver=r,this._positionBuilder=s,this._keyboardDispatcher=a,this._injector=l,this._ngZone=c,this._document=d,this._directionality=h,this._location=f,this._outsideClickDispatcher=w,this._animationsModuleType=j}create(e){let i=this._createHostElement(),r=this._createPaneElement(i),s=this._createPortalOutlet(r),a=new In(e);return a.direction=a.direction||this._directionality.value,new wa(s,i,r,a,this._ngZone,this._keyboardDispatcher,this._document,this._location,this._outsideClickDispatcher,this._animationsModuleType==="NoopAnimations")}position(){return this._positionBuilder}_createPaneElement(e){let i=this._document.createElement("div");return i.id=`cdk-overlay-${zg++}`,i.classList.add("cdk-overlay-pane"),e.appendChild(i),i}_createHostElement(){let e=this._document.createElement("div");return this._overlayContainer.getContainerElement().appendChild(e),e}_createPortalOutlet(e){return this._appRef||(this._appRef=this._injector.get(Re)),new Sn(e,this._componentFactoryResolver,this._appRef,this._injector,this._document)}};t.\u0275fac=function(i){return new(i||t)(m(Og),m(yu),m(Nn),m(Vg),m(Ng),m(Kt),m(I),m(T),m(gi),m(Te),m(Pg),m(Bt,8))},t.\u0275prov=b({token:t,factory:t.\u0275fac,providedIn:"root"});let n=t;return n})();var Bg=new C("cdk-connected-overlay-scroll-strategy",{providedIn:"root",factory:()=>{let n=g(we);return()=>n.scrollStrategies.reposition()}});function Ug(n){return()=>n.scrollStrategies.reposition()}var Hg={provide:Bg,deps:[we],useFactory:Ug},xu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({providers:[we,Hg],imports:[_e,hu,vn,vn]});let n=t;return n})();var qg=["mat-menu-item",""],Zg=[[["mat-icon"],["","matMenuItemIcon",""]],"*"],Xg=["mat-icon, [matMenuItemIcon]","*"];function Kg(n,t){n&1&&(La(),x(0,"svg",2),H(1,"polygon",3),_())}var Qg=["*"];function Jg(n,t){if(n&1){let o=Ft();x(0,"div",0),Z("keydown",function(i){xt(o);let r=X();return wt(r._handleKeydown(i))})("click",function(){xt(o);let i=X();return wt(i.closed.emit("click"))})("@transformMenu.start",function(i){xt(o);let r=X();return wt(r._onAnimationStart(i))})("@transformMenu.done",function(i){xt(o);let r=X();return wt(r._onAnimationDone(i))}),x(1,"div",1),K(2),_()()}if(n&2){let o=X();Jt(o._classList),L("id",o.panelId)("@transformMenu",o._panelAnimationState),ft("aria-label",o.ariaLabel||null)("aria-labelledby",o.ariaLabelledby||null)("aria-describedby",o.ariaDescribedby||null)}}var Ea=new C("MAT_MENU_PANEL"),Rn=(()=>{let t=class t{constructor(e,i,r,s,a){this._elementRef=e,this._document=i,this._focusMonitor=r,this._parentMenu=s,this._changeDetectorRef=a,this.role="menuitem",this.disabled=!1,this.disableRipple=!1,this._hovered=new N,this._focused=new N,this._highlighted=!1,this._triggersSubmenu=!1,s?.addItem?.(this)}focus(e,i){this._focusMonitor&&e?this._focusMonitor.focusVia(this._getHostElement(),e,i):this._getHostElement().focus(i),this._focused.next(this)}ngAfterViewInit(){this._focusMonitor&&this._focusMonitor.monitor(this._elementRef,!1)}ngOnDestroy(){this._focusMonitor&&this._focusMonitor.stopMonitoring(this._elementRef),this._parentMenu&&this._parentMenu.removeItem&&this._parentMenu.removeItem(this),this._hovered.complete(),this._focused.complete()}_getTabIndex(){return this.disabled?"-1":"0"}_getHostElement(){return this._elementRef.nativeElement}_checkDisabled(e){this.disabled&&(e.preventDefault(),e.stopPropagation())}_handleMouseEnter(){this._hovered.next(this)}getLabel(){let e=this._elementRef.nativeElement.cloneNode(!0),i=e.querySelectorAll("mat-icon, .material-icons");for(let r=0;r<i.length;r++)i[r].remove();return e.textContent?.trim()||""}_setHighlighted(e){this._highlighted=e,this._changeDetectorRef?.markForCheck()}_setTriggersSubmenu(e){this._triggersSubmenu=e,this._changeDetectorRef?.markForCheck()}_hasFocus(){return this._document&&this._document.activeElement===this._getHostElement()}};t.\u0275fac=function(i){return new(i||t)(u(A),u(T),u(wn),u(Ea,8),u(Dt))},t.\u0275cmp=P({type:t,selectors:[["","mat-menu-item",""]],hostAttrs:[1,"mat-mdc-menu-item","mat-mdc-focus-indicator"],hostVars:8,hostBindings:function(i,r){i&1&&Z("click",function(a){return r._checkDisabled(a)})("mouseenter",function(){return r._handleMouseEnter()}),i&2&&(ft("role",r.role)("tabindex",r._getTabIndex())("aria-disabled",r.disabled)("disabled",r.disabled||null),st("mat-mdc-menu-item-highlighted",r._highlighted)("mat-mdc-menu-item-submenu-trigger",r._triggersSubmenu))},inputs:{role:"role",disabled:[y.HasDecoratorInputTransform,"disabled","disabled",W],disableRipple:[y.HasDecoratorInputTransform,"disableRipple","disableRipple",W]},exportAs:["matMenuItem"],standalone:!0,features:[nt,tt],attrs:qg,ngContentSelectors:Xg,decls:5,vars:3,consts:[[1,"mat-mdc-menu-item-text"],["matRipple","",1,"mat-mdc-menu-ripple",3,"matRippleDisabled","matRippleTrigger"],["viewBox","0 0 5 10","focusable","false","aria-hidden","true",1,"mat-mdc-menu-submenu-icon"],["points","0,0 5,5 0,10"]],template:function(i,r){i&1&&(pt(Zg),K(0),x(1,"span",0),K(2,1),_(),H(3,"div",1),ot(4,Kg,2,0,":svg:svg",2)),i&2&&(R(3),L("matRippleDisabled",r.disableRipple||r.disabled)("matRippleTrigger",r._getHostElement()),R(),Ut(4,r._triggersSubmenu?4:-1))},dependencies:[ha],encapsulation:2,changeDetection:0});let n=t;return n})();var tb=new C("MatMenuContent");var nr={transformMenu:Cr("transformMenu",[Dr("void",ti({opacity:0,transform:"scale(0.8)"})),Gn("void => enter",Wn("120ms cubic-bezier(0, 0, 0.2, 1)",ti({opacity:1,transform:"scale(1)"}))),Gn("* => void",Wn("100ms 25ms linear",ti({opacity:0})))]),fadeInItems:Cr("fadeInItems",[Dr("showing",ti({opacity:1})),Gn("void => *",[ti({opacity:0}),Wn("400ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)")])])},dx=nr.fadeInItems,ux=nr.transformMenu,eb=0,ib=new C("mat-menu-default-options",{providedIn:"root",factory:nb});function nb(){return{overlapTrigger:!1,xPosition:"after",yPosition:"below",backdropClass:"cdk-overlay-transparent-backdrop"}}var Di=(()=>{let t=class t{get xPosition(){return this._xPosition}set xPosition(e){this._xPosition=e,this.setPositionClasses()}get yPosition(){return this._yPosition}set yPosition(e){this._yPosition=e,this.setPositionClasses()}set panelClass(e){let i=this._previousPanelClass,r=p({},this._classList);i&&i.length&&i.split(" ").forEach(s=>{r[s]=!1}),this._previousPanelClass=e,e&&e.length&&(e.split(" ").forEach(s=>{r[s]=!0}),this._elementRef.nativeElement.className=""),this._classList=r}get classList(){return this.panelClass}set classList(e){this.panelClass=e}constructor(e,i,r,s){this._elementRef=e,this._ngZone=i,this._changeDetectorRef=s,this._elevationPrefix="mat-elevation-z",this._baseElevation=8,this._directDescendantItems=new Ri,this._classList={},this._panelAnimationState="void",this._animationDone=new N,this.closed=new it,this.close=this.closed,this.panelId=`mat-menu-panel-${eb++}`,this.overlayPanelClass=r.overlayPanelClass||"",this._xPosition=r.xPosition,this._yPosition=r.yPosition,this.backdropClass=r.backdropClass,this.overlapTrigger=r.overlapTrigger,this.hasBackdrop=r.hasBackdrop}ngOnInit(){this.setPositionClasses()}ngAfterContentInit(){this._updateDirectDescendants(),this._keyManager=new Yo(this._directDescendantItems).withWrap().withTypeAhead().withHomeAndEnd(),this._keyManager.tabOut.subscribe(()=>this.closed.emit("tab")),this._directDescendantItems.changes.pipe(Xt(this._directDescendantItems),vt(e=>qt(...e.map(i=>i._focused)))).subscribe(e=>this._keyManager.updateActiveItem(e)),this._directDescendantItems.changes.subscribe(e=>{let i=this._keyManager;if(this._panelAnimationState==="enter"&&i.activeItem?._hasFocus()){let r=e.toArray(),s=Math.max(0,Math.min(r.length-1,i.activeItemIndex||0));r[s]&&!r[s].disabled?i.setActiveItem(s):i.setNextItemActive()}})}ngOnDestroy(){this._keyManager?.destroy(),this._directDescendantItems.destroy(),this.closed.complete(),this._firstItemFocusSubscription?.unsubscribe()}_hovered(){return this._directDescendantItems.changes.pipe(Xt(this._directDescendantItems),vt(i=>qt(...i.map(r=>r._hovered))))}addItem(e){}removeItem(e){}_handleKeydown(e){let i=e.keyCode,r=this._keyManager;switch(i){case 27:$o(e)||(e.preventDefault(),this.closed.emit("keydown"));break;case 37:this.parentMenu&&this.direction==="ltr"&&this.closed.emit("keydown");break;case 39:this.parentMenu&&this.direction==="rtl"&&this.closed.emit("keydown");break;default:(i===38||i===40)&&r.setFocusOrigin("keyboard"),r.onKeydown(e);return}e.stopPropagation()}focusFirstItem(e="program"){this._firstItemFocusSubscription?.unsubscribe(),this._firstItemFocusSubscription=this._ngZone.onStable.pipe(ut(1)).subscribe(()=>{let i=null;if(this._directDescendantItems.length&&(i=this._directDescendantItems.first._getHostElement().closest('[role="menu"]')),!i||!i.contains(document.activeElement)){let r=this._keyManager;r.setFocusOrigin(e).setFirstItemActive(),!r.activeItem&&i&&i.focus()}})}resetActiveItem(){this._keyManager.setActiveItem(-1)}setElevation(e){let i=Math.min(this._baseElevation+e,24),r=`${this._elevationPrefix}${i}`,s=Object.keys(this._classList).find(a=>a.startsWith(this._elevationPrefix));if(!s||s===this._previousElevation){let a=p({},this._classList);this._previousElevation&&(a[this._previousElevation]=!1),a[r]=!0,this._previousElevation=r,this._classList=a}}setPositionClasses(e=this.xPosition,i=this.yPosition){this._classList=q(p({},this._classList),{"mat-menu-before":e==="before","mat-menu-after":e==="after","mat-menu-above":i==="above","mat-menu-below":i==="below"}),this._changeDetectorRef?.markForCheck()}_startAnimation(){this._panelAnimationState="enter"}_resetAnimation(){this._panelAnimationState="void"}_onAnimationDone(e){this._animationDone.next(e),this._isAnimating=!1}_onAnimationStart(e){this._isAnimating=!0,e.toState==="enter"&&this._keyManager.activeItemIndex===0&&(e.element.scrollTop=0)}_updateDirectDescendants(){this._allItems.changes.pipe(Xt(this._allItems)).subscribe(e=>{this._directDescendantItems.reset(e.filter(i=>i._parentMenu===this)),this._directDescendantItems.notifyOnChanges()})}};t.\u0275fac=function(i){return new(i||t)(u(A),u(I),u(ib),u(Dt))},t.\u0275cmp=P({type:t,selectors:[["mat-menu"]],contentQueries:function(i,r,s){if(i&1&&(gt(s,tb,5),gt(s,Rn,5),gt(s,Rn,4)),i&2){let a;at(a=lt())&&(r.lazyContent=a.first),at(a=lt())&&(r._allItems=a),at(a=lt())&&(r.items=a)}},viewQuery:function(i,r){if(i&1&&Xe(Ct,5),i&2){let s;at(s=lt())&&(r.templateRef=s.first)}},hostVars:3,hostBindings:function(i,r){i&2&&ft("aria-label",null)("aria-labelledby",null)("aria-describedby",null)},inputs:{backdropClass:"backdropClass",ariaLabel:[y.None,"aria-label","ariaLabel"],ariaLabelledby:[y.None,"aria-labelledby","ariaLabelledby"],ariaDescribedby:[y.None,"aria-describedby","ariaDescribedby"],xPosition:"xPosition",yPosition:"yPosition",overlapTrigger:[y.HasDecoratorInputTransform,"overlapTrigger","overlapTrigger",W],hasBackdrop:[y.HasDecoratorInputTransform,"hasBackdrop","hasBackdrop",e=>e==null?null:W(e)],panelClass:[y.None,"class","panelClass"],classList:"classList"},outputs:{closed:"closed",close:"close"},exportAs:["matMenu"],standalone:!0,features:[Q([{provide:Ea,useExisting:t}]),nt,tt],ngContentSelectors:Qg,decls:1,vars:0,consts:[["tabindex","-1","role","menu",1,"mat-mdc-menu-panel","mat-mdc-elevation-specific",3,"keydown","click","id"],[1,"mat-mdc-menu-content"]],template:function(i,r){i&1&&(pt(),ot(0,Jg,3,7,"ng-template"))},styles:['mat-menu{display:none}.mat-mdc-menu-content{margin:0;padding:8px 0;list-style-type:none}.mat-mdc-menu-content:focus{outline:none}.mat-mdc-menu-content,.mat-mdc-menu-content .mat-mdc-menu-item .mat-mdc-menu-item-text{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;flex:1;white-space:normal;font-family:var(--mat-menu-item-label-text-font);line-height:var(--mat-menu-item-label-text-line-height);font-size:var(--mat-menu-item-label-text-size);letter-spacing:var(--mat-menu-item-label-text-tracking);font-weight:var(--mat-menu-item-label-text-weight)}.mat-mdc-menu-panel{min-width:112px;max-width:280px;overflow:auto;-webkit-overflow-scrolling:touch;box-sizing:border-box;outline:0;border-radius:var(--mat-menu-container-shape);background-color:var(--mat-menu-container-color);will-change:transform,opacity}.mat-mdc-menu-panel.ng-animating{pointer-events:none}.cdk-high-contrast-active .mat-mdc-menu-panel{outline:solid 1px}.mat-divider{color:var(--mat-menu-divider-color);margin-bottom:var(--mat-menu-divider-bottom-spacing);margin-top:var(--mat-menu-divider-top-spacing)}.mat-mdc-menu-item{display:flex;position:relative;align-items:center;justify-content:flex-start;overflow:hidden;padding:0;padding-left:var(--mat-menu-item-leading-spacing);padding-right:var(--mat-menu-item-trailing-spacing);-webkit-user-select:none;user-select:none;cursor:pointer;outline:none;border:none;-webkit-tap-highlight-color:rgba(0,0,0,0);cursor:pointer;width:100%;text-align:left;box-sizing:border-box;color:inherit;font-size:inherit;background:none;text-decoration:none;margin:0;align-items:center;min-height:48px}.mat-mdc-menu-item:focus{outline:none}[dir=rtl] .mat-mdc-menu-item,.mat-mdc-menu-item[dir=rtl]{padding-left:var(--mat-menu-item-trailing-spacing);padding-right:var(--mat-menu-item-leading-spacing)}.mat-mdc-menu-item:has(.material-icons,mat-icon,[matButtonIcon]){padding-left:var(--mat-menu-item-with-icon-leading-spacing);padding-right:var(--mat-menu-item-with-icon-trailing-spacing)}[dir=rtl] .mat-mdc-menu-item:has(.material-icons,mat-icon,[matButtonIcon]),.mat-mdc-menu-item:has(.material-icons,mat-icon,[matButtonIcon])[dir=rtl]{padding-left:var(--mat-menu-item-with-icon-trailing-spacing);padding-right:var(--mat-menu-item-with-icon-leading-spacing)}.mat-mdc-menu-item::-moz-focus-inner{border:0}.mat-mdc-menu-item,.mat-mdc-menu-item:visited,.mat-mdc-menu-item:link{color:var(--mat-menu-item-label-text-color)}.mat-mdc-menu-item .mat-icon-no-color,.mat-mdc-menu-item .mat-mdc-menu-submenu-icon{color:var(--mat-menu-item-icon-color)}.mat-mdc-menu-item[disabled]{cursor:default;opacity:.38}.mat-mdc-menu-item[disabled]::after{display:block;position:absolute;content:"";top:0;left:0;bottom:0;right:0}.mat-mdc-menu-item .mat-icon{flex-shrink:0;margin-right:var(--mat-menu-item-spacing);height:var(--mat-menu-item-icon-size);width:var(--mat-menu-item-icon-size)}[dir=rtl] .mat-mdc-menu-item{text-align:right}[dir=rtl] .mat-mdc-menu-item .mat-icon{margin-right:0;margin-left:var(--mat-menu-item-spacing)}.mat-mdc-menu-item:not([disabled]):hover{background-color:var(--mat-menu-item-hover-state-layer-color)}.mat-mdc-menu-item:not([disabled]).cdk-program-focused,.mat-mdc-menu-item:not([disabled]).cdk-keyboard-focused,.mat-mdc-menu-item:not([disabled]).mat-mdc-menu-item-highlighted{background-color:var(--mat-menu-item-focus-state-layer-color)}.cdk-high-contrast-active .mat-mdc-menu-item{margin-top:1px}.mat-mdc-menu-submenu-icon{width:var(--mat-menu-item-icon-size);height:10px;fill:currentColor;padding-left:var(--mat-menu-item-spacing)}[dir=rtl] .mat-mdc-menu-submenu-icon{padding-right:var(--mat-menu-item-spacing);padding-left:0}[dir=rtl] .mat-mdc-menu-submenu-icon polygon{transform:scaleX(-1)}.cdk-high-contrast-active .mat-mdc-menu-submenu-icon{fill:CanvasText}.mat-mdc-menu-item .mat-mdc-menu-ripple{top:0;left:0;right:0;bottom:0;position:absolute;pointer-events:none}'],encapsulation:2,data:{animation:[nr.transformMenu,nr.fadeInItems]},changeDetection:0});let n=t;return n})(),Cu=new C("mat-menu-scroll-strategy",{providedIn:"root",factory:()=>{let n=g(we);return()=>n.scrollStrategies.reposition()}});function ob(n){return()=>n.scrollStrategies.reposition()}var rb={provide:Cu,deps:[we],useFactory:ob},wu=ye({passive:!0});var Du=(()=>{let t=class t{get _deprecatedMatMenuTriggerFor(){return this.menu}set _deprecatedMatMenuTriggerFor(e){this.menu=e}get menu(){return this._menu}set menu(e){e!==this._menu&&(this._menu=e,this._menuCloseSubscription.unsubscribe(),e&&(this._parentMaterialMenu,this._menuCloseSubscription=e.close.subscribe(i=>{this._destroyMenu(i),(i==="click"||i==="tab")&&this._parentMaterialMenu&&this._parentMaterialMenu.closed.emit(i)})),this._menuItemInstance?._setTriggersSubmenu(this.triggersSubmenu()))}constructor(e,i,r,s,a,l,c,d,h){this._overlay=e,this._element=i,this._viewContainerRef=r,this._menuItemInstance=l,this._dir=c,this._focusMonitor=d,this._ngZone=h,this._overlayRef=null,this._menuOpen=!1,this._closingActionsSubscription=St.EMPTY,this._hoverSubscription=St.EMPTY,this._menuCloseSubscription=St.EMPTY,this._changeDetectorRef=g(Dt),this._handleTouchStart=f=>{xn(f)||(this._openedBy="touch")},this._openedBy=void 0,this.restoreFocus=!0,this.menuOpened=new it,this.onMenuOpen=this.menuOpened,this.menuClosed=new it,this.onMenuClose=this.menuClosed,this._scrollStrategy=s,this._parentMaterialMenu=a instanceof Di?a:void 0,i.nativeElement.addEventListener("touchstart",this._handleTouchStart,wu)}ngAfterContentInit(){this._handleHover()}ngOnDestroy(){this._overlayRef&&(this._overlayRef.dispose(),this._overlayRef=null),this._element.nativeElement.removeEventListener("touchstart",this._handleTouchStart,wu),this._menuCloseSubscription.unsubscribe(),this._closingActionsSubscription.unsubscribe(),this._hoverSubscription.unsubscribe()}get menuOpen(){return this._menuOpen}get dir(){return this._dir&&this._dir.value==="rtl"?"rtl":"ltr"}triggersSubmenu(){return!!(this._menuItemInstance&&this._parentMaterialMenu&&this.menu)}toggleMenu(){return this._menuOpen?this.closeMenu():this.openMenu()}openMenu(){let e=this.menu;if(this._menuOpen||!e)return;let i=this._createOverlay(e),r=i.getConfig(),s=r.positionStrategy;this._setPosition(e,s),r.hasBackdrop=e.hasBackdrop==null?!this.triggersSubmenu():e.hasBackdrop,i.attach(this._getPortal(e)),e.lazyContent&&e.lazyContent.attach(this.menuData),this._closingActionsSubscription=this._menuClosingActions().subscribe(()=>this.closeMenu()),this._initMenu(e),e instanceof Di&&(e._startAnimation(),e._directDescendantItems.changes.pipe(mt(e.close)).subscribe(()=>{s.withLockedPosition(!1).reapplyLastPosition(),s.withLockedPosition(!0)}))}closeMenu(){this.menu?.close.emit()}focus(e,i){this._focusMonitor&&e?this._focusMonitor.focusVia(this._element,e,i):this._element.nativeElement.focus(i)}updatePosition(){this._overlayRef?.updatePosition()}_destroyMenu(e){if(!this._overlayRef||!this.menuOpen)return;let i=this.menu;this._closingActionsSubscription.unsubscribe(),this._overlayRef.detach(),this.restoreFocus&&(e==="keydown"||!this._openedBy||!this.triggersSubmenu())&&this.focus(this._openedBy),this._openedBy=void 0,i instanceof Di?(i._resetAnimation(),i.lazyContent?i._animationDone.pipe(dt(r=>r.toState==="void"),ut(1),mt(i.lazyContent._attached)).subscribe({next:()=>i.lazyContent.detach(),complete:()=>this._setIsMenuOpen(!1)}):this._setIsMenuOpen(!1)):(this._setIsMenuOpen(!1),i?.lazyContent?.detach())}_initMenu(e){e.parentMenu=this.triggersSubmenu()?this._parentMaterialMenu:void 0,e.direction=this.dir,this._setMenuElevation(e),e.focusFirstItem(this._openedBy||"program"),this._setIsMenuOpen(!0)}_setMenuElevation(e){if(e.setElevation){let i=0,r=e.parentMenu;for(;r;)i++,r=r.parentMenu;e.setElevation(i)}}_setIsMenuOpen(e){e!==this._menuOpen&&(this._menuOpen=e,this._menuOpen?this.menuOpened.emit():this.menuClosed.emit(),this.triggersSubmenu()&&this._menuItemInstance._setHighlighted(e),this._changeDetectorRef.markForCheck())}_createOverlay(e){if(!this._overlayRef){let i=this._getOverlayConfig(e);this._subscribeToPositions(e,i.positionStrategy),this._overlayRef=this._overlay.create(i),this._overlayRef.keydownEvents().subscribe()}return this._overlayRef}_getOverlayConfig(e){return new In({positionStrategy:this._overlay.position().flexibleConnectedTo(this._element).withLockedPosition().withGrowAfterOpen().withTransformOriginOn(".mat-menu-panel, .mat-mdc-menu-panel"),backdropClass:e.backdropClass||"cdk-overlay-transparent-backdrop",panelClass:e.overlayPanelClass,scrollStrategy:this._scrollStrategy(),direction:this._dir})}_subscribeToPositions(e,i){e.setPositionClasses&&i.positionChanges.subscribe(r=>{let s=r.connectionPair.overlayX==="start"?"after":"before",a=r.connectionPair.overlayY==="top"?"below":"above";this._ngZone?this._ngZone.run(()=>e.setPositionClasses(s,a)):e.setPositionClasses(s,a)})}_setPosition(e,i){let[r,s]=e.xPosition==="before"?["end","start"]:["start","end"],[a,l]=e.yPosition==="above"?["bottom","top"]:["top","bottom"],[c,d]=[a,l],[h,f]=[r,s],w=0;if(this.triggersSubmenu()){if(f=r=e.xPosition==="before"?"start":"end",s=h=r==="end"?"start":"end",this._parentMaterialMenu){if(this._parentInnerPadding==null){let j=this._parentMaterialMenu.items.first;this._parentInnerPadding=j?j._getHostElement().offsetTop:0}w=a==="bottom"?this._parentInnerPadding:-this._parentInnerPadding}}else e.overlapTrigger||(c=a==="top"?"bottom":"top",d=l==="top"?"bottom":"top");i.withPositions([{originX:r,originY:c,overlayX:h,overlayY:a,offsetY:w},{originX:s,originY:c,overlayX:f,overlayY:a,offsetY:w},{originX:r,originY:d,overlayX:h,overlayY:l,offsetY:-w},{originX:s,originY:d,overlayX:f,overlayY:l,offsetY:-w}])}_menuClosingActions(){let e=this._overlayRef.backdropClick(),i=this._overlayRef.detachments(),r=this._parentMaterialMenu?this._parentMaterialMenu.closed:v(),s=this._parentMaterialMenu?this._parentMaterialMenu._hovered().pipe(dt(a=>a!==this._menuItemInstance),dt(()=>this._menuOpen)):v();return qt(e,r,s,i)}_handleMousedown(e){yn(e)||(this._openedBy=e.button===0?"mouse":void 0,this.triggersSubmenu()&&e.preventDefault())}_handleKeydown(e){let i=e.keyCode;(i===13||i===32)&&(this._openedBy="keyboard"),this.triggersSubmenu()&&(i===39&&this.dir==="ltr"||i===37&&this.dir==="rtl")&&(this._openedBy="keyboard",this.openMenu())}_handleClick(e){this.triggersSubmenu()?(e.stopPropagation(),this.openMenu()):this.toggleMenu()}_handleHover(){!this.triggersSubmenu()||!this._parentMaterialMenu||(this._hoverSubscription=this._parentMaterialMenu._hovered().pipe(dt(e=>e===this._menuItemInstance&&!e.disabled),ur(0,Mn)).subscribe(()=>{this._openedBy="mouse",this.menu instanceof Di&&this.menu._isAnimating?this.menu._animationDone.pipe(ut(1),ur(0,Mn),mt(this._parentMaterialMenu._hovered())).subscribe(()=>this.openMenu()):this.openMenu()}))}_getPortal(e){return(!this._portal||this._portal.templateRef!==e.templateRef)&&(this._portal=new Ci(e.templateRef,this._viewContainerRef)),this._portal}};t.\u0275fac=function(i){return new(i||t)(u(we),u(A),u(kt),u(Cu),u(Ea,8),u(Rn,10),u(gi,8),u(wn),u(I))},t.\u0275dir=D({type:t,selectors:[["","mat-menu-trigger-for",""],["","matMenuTriggerFor",""]],hostAttrs:[1,"mat-mdc-menu-trigger"],hostVars:3,hostBindings:function(i,r){i&1&&Z("click",function(a){return r._handleClick(a)})("mousedown",function(a){return r._handleMousedown(a)})("keydown",function(a){return r._handleKeydown(a)}),i&2&&ft("aria-haspopup",r.menu?"menu":null)("aria-expanded",r.menuOpen)("aria-controls",r.menuOpen?r.menu.panelId:null)},inputs:{_deprecatedMatMenuTriggerFor:[y.None,"mat-menu-trigger-for","_deprecatedMatMenuTriggerFor"],menu:[y.None,"matMenuTriggerFor","menu"],menuData:[y.None,"matMenuTriggerData","menuData"],restoreFocus:[y.None,"matMenuTriggerRestoreFocus","restoreFocus"]},outputs:{menuOpened:"menuOpened",onMenuOpen:"onMenuOpen",menuClosed:"menuClosed",onMenuClose:"onMenuClose"},exportAs:["matMenuTrigger"],standalone:!0});let n=t;return n})(),Eu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({providers:[rb],imports:[Je,Ko,Y,xu,No,Y]});let n=t;return n})();function ab(n,t){n&1&&(x(0,"button",8),F(1,"Account"),_())}function lb(n,t){if(n&1){let o=Ft();x(0,"button",9),Z("click",function(){xt(o);let i=X();return wt(i.logout())}),F(1,"Logout"),_()}}function cb(n,t){if(n&1){let o=Ft();x(0,"button",9),Z("click",function(){xt(o);let i=X();return wt(i.authenticateGoogle())}),F(1,"Login"),_()}}var Su=(()=>{let t=class t{constructor(e){this.authService=e,this.isLoggedIn=!1}ngOnInit(){this.authService.user.subscribe(e=>{this.isLoggedIn=!!e})}logout(){this.authService.logout()}authenticateGoogle(){this.authService.login()}};t.\u0275fac=function(i){return new(i||t)(u(Qo))},t.\u0275cmp=P({type:t,selectors:[["app-navbar"]],decls:18,vars:4,consts:[["accountMenu","matMenu"],["color","primary",1,"mat-elevation-z8"],["mat-button","","routerLink","",2,"font-size","20px"],[1,"nvHeaderSpace"],["mat-button","","routerLink","SFL"],["mat-menu-item","","routerLink","Account",4,"ngIf"],["mat-menu-item","",3,"click",4,"ngIf"],["mat-icon-button","",3,"matMenuTriggerFor"],["mat-menu-item","","routerLink","Account"],["mat-menu-item","",3,"click"]],template:function(i,r){if(i&1&&(x(0,"mat-toolbar",1)(1,"a",2)(2,"mat-icon"),F(3,"storefront"),_(),F(4,"PricePinion "),_(),H(5,"div",3),x(6,"a",4)(7,"mat-icon"),F(8,"favorite"),_(),F(9,"\xA0Save\xA0For\xA0Later "),_(),x(10,"mat-menu",null,0),ot(12,ab,2,0,"button",5)(13,lb,2,0,"button",6)(14,cb,2,0,"button",6),_(),x(15,"a",7)(16,"mat-icon"),F(17,"account_circle"),_()()()),i&2){let s=he(11);R(12),L("ngIf",r.isLoggedIn),R(),L("ngIf",r.isLoggedIn),R(),L("ngIf",!r.isLoggedIn),R(),L("matMenuTriggerFor",s)}},dependencies:[Ht,ui,ru,cu,du,er,Di,Rn,Du],styles:[".nvHeaderSpace[_ngcontent-%COMP%]{flex:1 1 auto}"]});let n=t;return n})();var Iu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275cmp=P({type:t,selectors:[["app-root"]],decls:2,vars:0,template:function(i,r){i&1&&H(0,"app-navbar")(1,"router-outlet")},dependencies:[xs,Su]});let n=t;return n})();var Ru=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({});let n=t;return n})();var Sa=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,Je,pd,Y]});let n=t;return n})();var Mu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[Y,Sa,Sa,Ru,Y]});let n=t;return n})();var ku=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t}),t.\u0275inj=E({imports:[ua,Y,ua,Y]});let n=t;return n})();var Tu=(()=>{let t=class t{};t.\u0275fac=function(i){return new(i||t)},t.\u0275mod=S({type:t,bootstrap:[Iu]}),t.\u0275inj=E({providers:[ou(),fe],imports:[Al,nu,su,uu,tu,Mu,ku,Qc,Kc,Eu,Wd,Dl]});let n=t;return n})();Tl().bootstrapModule(Tu).catch(n=>console.error(n));
+import {
+    $ as Na,
+    $a as gr,
+    $b as Dt,
+    A as qt,
+    Aa as ja,
+    Ab as Ze,
+    B as dt,
+    Ba as Mi,
+    Bb as gt,
+    Bc as Cr,
+    C as cr,
+    Ca as Va,
+    Cb as Xe,
+    Cc as Wn,
+    D as re,
+    Da as Qt,
+    Db as at,
+    E as se,
+    Ea as Bt,
+    Eb as lt,
+    Ec as ti,
+    F as An,
+    Fa as ki,
+    Fb as he,
+    Fc as Dr,
+    G as dr,
+    Ga as Ye,
+    Gb as F,
+    Gc as Gn,
+    H as ut,
+    Ha as qe,
+    Hb as te,
+    I as Ta,
+    Ia as za,
+    Ib as Oi,
+    J as ur,
+    Ja as Ba,
+    Jb as Xa,
+    K as hr,
+    Ka as Ua,
+    Kb as Ka,
+    L as Zt,
+    La as Ha,
+    Lb as Qa,
+    M as ae,
+    Ma as $a,
+    Mb as Q,
+    N as mr,
+    Na as Wa,
+    Nb as tt,
+    O as Aa,
+    Oa as Ga,
+    Ob as Ni,
+    P as Fa,
+    Pa as Mt,
+    Pb as Ke,
+    Q as Oa,
+    Qa as Se,
+    Qb as Ln,
+    R as Fn,
+    Ra as Ya,
+    Rb as Ja,
+    S as Xt,
+    Sa as Ti,
+    Sb as jn,
+    T as vt,
+    Ta as R,
+    Tb as Vn,
+    U as mt,
+    Ua as u,
+    Ub as yr,
+    V as et,
+    Va as Ie,
+    Vb as zn,
+    W as $,
+    Wa as Ct,
+    Wb as xr,
+    X as le,
+    Xa as qa,
+    Xb as wr,
+    Y as Si,
+    Ya as Nn,
+    Yb as Re,
+    Z as b,
+    Za as Pn,
+    Zb as Bn,
+    _ as E,
+    _a as Ai,
+    _b as tl,
+    a as p,
+    aa as C,
+    ab as I,
+    ac as Me,
+    b as q,
+    ba as fr,
+    bb as br,
+    bc as el,
+    ca as m,
+    cb as kt,
+    cc as il,
+    d as rr,
+    da as g,
+    db as vr,
+    dc as W,
+    e as St,
+    ea as On,
+    eb as U,
+    ec as nl,
+    f as Ra,
+    fa as pr,
+    fb as nt,
+    fc as ol,
+    g as $e,
+    ga as Ii,
+    gb as Za,
+    gc as rl,
+    h as sr,
+    ha as y,
+    hb as _r,
+    hc as ke,
+    i as Ei,
+    ia as P,
+    ib as Fi,
+    ic as sl,
+    j as N,
+    ja as S,
+    jb as ot,
+    jc as al,
+    k as rt,
+    ka as D,
+    kb as ft,
+    kc as T,
+    l as Mn,
+    la as Ge,
+    lb as L,
+    lc as ll,
+    m as oe,
+    ma as Pa,
+    mb as st,
+    mc as Pi,
+    n as ht,
+    na as ce,
+    nb as Jt,
+    nc as cl,
+    o as v,
+    oa as zt,
+    ob as Ut,
+    oc as dl,
+    p as Ce,
+    pa as yt,
+    pb as x,
+    pc as Te,
+    q as We,
+    qa as xt,
+    qb as _,
+    qc as Un,
+    r as Ma,
+    ra as wt,
+    rb as H,
+    rc as Qe,
+    s as M,
+    sa as La,
+    sb as de,
+    sc as Ht,
+    t as Vt,
+    ta as _t,
+    tb as ue,
+    tc as Je,
+    u as Rt,
+    ua as De,
+    ub as It,
+    uc as ul,
+    v as ar,
+    va as Kt,
+    vb as Ft,
+    vc as hl,
+    w as kn,
+    wa as Ee,
+    wb as Z,
+    wc as Hn,
+    x as lr,
+    xa as A,
+    xb as X,
+    xc as ml,
+    y as Tn,
+    ya as it,
+    yb as pt,
+    yc as $n,
+    z as ka,
+    za as Ri,
+    zb as K,
+} from "./chunk-LPDIY7FO.js";
+var ji = class {},
+    qn = class {},
+    Ae = class n {
+        constructor(t) {
+            (this.normalizedNames = new Map()),
+                (this.lazyUpdate = null),
+                t
+                    ? typeof t == "string"
+                        ? (this.lazyInit = () => {
+                              (this.headers = new Map()),
+                                  t
+                                      .split(
+                                          `
+`
+                                      )
+                                      .forEach((o) => {
+                                          let e = o.indexOf(":");
+                                          if (e > 0) {
+                                              let i = o.slice(0, e),
+                                                  r = i.toLowerCase(),
+                                                  s = o.slice(e + 1).trim();
+                                              this.maybeSetNormalizedName(i, r),
+                                                  this.headers.has(r)
+                                                      ? this.headers
+                                                            .get(r)
+                                                            .push(s)
+                                                      : this.headers.set(r, [
+                                                            s,
+                                                        ]);
+                                          }
+                                      });
+                          })
+                        : typeof Headers < "u" && t instanceof Headers
+                          ? ((this.headers = new Map()),
+                            t.forEach((o, e) => {
+                                this.setHeaderEntries(e, o);
+                            }))
+                          : (this.lazyInit = () => {
+                                (this.headers = new Map()),
+                                    Object.entries(t).forEach(([o, e]) => {
+                                        this.setHeaderEntries(o, e);
+                                    });
+                            })
+                    : (this.headers = new Map());
+        }
+        has(t) {
+            return this.init(), this.headers.has(t.toLowerCase());
+        }
+        get(t) {
+            this.init();
+            let o = this.headers.get(t.toLowerCase());
+            return o && o.length > 0 ? o[0] : null;
+        }
+        keys() {
+            return this.init(), Array.from(this.normalizedNames.values());
+        }
+        getAll(t) {
+            return this.init(), this.headers.get(t.toLowerCase()) || null;
+        }
+        append(t, o) {
+            return this.clone({ name: t, value: o, op: "a" });
+        }
+        set(t, o) {
+            return this.clone({ name: t, value: o, op: "s" });
+        }
+        delete(t, o) {
+            return this.clone({ name: t, value: o, op: "d" });
+        }
+        maybeSetNormalizedName(t, o) {
+            this.normalizedNames.has(o) || this.normalizedNames.set(o, t);
+        }
+        init() {
+            this.lazyInit &&
+                (this.lazyInit instanceof n
+                    ? this.copyFrom(this.lazyInit)
+                    : this.lazyInit(),
+                (this.lazyInit = null),
+                this.lazyUpdate &&
+                    (this.lazyUpdate.forEach((t) => this.applyUpdate(t)),
+                    (this.lazyUpdate = null)));
+        }
+        copyFrom(t) {
+            t.init(),
+                Array.from(t.headers.keys()).forEach((o) => {
+                    this.headers.set(o, t.headers.get(o)),
+                        this.normalizedNames.set(o, t.normalizedNames.get(o));
+                });
+        }
+        clone(t) {
+            let o = new n();
+            return (
+                (o.lazyInit =
+                    this.lazyInit && this.lazyInit instanceof n
+                        ? this.lazyInit
+                        : this),
+                (o.lazyUpdate = (this.lazyUpdate || []).concat([t])),
+                o
+            );
+        }
+        applyUpdate(t) {
+            let o = t.name.toLowerCase();
+            switch (t.op) {
+                case "a":
+                case "s":
+                    let e = t.value;
+                    if ((typeof e == "string" && (e = [e]), e.length === 0))
+                        return;
+                    this.maybeSetNormalizedName(t.name, o);
+                    let i = (t.op === "a" ? this.headers.get(o) : void 0) || [];
+                    i.push(...e), this.headers.set(o, i);
+                    break;
+                case "d":
+                    let r = t.value;
+                    if (!r)
+                        this.headers.delete(o), this.normalizedNames.delete(o);
+                    else {
+                        let s = this.headers.get(o);
+                        if (!s) return;
+                        (s = s.filter((a) => r.indexOf(a) === -1)),
+                            s.length === 0
+                                ? (this.headers.delete(o),
+                                  this.normalizedNames.delete(o))
+                                : this.headers.set(o, s);
+                    }
+                    break;
+            }
+        }
+        setHeaderEntries(t, o) {
+            let e = (Array.isArray(o) ? o : [o]).map((r) => r.toString()),
+                i = t.toLowerCase();
+            this.headers.set(i, e), this.maybeSetNormalizedName(t, i);
+        }
+        forEach(t) {
+            this.init(),
+                Array.from(this.normalizedNames.keys()).forEach((o) =>
+                    t(this.normalizedNames.get(o), this.headers.get(o))
+                );
+        }
+    };
+var Sr = class {
+    encodeKey(t) {
+        return fl(t);
+    }
+    encodeValue(t) {
+        return fl(t);
+    }
+    decodeKey(t) {
+        return decodeURIComponent(t);
+    }
+    decodeValue(t) {
+        return decodeURIComponent(t);
+    }
+};
+function Lu(n, t) {
+    let o = new Map();
+    return (
+        n.length > 0 &&
+            n
+                .replace(/^\?/, "")
+                .split("&")
+                .forEach((i) => {
+                    let r = i.indexOf("="),
+                        [s, a] =
+                            r == -1
+                                ? [t.decodeKey(i), ""]
+                                : [
+                                      t.decodeKey(i.slice(0, r)),
+                                      t.decodeValue(i.slice(r + 1)),
+                                  ],
+                        l = o.get(s) || [];
+                    l.push(a), o.set(s, l);
+                }),
+        o
+    );
+}
+var ju = /%(\d[a-f0-9])/gi,
+    Vu = {
+        40: "@",
+        "3A": ":",
+        24: "$",
+        "2C": ",",
+        "3B": ";",
+        "3D": "=",
+        "3F": "?",
+        "2F": "/",
+    };
+function fl(n) {
+    return encodeURIComponent(n).replace(ju, (t, o) => Vu[o] ?? t);
+}
+function Yn(n) {
+    return `${n}`;
+}
+var me = class n {
+    constructor(t = {}) {
+        if (
+            ((this.updates = null),
+            (this.cloneFrom = null),
+            (this.encoder = t.encoder || new Sr()),
+            t.fromString)
+        ) {
+            if (t.fromObject)
+                throw new Error(
+                    "Cannot specify both fromString and fromObject."
+                );
+            this.map = Lu(t.fromString, this.encoder);
+        } else
+            t.fromObject
+                ? ((this.map = new Map()),
+                  Object.keys(t.fromObject).forEach((o) => {
+                      let e = t.fromObject[o],
+                          i = Array.isArray(e) ? e.map(Yn) : [Yn(e)];
+                      this.map.set(o, i);
+                  }))
+                : (this.map = null);
+    }
+    has(t) {
+        return this.init(), this.map.has(t);
+    }
+    get(t) {
+        this.init();
+        let o = this.map.get(t);
+        return o ? o[0] : null;
+    }
+    getAll(t) {
+        return this.init(), this.map.get(t) || null;
+    }
+    keys() {
+        return this.init(), Array.from(this.map.keys());
+    }
+    append(t, o) {
+        return this.clone({ param: t, value: o, op: "a" });
+    }
+    appendAll(t) {
+        let o = [];
+        return (
+            Object.keys(t).forEach((e) => {
+                let i = t[e];
+                Array.isArray(i)
+                    ? i.forEach((r) => {
+                          o.push({ param: e, value: r, op: "a" });
+                      })
+                    : o.push({ param: e, value: i, op: "a" });
+            }),
+            this.clone(o)
+        );
+    }
+    set(t, o) {
+        return this.clone({ param: t, value: o, op: "s" });
+    }
+    delete(t, o) {
+        return this.clone({ param: t, value: o, op: "d" });
+    }
+    toString() {
+        return (
+            this.init(),
+            this.keys()
+                .map((t) => {
+                    let o = this.encoder.encodeKey(t);
+                    return this.map
+                        .get(t)
+                        .map((e) => o + "=" + this.encoder.encodeValue(e))
+                        .join("&");
+                })
+                .filter((t) => t !== "")
+                .join("&")
+        );
+    }
+    clone(t) {
+        let o = new n({ encoder: this.encoder });
+        return (
+            (o.cloneFrom = this.cloneFrom || this),
+            (o.updates = (this.updates || []).concat(t)),
+            o
+        );
+    }
+    init() {
+        this.map === null && (this.map = new Map()),
+            this.cloneFrom !== null &&
+                (this.cloneFrom.init(),
+                this.cloneFrom
+                    .keys()
+                    .forEach((t) => this.map.set(t, this.cloneFrom.map.get(t))),
+                this.updates.forEach((t) => {
+                    switch (t.op) {
+                        case "a":
+                        case "s":
+                            let o =
+                                (t.op === "a"
+                                    ? this.map.get(t.param)
+                                    : void 0) || [];
+                            o.push(Yn(t.value)), this.map.set(t.param, o);
+                            break;
+                        case "d":
+                            if (t.value !== void 0) {
+                                let e = this.map.get(t.param) || [],
+                                    i = e.indexOf(Yn(t.value));
+                                i !== -1 && e.splice(i, 1),
+                                    e.length > 0
+                                        ? this.map.set(t.param, e)
+                                        : this.map.delete(t.param);
+                            } else {
+                                this.map.delete(t.param);
+                                break;
+                            }
+                    }
+                }),
+                (this.cloneFrom = this.updates = null));
+    }
+};
+var Ir = class {
+    constructor() {
+        this.map = new Map();
+    }
+    set(t, o) {
+        return this.map.set(t, o), this;
+    }
+    get(t) {
+        return (
+            this.map.has(t) || this.map.set(t, t.defaultValue()),
+            this.map.get(t)
+        );
+    }
+    delete(t) {
+        return this.map.delete(t), this;
+    }
+    has(t) {
+        return this.map.has(t);
+    }
+    keys() {
+        return this.map.keys();
+    }
+};
+function zu(n) {
+    switch (n) {
+        case "DELETE":
+        case "GET":
+        case "HEAD":
+        case "OPTIONS":
+        case "JSONP":
+            return !1;
+        default:
+            return !0;
+    }
+}
+function pl(n) {
+    return typeof ArrayBuffer < "u" && n instanceof ArrayBuffer;
+}
+function gl(n) {
+    return typeof Blob < "u" && n instanceof Blob;
+}
+function bl(n) {
+    return typeof FormData < "u" && n instanceof FormData;
+}
+function Bu(n) {
+    return typeof URLSearchParams < "u" && n instanceof URLSearchParams;
+}
+var Li = class n {
+        constructor(t, o, e, i) {
+            (this.url = o),
+                (this.body = null),
+                (this.reportProgress = !1),
+                (this.withCredentials = !1),
+                (this.responseType = "json"),
+                (this.method = t.toUpperCase());
+            let r;
+            if (
+                (zu(this.method) || i
+                    ? ((this.body = e !== void 0 ? e : null), (r = i))
+                    : (r = e),
+                r &&
+                    ((this.reportProgress = !!r.reportProgress),
+                    (this.withCredentials = !!r.withCredentials),
+                    r.responseType && (this.responseType = r.responseType),
+                    r.headers && (this.headers = r.headers),
+                    r.context && (this.context = r.context),
+                    r.params && (this.params = r.params),
+                    (this.transferCache = r.transferCache)),
+                (this.headers ??= new Ae()),
+                (this.context ??= new Ir()),
+                !this.params)
+            )
+                (this.params = new me()), (this.urlWithParams = o);
+            else {
+                let s = this.params.toString();
+                if (s.length === 0) this.urlWithParams = o;
+                else {
+                    let a = o.indexOf("?"),
+                        l = a === -1 ? "?" : a < o.length - 1 ? "&" : "";
+                    this.urlWithParams = o + l + s;
+                }
+            }
+        }
+        serializeBody() {
+            return this.body === null
+                ? null
+                : typeof this.body == "string" ||
+                    pl(this.body) ||
+                    gl(this.body) ||
+                    bl(this.body) ||
+                    Bu(this.body)
+                  ? this.body
+                  : this.body instanceof me
+                    ? this.body.toString()
+                    : typeof this.body == "object" ||
+                        typeof this.body == "boolean" ||
+                        Array.isArray(this.body)
+                      ? JSON.stringify(this.body)
+                      : this.body.toString();
+        }
+        detectContentTypeHeader() {
+            return this.body === null || bl(this.body)
+                ? null
+                : gl(this.body)
+                  ? this.body.type || null
+                  : pl(this.body)
+                    ? null
+                    : typeof this.body == "string"
+                      ? "text/plain"
+                      : this.body instanceof me
+                        ? "application/x-www-form-urlencoded;charset=UTF-8"
+                        : typeof this.body == "object" ||
+                            typeof this.body == "number" ||
+                            typeof this.body == "boolean"
+                          ? "application/json"
+                          : null;
+        }
+        clone(t = {}) {
+            let o = t.method || this.method,
+                e = t.url || this.url,
+                i = t.responseType || this.responseType,
+                r = t.transferCache ?? this.transferCache,
+                s = t.body !== void 0 ? t.body : this.body,
+                a = t.withCredentials ?? this.withCredentials,
+                l = t.reportProgress ?? this.reportProgress,
+                c = t.headers || this.headers,
+                d = t.params || this.params,
+                h = t.context ?? this.context;
+            return (
+                t.setHeaders !== void 0 &&
+                    (c = Object.keys(t.setHeaders).reduce(
+                        (f, w) => f.set(w, t.setHeaders[w]),
+                        c
+                    )),
+                t.setParams &&
+                    (d = Object.keys(t.setParams).reduce(
+                        (f, w) => f.set(w, t.setParams[w]),
+                        d
+                    )),
+                new n(o, e, s, {
+                    params: d,
+                    headers: c,
+                    context: h,
+                    reportProgress: l,
+                    responseType: i,
+                    withCredentials: a,
+                    transferCache: r,
+                })
+            );
+        }
+    },
+    ei = (function (n) {
+        return (
+            (n[(n.Sent = 0)] = "Sent"),
+            (n[(n.UploadProgress = 1)] = "UploadProgress"),
+            (n[(n.ResponseHeader = 2)] = "ResponseHeader"),
+            (n[(n.DownloadProgress = 3)] = "DownloadProgress"),
+            (n[(n.Response = 4)] = "Response"),
+            (n[(n.User = 5)] = "User"),
+            n
+        );
+    })(ei || {}),
+    Vi = class {
+        constructor(t, o = Kn.Ok, e = "OK") {
+            (this.headers = t.headers || new Ae()),
+                (this.status = t.status !== void 0 ? t.status : o),
+                (this.statusText = t.statusText || e),
+                (this.url = t.url || null),
+                (this.ok = this.status >= 200 && this.status < 300);
+        }
+    },
+    Rr = class n extends Vi {
+        constructor(t = {}) {
+            super(t), (this.type = ei.ResponseHeader);
+        }
+        clone(t = {}) {
+            return new n({
+                headers: t.headers || this.headers,
+                status: t.status !== void 0 ? t.status : this.status,
+                statusText: t.statusText || this.statusText,
+                url: t.url || this.url || void 0,
+            });
+        }
+    },
+    Zn = class n extends Vi {
+        constructor(t = {}) {
+            super(t),
+                (this.type = ei.Response),
+                (this.body = t.body !== void 0 ? t.body : null);
+        }
+        clone(t = {}) {
+            return new n({
+                body: t.body !== void 0 ? t.body : this.body,
+                headers: t.headers || this.headers,
+                status: t.status !== void 0 ? t.status : this.status,
+                statusText: t.statusText || this.statusText,
+                url: t.url || this.url || void 0,
+            });
+        }
+    },
+    Xn = class extends Vi {
+        constructor(t) {
+            super(t, 0, "Unknown Error"),
+                (this.name = "HttpErrorResponse"),
+                (this.ok = !1),
+                this.status >= 200 && this.status < 300
+                    ? (this.message = `Http failure during parsing for ${t.url || "(unknown url)"}`)
+                    : (this.message = `Http failure response for ${t.url || "(unknown url)"}: ${t.status} ${t.statusText}`),
+                (this.error = t.error || null);
+        }
+    },
+    Kn = (function (n) {
+        return (
+            (n[(n.Continue = 100)] = "Continue"),
+            (n[(n.SwitchingProtocols = 101)] = "SwitchingProtocols"),
+            (n[(n.Processing = 102)] = "Processing"),
+            (n[(n.EarlyHints = 103)] = "EarlyHints"),
+            (n[(n.Ok = 200)] = "Ok"),
+            (n[(n.Created = 201)] = "Created"),
+            (n[(n.Accepted = 202)] = "Accepted"),
+            (n[(n.NonAuthoritativeInformation = 203)] =
+                "NonAuthoritativeInformation"),
+            (n[(n.NoContent = 204)] = "NoContent"),
+            (n[(n.ResetContent = 205)] = "ResetContent"),
+            (n[(n.PartialContent = 206)] = "PartialContent"),
+            (n[(n.MultiStatus = 207)] = "MultiStatus"),
+            (n[(n.AlreadyReported = 208)] = "AlreadyReported"),
+            (n[(n.ImUsed = 226)] = "ImUsed"),
+            (n[(n.MultipleChoices = 300)] = "MultipleChoices"),
+            (n[(n.MovedPermanently = 301)] = "MovedPermanently"),
+            (n[(n.Found = 302)] = "Found"),
+            (n[(n.SeeOther = 303)] = "SeeOther"),
+            (n[(n.NotModified = 304)] = "NotModified"),
+            (n[(n.UseProxy = 305)] = "UseProxy"),
+            (n[(n.Unused = 306)] = "Unused"),
+            (n[(n.TemporaryRedirect = 307)] = "TemporaryRedirect"),
+            (n[(n.PermanentRedirect = 308)] = "PermanentRedirect"),
+            (n[(n.BadRequest = 400)] = "BadRequest"),
+            (n[(n.Unauthorized = 401)] = "Unauthorized"),
+            (n[(n.PaymentRequired = 402)] = "PaymentRequired"),
+            (n[(n.Forbidden = 403)] = "Forbidden"),
+            (n[(n.NotFound = 404)] = "NotFound"),
+            (n[(n.MethodNotAllowed = 405)] = "MethodNotAllowed"),
+            (n[(n.NotAcceptable = 406)] = "NotAcceptable"),
+            (n[(n.ProxyAuthenticationRequired = 407)] =
+                "ProxyAuthenticationRequired"),
+            (n[(n.RequestTimeout = 408)] = "RequestTimeout"),
+            (n[(n.Conflict = 409)] = "Conflict"),
+            (n[(n.Gone = 410)] = "Gone"),
+            (n[(n.LengthRequired = 411)] = "LengthRequired"),
+            (n[(n.PreconditionFailed = 412)] = "PreconditionFailed"),
+            (n[(n.PayloadTooLarge = 413)] = "PayloadTooLarge"),
+            (n[(n.UriTooLong = 414)] = "UriTooLong"),
+            (n[(n.UnsupportedMediaType = 415)] = "UnsupportedMediaType"),
+            (n[(n.RangeNotSatisfiable = 416)] = "RangeNotSatisfiable"),
+            (n[(n.ExpectationFailed = 417)] = "ExpectationFailed"),
+            (n[(n.ImATeapot = 418)] = "ImATeapot"),
+            (n[(n.MisdirectedRequest = 421)] = "MisdirectedRequest"),
+            (n[(n.UnprocessableEntity = 422)] = "UnprocessableEntity"),
+            (n[(n.Locked = 423)] = "Locked"),
+            (n[(n.FailedDependency = 424)] = "FailedDependency"),
+            (n[(n.TooEarly = 425)] = "TooEarly"),
+            (n[(n.UpgradeRequired = 426)] = "UpgradeRequired"),
+            (n[(n.PreconditionRequired = 428)] = "PreconditionRequired"),
+            (n[(n.TooManyRequests = 429)] = "TooManyRequests"),
+            (n[(n.RequestHeaderFieldsTooLarge = 431)] =
+                "RequestHeaderFieldsTooLarge"),
+            (n[(n.UnavailableForLegalReasons = 451)] =
+                "UnavailableForLegalReasons"),
+            (n[(n.InternalServerError = 500)] = "InternalServerError"),
+            (n[(n.NotImplemented = 501)] = "NotImplemented"),
+            (n[(n.BadGateway = 502)] = "BadGateway"),
+            (n[(n.ServiceUnavailable = 503)] = "ServiceUnavailable"),
+            (n[(n.GatewayTimeout = 504)] = "GatewayTimeout"),
+            (n[(n.HttpVersionNotSupported = 505)] = "HttpVersionNotSupported"),
+            (n[(n.VariantAlsoNegotiates = 506)] = "VariantAlsoNegotiates"),
+            (n[(n.InsufficientStorage = 507)] = "InsufficientStorage"),
+            (n[(n.LoopDetected = 508)] = "LoopDetected"),
+            (n[(n.NotExtended = 510)] = "NotExtended"),
+            (n[(n.NetworkAuthenticationRequired = 511)] =
+                "NetworkAuthenticationRequired"),
+            n
+        );
+    })(Kn || {});
+function Er(n, t) {
+    return {
+        body: t,
+        headers: n.headers,
+        context: n.context,
+        observe: n.observe,
+        params: n.params,
+        reportProgress: n.reportProgress,
+        responseType: n.responseType,
+        withCredentials: n.withCredentials,
+        transferCache: n.transferCache,
+    };
+}
+var Oe = (() => {
+    let t = class t {
+        constructor(e) {
+            this.handler = e;
+        }
+        request(e, i, r = {}) {
+            let s;
+            if (e instanceof Li) s = e;
+            else {
+                let c;
+                r.headers instanceof Ae
+                    ? (c = r.headers)
+                    : (c = new Ae(r.headers));
+                let d;
+                r.params &&
+                    (r.params instanceof me
+                        ? (d = r.params)
+                        : (d = new me({ fromObject: r.params }))),
+                    (s = new Li(e, i, r.body !== void 0 ? r.body : null, {
+                        headers: c,
+                        context: r.context,
+                        params: d,
+                        reportProgress: r.reportProgress,
+                        responseType: r.responseType || "json",
+                        withCredentials: r.withCredentials,
+                        transferCache: r.transferCache,
+                    }));
+            }
+            let a = v(s).pipe(se((c) => this.handler.handle(c)));
+            if (e instanceof Li || r.observe === "events") return a;
+            let l = a.pipe(dt((c) => c instanceof Zn));
+            switch (r.observe || "body") {
+                case "body":
+                    switch (s.responseType) {
+                        case "arraybuffer":
+                            return l.pipe(
+                                M((c) => {
+                                    if (
+                                        c.body !== null &&
+                                        !(c.body instanceof ArrayBuffer)
+                                    )
+                                        throw new Error(
+                                            "Response is not an ArrayBuffer."
+                                        );
+                                    return c.body;
+                                })
+                            );
+                        case "blob":
+                            return l.pipe(
+                                M((c) => {
+                                    if (
+                                        c.body !== null &&
+                                        !(c.body instanceof Blob)
+                                    )
+                                        throw new Error(
+                                            "Response is not a Blob."
+                                        );
+                                    return c.body;
+                                })
+                            );
+                        case "text":
+                            return l.pipe(
+                                M((c) => {
+                                    if (
+                                        c.body !== null &&
+                                        typeof c.body != "string"
+                                    )
+                                        throw new Error(
+                                            "Response is not a string."
+                                        );
+                                    return c.body;
+                                })
+                            );
+                        case "json":
+                        default:
+                            return l.pipe(M((c) => c.body));
+                    }
+                case "response":
+                    return l;
+                default:
+                    throw new Error(
+                        `Unreachable: unhandled observe type ${r.observe}}`
+                    );
+            }
+        }
+        delete(e, i = {}) {
+            return this.request("DELETE", e, i);
+        }
+        get(e, i = {}) {
+            return this.request("GET", e, i);
+        }
+        head(e, i = {}) {
+            return this.request("HEAD", e, i);
+        }
+        jsonp(e, i) {
+            return this.request("JSONP", e, {
+                params: new me().append(i, "JSONP_CALLBACK"),
+                observe: "body",
+                responseType: "json",
+            });
+        }
+        options(e, i = {}) {
+            return this.request("OPTIONS", e, i);
+        }
+        patch(e, i, r = {}) {
+            return this.request("PATCH", e, Er(r, i));
+        }
+        post(e, i, r = {}) {
+            return this.request("POST", e, Er(r, i));
+        }
+        put(e, i, r = {}) {
+            return this.request("PUT", e, Er(r, i));
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(ji));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+    let n = t;
+    return n;
+})();
+function xl(n, t) {
+    return t(n);
+}
+function Uu(n, t) {
+    return (o, e) => t.intercept(o, { handle: (i) => n(i, e) });
+}
+function Hu(n, t, o) {
+    return (e, i) => zt(o, () => t(e, (r) => n(r, i)));
+}
+var $u = new C(""),
+    Mr = new C(""),
+    Wu = new C(""),
+    Gu = new C("");
+function Yu() {
+    let n = null;
+    return (t, o) => {
+        n === null && (n = (g($u, { optional: !0 }) ?? []).reduceRight(Uu, xl));
+        let e = g(Fi),
+            i = e.add();
+        return n(t, o).pipe(Zt(() => e.remove(i)));
+    };
+}
+var vl = (() => {
+    let t = class t extends ji {
+        constructor(e, i) {
+            super(),
+                (this.backend = e),
+                (this.injector = i),
+                (this.chain = null),
+                (this.pendingTasks = g(Fi));
+            let r = g(Gu, { optional: !0 });
+            this.backend = r ?? e;
+        }
+        handle(e) {
+            if (this.chain === null) {
+                let r = Array.from(
+                    new Set([
+                        ...this.injector.get(Mr),
+                        ...this.injector.get(Wu, []),
+                    ])
+                );
+                this.chain = r.reduceRight(
+                    (s, a) => Hu(s, a, this.injector),
+                    xl
+                );
+            }
+            let i = this.pendingTasks.add();
+            return this.chain(e, (r) => this.backend.handle(r)).pipe(
+                Zt(() => this.pendingTasks.remove(i))
+            );
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(qn), m(ce));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+    let n = t;
+    return n;
+})();
+var qu = /^\)\]\}',?\n/;
+function Zu(n) {
+    return "responseURL" in n && n.responseURL
+        ? n.responseURL
+        : /^X-Request-URL:/m.test(n.getAllResponseHeaders())
+          ? n.getResponseHeader("X-Request-URL")
+          : null;
+}
+var _l = (() => {
+        let t = class t {
+            constructor(e) {
+                this.xhrFactory = e;
+            }
+            handle(e) {
+                if (e.method === "JSONP") throw new $(-2800, !1);
+                let i = this.xhrFactory;
+                return (i.ɵloadImpl ? ht(i.ɵloadImpl()) : v(null)).pipe(
+                    vt(
+                        () =>
+                            new $e((s) => {
+                                let a = i.build();
+                                if (
+                                    (a.open(e.method, e.urlWithParams),
+                                    e.withCredentials &&
+                                        (a.withCredentials = !0),
+                                    e.headers.forEach((k, V) =>
+                                        a.setRequestHeader(k, V.join(","))
+                                    ),
+                                    e.headers.has("Accept") ||
+                                        a.setRequestHeader(
+                                            "Accept",
+                                            "application/json, text/plain, */*"
+                                        ),
+                                    !e.headers.has("Content-Type"))
+                                ) {
+                                    let k = e.detectContentTypeHeader();
+                                    k !== null &&
+                                        a.setRequestHeader("Content-Type", k);
+                                }
+                                if (e.responseType) {
+                                    let k = e.responseType.toLowerCase();
+                                    a.responseType = k !== "json" ? k : "text";
+                                }
+                                let l = e.serializeBody(),
+                                    c = null,
+                                    d = () => {
+                                        if (c !== null) return c;
+                                        let k = a.statusText || "OK",
+                                            V = new Ae(
+                                                a.getAllResponseHeaders()
+                                            ),
+                                            Pt = Zu(a) || e.url;
+                                        return (
+                                            (c = new Rr({
+                                                headers: V,
+                                                status: a.status,
+                                                statusText: k,
+                                                url: Pt,
+                                            })),
+                                            c
+                                        );
+                                    },
+                                    h = () => {
+                                        let {
+                                                headers: k,
+                                                status: V,
+                                                statusText: Pt,
+                                                url: Ia,
+                                            } = d(),
+                                            Et = null;
+                                        V !== Kn.NoContent &&
+                                            (Et =
+                                                typeof a.response > "u"
+                                                    ? a.responseText
+                                                    : a.response),
+                                            V === 0 && (V = Et ? Kn.Ok : 0);
+                                        let or = V >= 200 && V < 300;
+                                        if (
+                                            e.responseType === "json" &&
+                                            typeof Et == "string"
+                                        ) {
+                                            let Au = Et;
+                                            Et = Et.replace(qu, "");
+                                            try {
+                                                Et =
+                                                    Et !== ""
+                                                        ? JSON.parse(Et)
+                                                        : null;
+                                            } catch (Fu) {
+                                                (Et = Au),
+                                                    or &&
+                                                        ((or = !1),
+                                                        (Et = {
+                                                            error: Fu,
+                                                            text: Et,
+                                                        }));
+                                            }
+                                        }
+                                        or
+                                            ? (s.next(
+                                                  new Zn({
+                                                      body: Et,
+                                                      headers: k,
+                                                      status: V,
+                                                      statusText: Pt,
+                                                      url: Ia || void 0,
+                                                  })
+                                              ),
+                                              s.complete())
+                                            : s.error(
+                                                  new Xn({
+                                                      error: Et,
+                                                      headers: k,
+                                                      status: V,
+                                                      statusText: Pt,
+                                                      url: Ia || void 0,
+                                                  })
+                                              );
+                                    },
+                                    f = (k) => {
+                                        let { url: V } = d(),
+                                            Pt = new Xn({
+                                                error: k,
+                                                status: a.status || 0,
+                                                statusText:
+                                                    a.statusText ||
+                                                    "Unknown Error",
+                                                url: V || void 0,
+                                            });
+                                        s.error(Pt);
+                                    },
+                                    w = !1,
+                                    j = (k) => {
+                                        w || (s.next(d()), (w = !0));
+                                        let V = {
+                                            type: ei.DownloadProgress,
+                                            loaded: k.loaded,
+                                        };
+                                        k.lengthComputable &&
+                                            (V.total = k.total),
+                                            e.responseType === "text" &&
+                                                a.responseText &&
+                                                (V.partialText =
+                                                    a.responseText),
+                                            s.next(V);
+                                    },
+                                    z = (k) => {
+                                        let V = {
+                                            type: ei.UploadProgress,
+                                            loaded: k.loaded,
+                                        };
+                                        k.lengthComputable &&
+                                            (V.total = k.total),
+                                            s.next(V);
+                                    };
+                                return (
+                                    a.addEventListener("load", h),
+                                    a.addEventListener("error", f),
+                                    a.addEventListener("timeout", f),
+                                    a.addEventListener("abort", f),
+                                    e.reportProgress &&
+                                        (a.addEventListener("progress", j),
+                                        l !== null &&
+                                            a.upload &&
+                                            a.upload.addEventListener(
+                                                "progress",
+                                                z
+                                            )),
+                                    a.send(l),
+                                    s.next({ type: ei.Sent }),
+                                    () => {
+                                        a.removeEventListener("error", f),
+                                            a.removeEventListener("abort", f),
+                                            a.removeEventListener("load", h),
+                                            a.removeEventListener("timeout", f),
+                                            e.reportProgress &&
+                                                (a.removeEventListener(
+                                                    "progress",
+                                                    j
+                                                ),
+                                                l !== null &&
+                                                    a.upload &&
+                                                    a.upload.removeEventListener(
+                                                        "progress",
+                                                        z
+                                                    )),
+                                            a.readyState !== a.DONE &&
+                                                a.abort();
+                                    }
+                                );
+                            })
+                    )
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m($n));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })(),
+    wl = new C(""),
+    Xu = "XSRF-TOKEN",
+    Ku = new C("", { providedIn: "root", factory: () => Xu }),
+    Qu = "X-XSRF-TOKEN",
+    Ju = new C("", { providedIn: "root", factory: () => Qu }),
+    Qn = class {},
+    th = (() => {
+        let t = class t {
+            constructor(e, i, r) {
+                (this.doc = e),
+                    (this.platform = i),
+                    (this.cookieName = r),
+                    (this.lastCookieString = ""),
+                    (this.lastToken = null),
+                    (this.parseCount = 0);
+            }
+            getToken() {
+                if (this.platform === "server") return null;
+                let e = this.doc.cookie || "";
+                return (
+                    e !== this.lastCookieString &&
+                        (this.parseCount++,
+                        (this.lastToken = Un(e, this.cookieName)),
+                        (this.lastCookieString = e)),
+                    this.lastToken
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T), m(Qt), m(Ku));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })();
+function eh(n, t) {
+    let o = n.url.toLowerCase();
+    if (
+        !g(wl) ||
+        n.method === "GET" ||
+        n.method === "HEAD" ||
+        o.startsWith("http://") ||
+        o.startsWith("https://")
+    )
+        return t(n);
+    let e = g(Qn).getToken(),
+        i = g(Ju);
+    return (
+        e != null &&
+            !n.headers.has(i) &&
+            (n = n.clone({ headers: n.headers.set(i, e) })),
+        t(n)
+    );
+}
+var Cl = (function (n) {
+    return (
+        (n[(n.Interceptors = 0)] = "Interceptors"),
+        (n[(n.LegacyInterceptors = 1)] = "LegacyInterceptors"),
+        (n[(n.CustomXsrfConfiguration = 2)] = "CustomXsrfConfiguration"),
+        (n[(n.NoXsrfProtection = 3)] = "NoXsrfProtection"),
+        (n[(n.JsonpSupport = 4)] = "JsonpSupport"),
+        (n[(n.RequestsMadeViaParent = 5)] = "RequestsMadeViaParent"),
+        (n[(n.Fetch = 6)] = "Fetch"),
+        n
+    );
+})(Cl || {});
+function ih(n, t) {
+    return { ɵkind: n, ɵproviders: t };
+}
+function nh(...n) {
+    let t = [
+        Oe,
+        _l,
+        vl,
+        { provide: ji, useExisting: vl },
+        { provide: qn, useExisting: _l },
+        { provide: Mr, useValue: eh, multi: !0 },
+        { provide: wl, useValue: !0 },
+        { provide: Qn, useClass: th },
+    ];
+    for (let o of n) t.push(...o.ɵproviders);
+    return Ge(t);
+}
+var yl = new C("");
+function oh() {
+    return ih(Cl.LegacyInterceptors, [
+        { provide: yl, useFactory: Yu },
+        { provide: Mr, useExisting: yl, multi: !0 },
+    ]);
+}
+var Dl = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({ providers: [nh(oh())] }));
+    let n = t;
+    return n;
+})();
+var Fr = class extends al {
+        constructor() {
+            super(...arguments), (this.supportsDOMEvents = !0);
+        }
+    },
+    Or = class n extends Fr {
+        static makeCurrent() {
+            sl(new n());
+        }
+        onAndCancel(t, o, e) {
+            return (
+                t.addEventListener(o, e),
+                () => {
+                    t.removeEventListener(o, e);
+                }
+            );
+        }
+        dispatchEvent(t, o) {
+            t.dispatchEvent(o);
+        }
+        remove(t) {
+            t.parentNode && t.parentNode.removeChild(t);
+        }
+        createElement(t, o) {
+            return (o = o || this.getDefaultDocument()), o.createElement(t);
+        }
+        createHtmlDocument() {
+            return document.implementation.createHTMLDocument("fakeTitle");
+        }
+        getDefaultDocument() {
+            return document;
+        }
+        isElementNode(t) {
+            return t.nodeType === Node.ELEMENT_NODE;
+        }
+        isShadowRoot(t) {
+            return t instanceof DocumentFragment;
+        }
+        getGlobalEventTarget(t, o) {
+            return o === "window"
+                ? window
+                : o === "document"
+                  ? t
+                  : o === "body"
+                    ? t.body
+                    : null;
+        }
+        getBaseHref(t) {
+            let o = sh();
+            return o == null ? null : ah(o);
+        }
+        resetBaseElement() {
+            zi = null;
+        }
+        getUserAgent() {
+            return window.navigator.userAgent;
+        }
+        getCookie(t) {
+            return Un(document.cookie, t);
+        }
+    },
+    zi = null;
+function sh() {
+    return (
+        (zi = zi || document.querySelector("base")),
+        zi ? zi.getAttribute("href") : null
+    );
+}
+function ah(n) {
+    return new URL(n, document.baseURI).pathname;
+}
+var Nr = class {
+        addToWindow(t) {
+            (le.getAngularTestability = (e, i = !0) => {
+                let r = t.findTestabilityInTree(e, i);
+                if (r == null) throw new $(5103, !1);
+                return r;
+            }),
+                (le.getAllAngularTestabilities = () => t.getAllTestabilities()),
+                (le.getAllAngularRootElements = () => t.getAllRootElements());
+            let o = (e) => {
+                let i = le.getAllAngularTestabilities(),
+                    r = i.length,
+                    s = function () {
+                        r--, r == 0 && e();
+                    };
+                i.forEach((a) => {
+                    a.whenStable(s);
+                });
+            };
+            le.frameworkStabilizers || (le.frameworkStabilizers = []),
+                le.frameworkStabilizers.push(o);
+        }
+        findTestabilityInTree(t, o, e) {
+            if (o == null) return null;
+            let i = t.getTestability(o);
+            return (
+                i ??
+                (e
+                    ? ke().isShadowRoot(o)
+                        ? this.findTestabilityInTree(t, o.host, !0)
+                        : this.findTestabilityInTree(t, o.parentElement, !0)
+                    : null)
+            );
+        }
+    },
+    lh = (() => {
+        let t = class t {
+            build() {
+                return new XMLHttpRequest();
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })(),
+    Pr = new C(""),
+    Il = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this._zone = i),
+                    (this._eventNameToPlugin = new Map()),
+                    e.forEach((r) => {
+                        r.manager = this;
+                    }),
+                    (this._plugins = e.slice().reverse());
+            }
+            addEventListener(e, i, r) {
+                return this._findPluginFor(i).addEventListener(e, i, r);
+            }
+            getZone() {
+                return this._zone;
+            }
+            _findPluginFor(e) {
+                let i = this._eventNameToPlugin.get(e);
+                if (i) return i;
+                if (((i = this._plugins.find((s) => s.supports(e))), !i))
+                    throw new $(5101, !1);
+                return this._eventNameToPlugin.set(e, i), i;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(Pr), m(I));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })(),
+    Jn = class {
+        constructor(t) {
+            this._doc = t;
+        }
+    },
+    Tr = "ng-app-id",
+    Rl = (() => {
+        let t = class t {
+            constructor(e, i, r, s = {}) {
+                (this.doc = e),
+                    (this.appId = i),
+                    (this.nonce = r),
+                    (this.platformId = s),
+                    (this.styleRef = new Map()),
+                    (this.hostNodes = new Set()),
+                    (this.styleNodesInDOM = this.collectServerRenderedStyles()),
+                    (this.platformIsServer = Hn(s)),
+                    this.resetHostNodes();
+            }
+            addStyles(e) {
+                for (let i of e)
+                    this.changeUsageCount(i, 1) === 1 && this.onStyleAdded(i);
+            }
+            removeStyles(e) {
+                for (let i of e)
+                    this.changeUsageCount(i, -1) <= 0 && this.onStyleRemoved(i);
+            }
+            ngOnDestroy() {
+                let e = this.styleNodesInDOM;
+                e && (e.forEach((i) => i.remove()), e.clear());
+                for (let i of this.getAllStyles()) this.onStyleRemoved(i);
+                this.resetHostNodes();
+            }
+            addHost(e) {
+                this.hostNodes.add(e);
+                for (let i of this.getAllStyles()) this.addStyleToHost(e, i);
+            }
+            removeHost(e) {
+                this.hostNodes.delete(e);
+            }
+            getAllStyles() {
+                return this.styleRef.keys();
+            }
+            onStyleAdded(e) {
+                for (let i of this.hostNodes) this.addStyleToHost(i, e);
+            }
+            onStyleRemoved(e) {
+                let i = this.styleRef;
+                i.get(e)?.elements?.forEach((r) => r.remove()), i.delete(e);
+            }
+            collectServerRenderedStyles() {
+                let e = this.doc.head?.querySelectorAll(
+                    `style[${Tr}="${this.appId}"]`
+                );
+                if (e?.length) {
+                    let i = new Map();
+                    return (
+                        e.forEach((r) => {
+                            r.textContent != null && i.set(r.textContent, r);
+                        }),
+                        i
+                    );
+                }
+                return null;
+            }
+            changeUsageCount(e, i) {
+                let r = this.styleRef;
+                if (r.has(e)) {
+                    let s = r.get(e);
+                    return (s.usage += i), s.usage;
+                }
+                return r.set(e, { usage: i, elements: [] }), i;
+            }
+            getStyleElement(e, i) {
+                let r = this.styleNodesInDOM,
+                    s = r?.get(i);
+                if (s?.parentNode === e)
+                    return r.delete(i), s.removeAttribute(Tr), s;
+                {
+                    let a = this.doc.createElement("style");
+                    return (
+                        this.nonce && a.setAttribute("nonce", this.nonce),
+                        (a.textContent = i),
+                        this.platformIsServer && a.setAttribute(Tr, this.appId),
+                        e.appendChild(a),
+                        a
+                    );
+                }
+            }
+            addStyleToHost(e, i) {
+                let r = this.getStyleElement(e, i),
+                    s = this.styleRef,
+                    a = s.get(i)?.elements;
+                a ? a.push(r) : s.set(i, { elements: [r], usage: 1 });
+            }
+            resetHostNodes() {
+                let e = this.hostNodes;
+                e.clear(), e.add(this.doc.head);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T), m(Mi), m(ki, 8), m(Qt));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })(),
+    Ar = {
+        svg: "http://www.w3.org/2000/svg",
+        xhtml: "http://www.w3.org/1999/xhtml",
+        xlink: "http://www.w3.org/1999/xlink",
+        xml: "http://www.w3.org/XML/1998/namespace",
+        xmlns: "http://www.w3.org/2000/xmlns/",
+        math: "http://www.w3.org/1998/MathML/",
+    },
+    Vr = /%COMP%/g,
+    Ml = "%COMP%",
+    ch = `_nghost-${Ml}`,
+    dh = `_ngcontent-${Ml}`,
+    uh = !0,
+    hh = new C("", { providedIn: "root", factory: () => uh });
+function mh(n) {
+    return dh.replace(Vr, n);
+}
+function fh(n) {
+    return ch.replace(Vr, n);
+}
+function kl(n, t) {
+    return t.map((o) => o.replace(Vr, n));
+}
+var to = (() => {
+        let t = class t {
+            constructor(e, i, r, s, a, l, c, d = null) {
+                (this.eventManager = e),
+                    (this.sharedStylesHost = i),
+                    (this.appId = r),
+                    (this.removeStylesOnCompDestroy = s),
+                    (this.doc = a),
+                    (this.platformId = l),
+                    (this.ngZone = c),
+                    (this.nonce = d),
+                    (this.rendererByCompId = new Map()),
+                    (this.platformIsServer = Hn(l)),
+                    (this.defaultRenderer = new Bi(
+                        e,
+                        a,
+                        c,
+                        this.platformIsServer
+                    ));
+            }
+            createRenderer(e, i) {
+                if (!e || !i) return this.defaultRenderer;
+                this.platformIsServer &&
+                    i.encapsulation === Ii.ShadowDom &&
+                    (i = q(p({}, i), { encapsulation: Ii.Emulated }));
+                let r = this.getOrCreateRenderer(e, i);
+                return (
+                    r instanceof eo
+                        ? r.applyToHost(e)
+                        : r instanceof Ui && r.applyStyles(),
+                    r
+                );
+            }
+            getOrCreateRenderer(e, i) {
+                let r = this.rendererByCompId,
+                    s = r.get(i.id);
+                if (!s) {
+                    let a = this.doc,
+                        l = this.ngZone,
+                        c = this.eventManager,
+                        d = this.sharedStylesHost,
+                        h = this.removeStylesOnCompDestroy,
+                        f = this.platformIsServer;
+                    switch (i.encapsulation) {
+                        case Ii.Emulated:
+                            s = new eo(c, d, i, this.appId, h, a, l, f);
+                            break;
+                        case Ii.ShadowDom:
+                            return new Lr(c, d, e, i, a, l, this.nonce, f);
+                        default:
+                            s = new Ui(c, d, i, h, a, l, f);
+                            break;
+                    }
+                    r.set(i.id, s);
+                }
+                return s;
+            }
+            ngOnDestroy() {
+                this.rendererByCompId.clear();
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(
+                m(Il),
+                m(Rl),
+                m(Mi),
+                m(hh),
+                m(T),
+                m(Qt),
+                m(I),
+                m(ki)
+            );
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })(),
+    Bi = class {
+        constructor(t, o, e, i) {
+            (this.eventManager = t),
+                (this.doc = o),
+                (this.ngZone = e),
+                (this.platformIsServer = i),
+                (this.data = Object.create(null)),
+                (this.throwOnSyntheticProps = !0),
+                (this.destroyNode = null);
+        }
+        destroy() {}
+        createElement(t, o) {
+            return o
+                ? this.doc.createElementNS(Ar[o] || o, t)
+                : this.doc.createElement(t);
+        }
+        createComment(t) {
+            return this.doc.createComment(t);
+        }
+        createText(t) {
+            return this.doc.createTextNode(t);
+        }
+        appendChild(t, o) {
+            (El(t) ? t.content : t).appendChild(o);
+        }
+        insertBefore(t, o, e) {
+            t && (El(t) ? t.content : t).insertBefore(o, e);
+        }
+        removeChild(t, o) {
+            t && t.removeChild(o);
+        }
+        selectRootElement(t, o) {
+            let e = typeof t == "string" ? this.doc.querySelector(t) : t;
+            if (!e) throw new $(-5104, !1);
+            return o || (e.textContent = ""), e;
+        }
+        parentNode(t) {
+            return t.parentNode;
+        }
+        nextSibling(t) {
+            return t.nextSibling;
+        }
+        setAttribute(t, o, e, i) {
+            if (i) {
+                o = i + ":" + o;
+                let r = Ar[i];
+                r ? t.setAttributeNS(r, o, e) : t.setAttribute(o, e);
+            } else t.setAttribute(o, e);
+        }
+        removeAttribute(t, o, e) {
+            if (e) {
+                let i = Ar[e];
+                i ? t.removeAttributeNS(i, o) : t.removeAttribute(`${e}:${o}`);
+            } else t.removeAttribute(o);
+        }
+        addClass(t, o) {
+            t.classList.add(o);
+        }
+        removeClass(t, o) {
+            t.classList.remove(o);
+        }
+        setStyle(t, o, e, i) {
+            i & (Ti.DashCase | Ti.Important)
+                ? t.style.setProperty(o, e, i & Ti.Important ? "important" : "")
+                : (t.style[o] = e);
+        }
+        removeStyle(t, o, e) {
+            e & Ti.DashCase ? t.style.removeProperty(o) : (t.style[o] = "");
+        }
+        setProperty(t, o, e) {
+            t != null && (t[o] = e);
+        }
+        setValue(t, o) {
+            t.nodeValue = o;
+        }
+        listen(t, o, e) {
+            if (
+                typeof t == "string" &&
+                ((t = ke().getGlobalEventTarget(this.doc, t)), !t)
+            )
+                throw new Error(`Unsupported event target ${t} for event ${o}`);
+            return this.eventManager.addEventListener(
+                t,
+                o,
+                this.decoratePreventDefault(e)
+            );
+        }
+        decoratePreventDefault(t) {
+            return (o) => {
+                if (o === "__ngUnwrap__") return t;
+                (this.platformIsServer
+                    ? this.ngZone.runGuarded(() => t(o))
+                    : t(o)) === !1 && o.preventDefault();
+            };
+        }
+    };
+function El(n) {
+    return n.tagName === "TEMPLATE" && n.content !== void 0;
+}
+var Lr = class extends Bi {
+        constructor(t, o, e, i, r, s, a, l) {
+            super(t, r, s, l),
+                (this.sharedStylesHost = o),
+                (this.hostEl = e),
+                (this.shadowRoot = e.attachShadow({ mode: "open" })),
+                this.sharedStylesHost.addHost(this.shadowRoot);
+            let c = kl(i.id, i.styles);
+            for (let d of c) {
+                let h = document.createElement("style");
+                a && h.setAttribute("nonce", a),
+                    (h.textContent = d),
+                    this.shadowRoot.appendChild(h);
+            }
+        }
+        nodeOrShadowRoot(t) {
+            return t === this.hostEl ? this.shadowRoot : t;
+        }
+        appendChild(t, o) {
+            return super.appendChild(this.nodeOrShadowRoot(t), o);
+        }
+        insertBefore(t, o, e) {
+            return super.insertBefore(this.nodeOrShadowRoot(t), o, e);
+        }
+        removeChild(t, o) {
+            return super.removeChild(this.nodeOrShadowRoot(t), o);
+        }
+        parentNode(t) {
+            return this.nodeOrShadowRoot(
+                super.parentNode(this.nodeOrShadowRoot(t))
+            );
+        }
+        destroy() {
+            this.sharedStylesHost.removeHost(this.shadowRoot);
+        }
+    },
+    Ui = class extends Bi {
+        constructor(t, o, e, i, r, s, a, l) {
+            super(t, r, s, a),
+                (this.sharedStylesHost = o),
+                (this.removeStylesOnCompDestroy = i),
+                (this.styles = l ? kl(l, e.styles) : e.styles);
+        }
+        applyStyles() {
+            this.sharedStylesHost.addStyles(this.styles);
+        }
+        destroy() {
+            this.removeStylesOnCompDestroy &&
+                this.sharedStylesHost.removeStyles(this.styles);
+        }
+    },
+    eo = class extends Ui {
+        constructor(t, o, e, i, r, s, a, l) {
+            let c = i + "-" + e.id;
+            super(t, o, e, r, s, a, l, c),
+                (this.contentAttr = mh(c)),
+                (this.hostAttr = fh(c));
+        }
+        applyToHost(t) {
+            this.applyStyles(), this.setAttribute(t, this.hostAttr, "");
+        }
+        createElement(t, o) {
+            let e = super.createElement(t, o);
+            return super.setAttribute(e, this.contentAttr, ""), e;
+        }
+    },
+    ph = (() => {
+        let t = class t extends Jn {
+            constructor(e) {
+                super(e);
+            }
+            supports(e) {
+                return !0;
+            }
+            addEventListener(e, i, r) {
+                return (
+                    e.addEventListener(i, r, !1),
+                    () => this.removeEventListener(e, i, r)
+                );
+            }
+            removeEventListener(e, i, r) {
+                return e.removeEventListener(i, r);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })(),
+    Sl = ["alt", "control", "meta", "shift"],
+    gh = {
+        "\b": "Backspace",
+        "	": "Tab",
+        "\x7F": "Delete",
+        "\x1B": "Escape",
+        Del: "Delete",
+        Esc: "Escape",
+        Left: "ArrowLeft",
+        Right: "ArrowRight",
+        Up: "ArrowUp",
+        Down: "ArrowDown",
+        Menu: "ContextMenu",
+        Scroll: "ScrollLock",
+        Win: "OS",
+    },
+    bh = {
+        alt: (n) => n.altKey,
+        control: (n) => n.ctrlKey,
+        meta: (n) => n.metaKey,
+        shift: (n) => n.shiftKey,
+    },
+    vh = (() => {
+        let t = class t extends Jn {
+            constructor(e) {
+                super(e);
+            }
+            supports(e) {
+                return t.parseEventName(e) != null;
+            }
+            addEventListener(e, i, r) {
+                let s = t.parseEventName(i),
+                    a = t.eventCallback(s.fullKey, r, this.manager.getZone());
+                return this.manager
+                    .getZone()
+                    .runOutsideAngular(() =>
+                        ke().onAndCancel(e, s.domEventName, a)
+                    );
+            }
+            static parseEventName(e) {
+                let i = e.toLowerCase().split("."),
+                    r = i.shift();
+                if (i.length === 0 || !(r === "keydown" || r === "keyup"))
+                    return null;
+                let s = t._normalizeKey(i.pop()),
+                    a = "",
+                    l = i.indexOf("code");
+                if (
+                    (l > -1 && (i.splice(l, 1), (a = "code.")),
+                    Sl.forEach((d) => {
+                        let h = i.indexOf(d);
+                        h > -1 && (i.splice(h, 1), (a += d + "."));
+                    }),
+                    (a += s),
+                    i.length != 0 || s.length === 0)
+                )
+                    return null;
+                let c = {};
+                return (c.domEventName = r), (c.fullKey = a), c;
+            }
+            static matchEventFullKeyCode(e, i) {
+                let r = gh[e.key] || e.key,
+                    s = "";
+                return (
+                    i.indexOf("code.") > -1 && ((r = e.code), (s = "code.")),
+                    r == null || !r
+                        ? !1
+                        : ((r = r.toLowerCase()),
+                          r === " " ? (r = "space") : r === "." && (r = "dot"),
+                          Sl.forEach((a) => {
+                              if (a !== r) {
+                                  let l = bh[a];
+                                  l(e) && (s += a + ".");
+                              }
+                          }),
+                          (s += r),
+                          s === i)
+                );
+            }
+            static eventCallback(e, i, r) {
+                return (s) => {
+                    t.matchEventFullKeyCode(s, e) && r.runGuarded(() => i(s));
+                };
+            }
+            static _normalizeKey(e) {
+                return e === "esc" ? "escape" : e;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })();
+function _h() {
+    Or.makeCurrent();
+}
+function yh() {
+    return new Ee();
+}
+function xh() {
+    return ja(document), document;
+}
+var wh = [
+        { provide: Qt, useValue: ul },
+        { provide: Va, useValue: _h, multi: !0 },
+        { provide: T, useFactory: xh, deps: [] },
+    ],
+    Tl = tl(el, "browser", wh),
+    Ch = new C(""),
+    Dh = [
+        { provide: jn, useClass: Nr, deps: [] },
+        { provide: Ja, useClass: Vn, deps: [I, yr, jn] },
+        { provide: Vn, useClass: Vn, deps: [I, yr, jn] },
+    ],
+    Eh = [
+        { provide: Pa, useValue: "root" },
+        { provide: Ee, useFactory: yh, deps: [] },
+        { provide: Pr, useClass: ph, multi: !0, deps: [T, I, Qt] },
+        { provide: Pr, useClass: vh, multi: !0, deps: [T] },
+        to,
+        Rl,
+        Il,
+        { provide: Pn, useExisting: to },
+        { provide: $n, useClass: lh, deps: [] },
+        [],
+    ],
+    Al = (() => {
+        let t = class t {
+            constructor(e) {}
+            static withServerTransition(e) {
+                return {
+                    ngModule: t,
+                    providers: [{ provide: Mi, useValue: e.appId }],
+                };
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(Ch, 12));
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ providers: [...Eh, ...Dh], imports: [Je, il] }));
+        let n = t;
+        return n;
+    })();
+var Fl = (() => {
+    let t = class t {
+        constructor(e) {
+            this._doc = e;
+        }
+        getTitle() {
+            return this._doc.title;
+        }
+        setTitle(e) {
+            this._doc.title = e || "";
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(T));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+var zr = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({
+                token: t,
+                factory: function (i) {
+                    let r = null;
+                    return i ? (r = new (i || t)()) : (r = m(Sh)), r;
+                },
+                providedIn: "root",
+            }));
+        let n = t;
+        return n;
+    })(),
+    Sh = (() => {
+        let t = class t extends zr {
+            constructor(e) {
+                super(), (this._doc = e);
+            }
+            sanitize(e, i) {
+                if (i == null) return null;
+                switch (e) {
+                    case Mt.NONE:
+                        return i;
+                    case Mt.HTML:
+                        return qe(i, "HTML")
+                            ? Ye(i)
+                            : Ga(this._doc, String(i)).toString();
+                    case Mt.STYLE:
+                        return qe(i, "Style") ? Ye(i) : i;
+                    case Mt.SCRIPT:
+                        if (qe(i, "Script")) return Ye(i);
+                        throw new $(5200, !1);
+                    case Mt.URL:
+                        return qe(i, "URL") ? Ye(i) : Wa(String(i));
+                    case Mt.RESOURCE_URL:
+                        if (qe(i, "ResourceURL")) return Ye(i);
+                        throw new $(5201, !1);
+                    default:
+                        throw new $(5202, !1);
+                }
+            }
+            bypassSecurityTrustHtml(e) {
+                return za(e);
+            }
+            bypassSecurityTrustStyle(e) {
+                return Ba(e);
+            }
+            bypassSecurityTrustScript(e) {
+                return Ua(e);
+            }
+            bypassSecurityTrustUrl(e) {
+                return Ha(e);
+            }
+            bypassSecurityTrustResourceUrl(e) {
+                return $a(e);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+var fe = (() => {
+    let t = class t {
+        constructor(e) {
+            (this.http = e),
+                (this.hostUrl = "https://pricepinion.azurewebsites.net/");
+        }
+        getAllProducts() {
+            return this.http.get(`${this.hostUrl}api/products`);
+        }
+        getOneProduct(e) {
+            return this.http.get(`${this.hostUrl}api/product/${e}`);
+        }
+        setSaveForLater(e) {
+            return this.http.post(
+                `${this.hostUrl}api/customer/save-for-later`,
+                { productID: e },
+                { withCredentials: !0 }
+            );
+        }
+        getSaveForLater() {
+            return this.http.get(`${this.hostUrl}api/save-for-later`, {
+                withCredentials: !0,
+            });
+        }
+        deleteSflProduct(e) {
+            return this.http.delete(
+                `${this.hostUrl}api/customer/delete-one-product-from-sfl/${e}`,
+                { withCredentials: !0 }
+            );
+        }
+        deleteAllSflProducts() {
+            return this.http.delete(
+                `${this.hostUrl}api/customer/delete-all-products-from-sfl`,
+                { withCredentials: !0 }
+            );
+        }
+        authenticateGoogle() {
+            return this.http.get(`${this.hostUrl}auth/google`);
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(Oe));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+var O = "primary",
+    on = Symbol("RouteTitle"),
+    Yr = class {
+        constructor(t) {
+            this.params = t || {};
+        }
+        has(t) {
+            return Object.prototype.hasOwnProperty.call(this.params, t);
+        }
+        get(t) {
+            if (this.has(t)) {
+                let o = this.params[t];
+                return Array.isArray(o) ? o[0] : o;
+            }
+            return null;
+        }
+        getAll(t) {
+            if (this.has(t)) {
+                let o = this.params[t];
+                return Array.isArray(o) ? o : [o];
+            }
+            return [];
+        }
+        get keys() {
+            return Object.keys(this.params);
+        }
+    };
+function si(n) {
+    return new Yr(n);
+}
+function Ih(n, t, o) {
+    let e = o.path.split("/");
+    if (
+        e.length > n.length ||
+        (o.pathMatch === "full" && (t.hasChildren() || e.length < n.length))
+    )
+        return null;
+    let i = {};
+    for (let r = 0; r < e.length; r++) {
+        let s = e[r],
+            a = n[r];
+        if (s.startsWith(":")) i[s.substring(1)] = a;
+        else if (s !== a.path) return null;
+    }
+    return { consumed: n.slice(0, e.length), posParams: i };
+}
+function Rh(n, t) {
+    if (n.length !== t.length) return !1;
+    for (let o = 0; o < n.length; ++o) if (!$t(n[o], t[o])) return !1;
+    return !0;
+}
+function $t(n, t) {
+    let o = n ? qr(n) : void 0,
+        e = t ? qr(t) : void 0;
+    if (!o || !e || o.length != e.length) return !1;
+    let i;
+    for (let r = 0; r < o.length; r++)
+        if (((i = o[r]), !Ul(n[i], t[i]))) return !1;
+    return !0;
+}
+function qr(n) {
+    return [...Object.keys(n), ...Object.getOwnPropertySymbols(n)];
+}
+function Ul(n, t) {
+    if (Array.isArray(n) && Array.isArray(t)) {
+        if (n.length !== t.length) return !1;
+        let o = [...n].sort(),
+            e = [...t].sort();
+        return o.every((i, r) => e[r] === i);
+    } else return n === t;
+}
+function Hl(n) {
+    return n.length > 0 ? n[n.length - 1] : null;
+}
+function ve(n) {
+    return We(n) ? n : zn(n) ? ht(Promise.resolve(n)) : v(n);
+}
+var Mh = { exact: Wl, subset: Gl },
+    $l = { exact: kh, subset: Th, ignored: () => !0 };
+function Ol(n, t, o) {
+    return (
+        Mh[o.paths](n.root, t.root, o.matrixParams) &&
+        $l[o.queryParams](n.queryParams, t.queryParams) &&
+        !(o.fragment === "exact" && n.fragment !== t.fragment)
+    );
+}
+function kh(n, t) {
+    return $t(n, t);
+}
+function Wl(n, t, o) {
+    if (
+        !Pe(n.segments, t.segments) ||
+        !oo(n.segments, t.segments, o) ||
+        n.numberOfChildren !== t.numberOfChildren
+    )
+        return !1;
+    for (let e in t.children)
+        if (!n.children[e] || !Wl(n.children[e], t.children[e], o)) return !1;
+    return !0;
+}
+function Th(n, t) {
+    return (
+        Object.keys(t).length <= Object.keys(n).length &&
+        Object.keys(t).every((o) => Ul(n[o], t[o]))
+    );
+}
+function Gl(n, t, o) {
+    return Yl(n, t, t.segments, o);
+}
+function Yl(n, t, o, e) {
+    if (n.segments.length > o.length) {
+        let i = n.segments.slice(0, o.length);
+        return !(!Pe(i, o) || t.hasChildren() || !oo(i, o, e));
+    } else if (n.segments.length === o.length) {
+        if (!Pe(n.segments, o) || !oo(n.segments, o, e)) return !1;
+        for (let i in t.children)
+            if (!n.children[i] || !Gl(n.children[i], t.children[i], e))
+                return !1;
+        return !0;
+    } else {
+        let i = o.slice(0, n.segments.length),
+            r = o.slice(n.segments.length);
+        return !Pe(n.segments, i) || !oo(n.segments, i, e) || !n.children[O]
+            ? !1
+            : Yl(n.children[O], t, r, e);
+    }
+}
+function oo(n, t, o) {
+    return t.every((e, i) => $l[o](n[i].parameters, e.parameters));
+}
+var pe = class {
+        constructor(t = new G([], {}), o = {}, e = null) {
+            (this.root = t), (this.queryParams = o), (this.fragment = e);
+        }
+        get queryParamMap() {
+            return (
+                (this._queryParamMap ??= si(this.queryParams)),
+                this._queryParamMap
+            );
+        }
+        toString() {
+            return Oh.serialize(this);
+        }
+    },
+    G = class {
+        constructor(t, o) {
+            (this.segments = t),
+                (this.children = o),
+                (this.parent = null),
+                Object.values(o).forEach((e) => (e.parent = this));
+        }
+        hasChildren() {
+            return this.numberOfChildren > 0;
+        }
+        get numberOfChildren() {
+            return Object.keys(this.children).length;
+        }
+        toString() {
+            return ro(this);
+        }
+    },
+    Ne = class {
+        constructor(t, o) {
+            (this.path = t), (this.parameters = o);
+        }
+        get parameterMap() {
+            return (
+                (this._parameterMap ??= si(this.parameters)), this._parameterMap
+            );
+        }
+        toString() {
+            return Zl(this);
+        }
+    };
+function Ah(n, t) {
+    return Pe(n, t) && n.every((o, e) => $t(o.parameters, t[e].parameters));
+}
+function Pe(n, t) {
+    return n.length !== t.length ? !1 : n.every((o, e) => o.path === t[e].path);
+}
+function Fh(n, t) {
+    let o = [];
+    return (
+        Object.entries(n.children).forEach(([e, i]) => {
+            e === O && (o = o.concat(t(i, e)));
+        }),
+        Object.entries(n.children).forEach(([e, i]) => {
+            e !== O && (o = o.concat(t(i, e)));
+        }),
+        o
+    );
+}
+var rn = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({
+                token: t,
+                factory: () => new Zi(),
+                providedIn: "root",
+            }));
+        let n = t;
+        return n;
+    })(),
+    Zi = class {
+        parse(t) {
+            let o = new Xr(t);
+            return new pe(
+                o.parseRootSegment(),
+                o.parseQueryParams(),
+                o.parseFragment()
+            );
+        }
+        serialize(t) {
+            let o = `/${Hi(t.root, !0)}`,
+                e = Lh(t.queryParams),
+                i = typeof t.fragment == "string" ? `#${Nh(t.fragment)}` : "";
+            return `${o}${e}${i}`;
+        }
+    },
+    Oh = new Zi();
+function ro(n) {
+    return n.segments.map((t) => Zl(t)).join("/");
+}
+function Hi(n, t) {
+    if (!n.hasChildren()) return ro(n);
+    if (t) {
+        let o = n.children[O] ? Hi(n.children[O], !1) : "",
+            e = [];
+        return (
+            Object.entries(n.children).forEach(([i, r]) => {
+                i !== O && e.push(`${i}:${Hi(r, !1)}`);
+            }),
+            e.length > 0 ? `${o}(${e.join("//")})` : o
+        );
+    } else {
+        let o = Fh(n, (e, i) =>
+            i === O ? [Hi(n.children[O], !1)] : [`${i}:${Hi(e, !1)}`]
+        );
+        return Object.keys(n.children).length === 1 && n.children[O] != null
+            ? `${ro(n)}/${o[0]}`
+            : `${ro(n)}/(${o.join("//")})`;
+    }
+}
+function ql(n) {
+    return encodeURIComponent(n)
+        .replace(/%40/g, "@")
+        .replace(/%3A/gi, ":")
+        .replace(/%24/g, "$")
+        .replace(/%2C/gi, ",");
+}
+function io(n) {
+    return ql(n).replace(/%3B/gi, ";");
+}
+function Nh(n) {
+    return encodeURI(n);
+}
+function Zr(n) {
+    return ql(n)
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29")
+        .replace(/%26/gi, "&");
+}
+function so(n) {
+    return decodeURIComponent(n);
+}
+function Nl(n) {
+    return so(n.replace(/\+/g, "%20"));
+}
+function Zl(n) {
+    return `${Zr(n.path)}${Ph(n.parameters)}`;
+}
+function Ph(n) {
+    return Object.entries(n)
+        .map(([t, o]) => `;${Zr(t)}=${Zr(o)}`)
+        .join("");
+}
+function Lh(n) {
+    let t = Object.entries(n)
+        .map(([o, e]) =>
+            Array.isArray(e)
+                ? e.map((i) => `${io(o)}=${io(i)}`).join("&")
+                : `${io(o)}=${io(e)}`
+        )
+        .filter((o) => o);
+    return t.length ? `?${t.join("&")}` : "";
+}
+var jh = /^[^\/()?;#]+/;
+function Hr(n) {
+    let t = n.match(jh);
+    return t ? t[0] : "";
+}
+var Vh = /^[^\/()?;=#]+/;
+function zh(n) {
+    let t = n.match(Vh);
+    return t ? t[0] : "";
+}
+var Bh = /^[^=?&#]+/;
+function Uh(n) {
+    let t = n.match(Bh);
+    return t ? t[0] : "";
+}
+var Hh = /^[^&#]+/;
+function $h(n) {
+    let t = n.match(Hh);
+    return t ? t[0] : "";
+}
+var Xr = class {
+    constructor(t) {
+        (this.url = t), (this.remaining = t);
+    }
+    parseRootSegment() {
+        return (
+            this.consumeOptional("/"),
+            this.remaining === "" ||
+            this.peekStartsWith("?") ||
+            this.peekStartsWith("#")
+                ? new G([], {})
+                : new G([], this.parseChildren())
+        );
+    }
+    parseQueryParams() {
+        let t = {};
+        if (this.consumeOptional("?"))
+            do this.parseQueryParam(t);
+            while (this.consumeOptional("&"));
+        return t;
+    }
+    parseFragment() {
+        return this.consumeOptional("#")
+            ? decodeURIComponent(this.remaining)
+            : null;
+    }
+    parseChildren() {
+        if (this.remaining === "") return {};
+        this.consumeOptional("/");
+        let t = [];
+        for (
+            this.peekStartsWith("(") || t.push(this.parseSegment());
+            this.peekStartsWith("/") &&
+            !this.peekStartsWith("//") &&
+            !this.peekStartsWith("/(");
+
+        )
+            this.capture("/"), t.push(this.parseSegment());
+        let o = {};
+        this.peekStartsWith("/(") &&
+            (this.capture("/"), (o = this.parseParens(!0)));
+        let e = {};
+        return (
+            this.peekStartsWith("(") && (e = this.parseParens(!1)),
+            (t.length > 0 || Object.keys(o).length > 0) && (e[O] = new G(t, o)),
+            e
+        );
+    }
+    parseSegment() {
+        let t = Hr(this.remaining);
+        if (t === "" && this.peekStartsWith(";")) throw new $(4009, !1);
+        return this.capture(t), new Ne(so(t), this.parseMatrixParams());
+    }
+    parseMatrixParams() {
+        let t = {};
+        for (; this.consumeOptional(";"); ) this.parseParam(t);
+        return t;
+    }
+    parseParam(t) {
+        let o = zh(this.remaining);
+        if (!o) return;
+        this.capture(o);
+        let e = "";
+        if (this.consumeOptional("=")) {
+            let i = Hr(this.remaining);
+            i && ((e = i), this.capture(e));
+        }
+        t[so(o)] = so(e);
+    }
+    parseQueryParam(t) {
+        let o = Uh(this.remaining);
+        if (!o) return;
+        this.capture(o);
+        let e = "";
+        if (this.consumeOptional("=")) {
+            let s = $h(this.remaining);
+            s && ((e = s), this.capture(e));
+        }
+        let i = Nl(o),
+            r = Nl(e);
+        if (t.hasOwnProperty(i)) {
+            let s = t[i];
+            Array.isArray(s) || ((s = [s]), (t[i] = s)), s.push(r);
+        } else t[i] = r;
+    }
+    parseParens(t) {
+        let o = {};
+        for (
+            this.capture("(");
+            !this.consumeOptional(")") && this.remaining.length > 0;
+
+        ) {
+            let e = Hr(this.remaining),
+                i = this.remaining[e.length];
+            if (i !== "/" && i !== ")" && i !== ";") throw new $(4010, !1);
+            let r;
+            e.indexOf(":") > -1
+                ? ((r = e.slice(0, e.indexOf(":"))),
+                  this.capture(r),
+                  this.capture(":"))
+                : t && (r = O);
+            let s = this.parseChildren();
+            (o[r] = Object.keys(s).length === 1 ? s[O] : new G([], s)),
+                this.consumeOptional("//");
+        }
+        return o;
+    }
+    peekStartsWith(t) {
+        return this.remaining.startsWith(t);
+    }
+    consumeOptional(t) {
+        return this.peekStartsWith(t)
+            ? ((this.remaining = this.remaining.substring(t.length)), !0)
+            : !1;
+    }
+    capture(t) {
+        if (!this.consumeOptional(t)) throw new $(4011, !1);
+    }
+};
+function Xl(n) {
+    return n.segments.length > 0 ? new G([], { [O]: n }) : n;
+}
+function Kl(n) {
+    let t = {};
+    for (let [e, i] of Object.entries(n.children)) {
+        let r = Kl(i);
+        if (e === O && r.segments.length === 0 && r.hasChildren())
+            for (let [s, a] of Object.entries(r.children)) t[s] = a;
+        else (r.segments.length > 0 || r.hasChildren()) && (t[e] = r);
+    }
+    let o = new G(n.segments, t);
+    return Wh(o);
+}
+function Wh(n) {
+    if (n.numberOfChildren === 1 && n.children[O]) {
+        let t = n.children[O];
+        return new G(n.segments.concat(t.segments), t.children);
+    }
+    return n;
+}
+function ai(n) {
+    return n instanceof pe;
+}
+function Gh(n, t, o = null, e = null) {
+    let i = Ql(n);
+    return Jl(i, t, o, e);
+}
+function Ql(n) {
+    let t;
+    function o(r) {
+        let s = {};
+        for (let l of r.children) {
+            let c = o(l);
+            s[l.outlet] = c;
+        }
+        let a = new G(r.url, s);
+        return r === n && (t = a), a;
+    }
+    let e = o(n.root),
+        i = Xl(e);
+    return t ?? i;
+}
+function Jl(n, t, o, e) {
+    let i = n;
+    for (; i.parent; ) i = i.parent;
+    if (t.length === 0) return $r(i, i, i, o, e);
+    let r = Yh(t);
+    if (r.toRoot()) return $r(i, i, new G([], {}), o, e);
+    let s = qh(r, i, n),
+        a = s.processChildren
+            ? Gi(s.segmentGroup, s.index, r.commands)
+            : ec(s.segmentGroup, s.index, r.commands);
+    return $r(i, s.segmentGroup, a, o, e);
+}
+function ao(n) {
+    return typeof n == "object" && n != null && !n.outlets && !n.segmentPath;
+}
+function Xi(n) {
+    return typeof n == "object" && n != null && n.outlets;
+}
+function $r(n, t, o, e, i) {
+    let r = {};
+    e &&
+        Object.entries(e).forEach(([l, c]) => {
+            r[l] = Array.isArray(c) ? c.map((d) => `${d}`) : `${c}`;
+        });
+    let s;
+    n === t ? (s = o) : (s = tc(n, t, o));
+    let a = Xl(Kl(s));
+    return new pe(a, r, i);
+}
+function tc(n, t, o) {
+    let e = {};
+    return (
+        Object.entries(n.children).forEach(([i, r]) => {
+            r === t ? (e[i] = o) : (e[i] = tc(r, t, o));
+        }),
+        new G(n.segments, e)
+    );
+}
+var lo = class {
+    constructor(t, o, e) {
+        if (
+            ((this.isAbsolute = t),
+            (this.numberOfDoubleDots = o),
+            (this.commands = e),
+            t && e.length > 0 && ao(e[0]))
+        )
+            throw new $(4003, !1);
+        let i = e.find(Xi);
+        if (i && i !== Hl(e)) throw new $(4004, !1);
+    }
+    toRoot() {
+        return (
+            this.isAbsolute &&
+            this.commands.length === 1 &&
+            this.commands[0] == "/"
+        );
+    }
+};
+function Yh(n) {
+    if (typeof n[0] == "string" && n.length === 1 && n[0] === "/")
+        return new lo(!0, 0, n);
+    let t = 0,
+        o = !1,
+        e = n.reduce((i, r, s) => {
+            if (typeof r == "object" && r != null) {
+                if (r.outlets) {
+                    let a = {};
+                    return (
+                        Object.entries(r.outlets).forEach(([l, c]) => {
+                            a[l] = typeof c == "string" ? c.split("/") : c;
+                        }),
+                        [...i, { outlets: a }]
+                    );
+                }
+                if (r.segmentPath) return [...i, r.segmentPath];
+            }
+            return typeof r != "string"
+                ? [...i, r]
+                : s === 0
+                  ? (r.split("/").forEach((a, l) => {
+                        (l == 0 && a === ".") ||
+                            (l == 0 && a === ""
+                                ? (o = !0)
+                                : a === ".."
+                                  ? t++
+                                  : a != "" && i.push(a));
+                    }),
+                    i)
+                  : [...i, r];
+        }, []);
+    return new lo(o, t, e);
+}
+var oi = class {
+    constructor(t, o, e) {
+        (this.segmentGroup = t), (this.processChildren = o), (this.index = e);
+    }
+};
+function qh(n, t, o) {
+    if (n.isAbsolute) return new oi(t, !0, 0);
+    if (!o) return new oi(t, !1, NaN);
+    if (o.parent === null) return new oi(o, !0, 0);
+    let e = ao(n.commands[0]) ? 0 : 1,
+        i = o.segments.length - 1 + e;
+    return Zh(o, i, n.numberOfDoubleDots);
+}
+function Zh(n, t, o) {
+    let e = n,
+        i = t,
+        r = o;
+    for (; r > i; ) {
+        if (((r -= i), (e = e.parent), !e)) throw new $(4005, !1);
+        i = e.segments.length;
+    }
+    return new oi(e, !1, i - r);
+}
+function Xh(n) {
+    return Xi(n[0]) ? n[0].outlets : { [O]: n };
+}
+function ec(n, t, o) {
+    if (((n ??= new G([], {})), n.segments.length === 0 && n.hasChildren()))
+        return Gi(n, t, o);
+    let e = Kh(n, t, o),
+        i = o.slice(e.commandIndex);
+    if (e.match && e.pathIndex < n.segments.length) {
+        let r = new G(n.segments.slice(0, e.pathIndex), {});
+        return (
+            (r.children[O] = new G(n.segments.slice(e.pathIndex), n.children)),
+            Gi(r, 0, i)
+        );
+    } else
+        return e.match && i.length === 0
+            ? new G(n.segments, {})
+            : e.match && !n.hasChildren()
+              ? Kr(n, t, o)
+              : e.match
+                ? Gi(n, 0, i)
+                : Kr(n, t, o);
+}
+function Gi(n, t, o) {
+    if (o.length === 0) return new G(n.segments, {});
+    {
+        let e = Xh(o),
+            i = {};
+        if (
+            Object.keys(e).some((r) => r !== O) &&
+            n.children[O] &&
+            n.numberOfChildren === 1 &&
+            n.children[O].segments.length === 0
+        ) {
+            let r = Gi(n.children[O], t, o);
+            return new G(n.segments, r.children);
+        }
+        return (
+            Object.entries(e).forEach(([r, s]) => {
+                typeof s == "string" && (s = [s]),
+                    s !== null && (i[r] = ec(n.children[r], t, s));
+            }),
+            Object.entries(n.children).forEach(([r, s]) => {
+                e[r] === void 0 && (i[r] = s);
+            }),
+            new G(n.segments, i)
+        );
+    }
+}
+function Kh(n, t, o) {
+    let e = 0,
+        i = t,
+        r = { match: !1, pathIndex: 0, commandIndex: 0 };
+    for (; i < n.segments.length; ) {
+        if (e >= o.length) return r;
+        let s = n.segments[i],
+            a = o[e];
+        if (Xi(a)) break;
+        let l = `${a}`,
+            c = e < o.length - 1 ? o[e + 1] : null;
+        if (i > 0 && l === void 0) break;
+        if (l && c && typeof c == "object" && c.outlets === void 0) {
+            if (!Ll(l, c, s)) return r;
+            e += 2;
+        } else {
+            if (!Ll(l, {}, s)) return r;
+            e++;
+        }
+        i++;
+    }
+    return { match: !0, pathIndex: i, commandIndex: e };
+}
+function Kr(n, t, o) {
+    let e = n.segments.slice(0, t),
+        i = 0;
+    for (; i < o.length; ) {
+        let r = o[i];
+        if (Xi(r)) {
+            let l = Qh(r.outlets);
+            return new G(e, l);
+        }
+        if (i === 0 && ao(o[0])) {
+            let l = n.segments[t];
+            e.push(new Ne(l.path, Pl(o[0]))), i++;
+            continue;
+        }
+        let s = Xi(r) ? r.outlets[O] : `${r}`,
+            a = i < o.length - 1 ? o[i + 1] : null;
+        s && a && ao(a)
+            ? (e.push(new Ne(s, Pl(a))), (i += 2))
+            : (e.push(new Ne(s, {})), i++);
+    }
+    return new G(e, {});
+}
+function Qh(n) {
+    let t = {};
+    return (
+        Object.entries(n).forEach(([o, e]) => {
+            typeof e == "string" && (e = [e]),
+                e !== null && (t[o] = Kr(new G([], {}), 0, e));
+        }),
+        t
+    );
+}
+function Pl(n) {
+    let t = {};
+    return Object.entries(n).forEach(([o, e]) => (t[o] = `${e}`)), t;
+}
+function Ll(n, t, o) {
+    return n == o.path && $t(t, o.parameters);
+}
+var Yi = "imperative",
+    bt = (function (n) {
+        return (
+            (n[(n.NavigationStart = 0)] = "NavigationStart"),
+            (n[(n.NavigationEnd = 1)] = "NavigationEnd"),
+            (n[(n.NavigationCancel = 2)] = "NavigationCancel"),
+            (n[(n.NavigationError = 3)] = "NavigationError"),
+            (n[(n.RoutesRecognized = 4)] = "RoutesRecognized"),
+            (n[(n.ResolveStart = 5)] = "ResolveStart"),
+            (n[(n.ResolveEnd = 6)] = "ResolveEnd"),
+            (n[(n.GuardsCheckStart = 7)] = "GuardsCheckStart"),
+            (n[(n.GuardsCheckEnd = 8)] = "GuardsCheckEnd"),
+            (n[(n.RouteConfigLoadStart = 9)] = "RouteConfigLoadStart"),
+            (n[(n.RouteConfigLoadEnd = 10)] = "RouteConfigLoadEnd"),
+            (n[(n.ChildActivationStart = 11)] = "ChildActivationStart"),
+            (n[(n.ChildActivationEnd = 12)] = "ChildActivationEnd"),
+            (n[(n.ActivationStart = 13)] = "ActivationStart"),
+            (n[(n.ActivationEnd = 14)] = "ActivationEnd"),
+            (n[(n.Scroll = 15)] = "Scroll"),
+            (n[(n.NavigationSkipped = 16)] = "NavigationSkipped"),
+            n
+        );
+    })(bt || {}),
+    Ot = class {
+        constructor(t, o) {
+            (this.id = t), (this.url = o);
+        }
+    },
+    li = class extends Ot {
+        constructor(t, o, e = "imperative", i = null) {
+            super(t, o),
+                (this.type = bt.NavigationStart),
+                (this.navigationTrigger = e),
+                (this.restoredState = i);
+        }
+        toString() {
+            return `NavigationStart(id: ${this.id}, url: '${this.url}')`;
+        }
+    },
+    Wt = class extends Ot {
+        constructor(t, o, e) {
+            super(t, o),
+                (this.urlAfterRedirects = e),
+                (this.type = bt.NavigationEnd);
+        }
+        toString() {
+            return `NavigationEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}')`;
+        }
+    },
+    At = (function (n) {
+        return (
+            (n[(n.Redirect = 0)] = "Redirect"),
+            (n[(n.SupersededByNewNavigation = 1)] =
+                "SupersededByNewNavigation"),
+            (n[(n.NoDataFromResolver = 2)] = "NoDataFromResolver"),
+            (n[(n.GuardRejected = 3)] = "GuardRejected"),
+            n
+        );
+    })(At || {}),
+    co = (function (n) {
+        return (
+            (n[(n.IgnoredSameUrlNavigation = 0)] = "IgnoredSameUrlNavigation"),
+            (n[(n.IgnoredByUrlHandlingStrategy = 1)] =
+                "IgnoredByUrlHandlingStrategy"),
+            n
+        );
+    })(co || {}),
+    ge = class extends Ot {
+        constructor(t, o, e, i) {
+            super(t, o),
+                (this.reason = e),
+                (this.code = i),
+                (this.type = bt.NavigationCancel);
+        }
+        toString() {
+            return `NavigationCancel(id: ${this.id}, url: '${this.url}')`;
+        }
+    },
+    be = class extends Ot {
+        constructor(t, o, e, i) {
+            super(t, o),
+                (this.reason = e),
+                (this.code = i),
+                (this.type = bt.NavigationSkipped);
+        }
+    },
+    Ki = class extends Ot {
+        constructor(t, o, e, i) {
+            super(t, o),
+                (this.error = e),
+                (this.target = i),
+                (this.type = bt.NavigationError);
+        }
+        toString() {
+            return `NavigationError(id: ${this.id}, url: '${this.url}', error: ${this.error})`;
+        }
+    },
+    uo = class extends Ot {
+        constructor(t, o, e, i) {
+            super(t, o),
+                (this.urlAfterRedirects = e),
+                (this.state = i),
+                (this.type = bt.RoutesRecognized);
+        }
+        toString() {
+            return `RoutesRecognized(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+        }
+    },
+    Qr = class extends Ot {
+        constructor(t, o, e, i) {
+            super(t, o),
+                (this.urlAfterRedirects = e),
+                (this.state = i),
+                (this.type = bt.GuardsCheckStart);
+        }
+        toString() {
+            return `GuardsCheckStart(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+        }
+    },
+    Jr = class extends Ot {
+        constructor(t, o, e, i, r) {
+            super(t, o),
+                (this.urlAfterRedirects = e),
+                (this.state = i),
+                (this.shouldActivate = r),
+                (this.type = bt.GuardsCheckEnd);
+        }
+        toString() {
+            return `GuardsCheckEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state}, shouldActivate: ${this.shouldActivate})`;
+        }
+    },
+    ts = class extends Ot {
+        constructor(t, o, e, i) {
+            super(t, o),
+                (this.urlAfterRedirects = e),
+                (this.state = i),
+                (this.type = bt.ResolveStart);
+        }
+        toString() {
+            return `ResolveStart(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+        }
+    },
+    es = class extends Ot {
+        constructor(t, o, e, i) {
+            super(t, o),
+                (this.urlAfterRedirects = e),
+                (this.state = i),
+                (this.type = bt.ResolveEnd);
+        }
+        toString() {
+            return `ResolveEnd(id: ${this.id}, url: '${this.url}', urlAfterRedirects: '${this.urlAfterRedirects}', state: ${this.state})`;
+        }
+    },
+    is = class {
+        constructor(t) {
+            (this.route = t), (this.type = bt.RouteConfigLoadStart);
+        }
+        toString() {
+            return `RouteConfigLoadStart(path: ${this.route.path})`;
+        }
+    },
+    ns = class {
+        constructor(t) {
+            (this.route = t), (this.type = bt.RouteConfigLoadEnd);
+        }
+        toString() {
+            return `RouteConfigLoadEnd(path: ${this.route.path})`;
+        }
+    },
+    os = class {
+        constructor(t) {
+            (this.snapshot = t), (this.type = bt.ChildActivationStart);
+        }
+        toString() {
+            return `ChildActivationStart(path: '${(this.snapshot.routeConfig && this.snapshot.routeConfig.path) || ""}')`;
+        }
+    },
+    rs = class {
+        constructor(t) {
+            (this.snapshot = t), (this.type = bt.ChildActivationEnd);
+        }
+        toString() {
+            return `ChildActivationEnd(path: '${(this.snapshot.routeConfig && this.snapshot.routeConfig.path) || ""}')`;
+        }
+    },
+    ss = class {
+        constructor(t) {
+            (this.snapshot = t), (this.type = bt.ActivationStart);
+        }
+        toString() {
+            return `ActivationStart(path: '${(this.snapshot.routeConfig && this.snapshot.routeConfig.path) || ""}')`;
+        }
+    },
+    as = class {
+        constructor(t) {
+            (this.snapshot = t), (this.type = bt.ActivationEnd);
+        }
+        toString() {
+            return `ActivationEnd(path: '${(this.snapshot.routeConfig && this.snapshot.routeConfig.path) || ""}')`;
+        }
+    },
+    ho = class {
+        constructor(t, o, e) {
+            (this.routerEvent = t),
+                (this.position = o),
+                (this.anchor = e),
+                (this.type = bt.Scroll);
+        }
+        toString() {
+            let t = this.position
+                ? `${this.position[0]}, ${this.position[1]}`
+                : null;
+            return `Scroll(anchor: '${this.anchor}', position: '${t}')`;
+        }
+    },
+    Qi = class {},
+    Ji = class {
+        constructor(t) {
+            this.url = t;
+        }
+    };
+var ls = class {
+        constructor() {
+            (this.outlet = null),
+                (this.route = null),
+                (this.injector = null),
+                (this.children = new sn()),
+                (this.attachRef = null);
+        }
+    },
+    sn = (() => {
+        let t = class t {
+            constructor() {
+                this.contexts = new Map();
+            }
+            onChildOutletCreated(e, i) {
+                let r = this.getOrCreateContext(e);
+                (r.outlet = i), this.contexts.set(e, r);
+            }
+            onChildOutletDestroyed(e) {
+                let i = this.getContext(e);
+                i && ((i.outlet = null), (i.attachRef = null));
+            }
+            onOutletDeactivated() {
+                let e = this.contexts;
+                return (this.contexts = new Map()), e;
+            }
+            onOutletReAttached(e) {
+                this.contexts = e;
+            }
+            getOrCreateContext(e) {
+                let i = this.getContext(e);
+                return i || ((i = new ls()), this.contexts.set(e, i)), i;
+            }
+            getContext(e) {
+                return this.contexts.get(e) || null;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    mo = class {
+        constructor(t) {
+            this._root = t;
+        }
+        get root() {
+            return this._root.value;
+        }
+        parent(t) {
+            let o = this.pathFromRoot(t);
+            return o.length > 1 ? o[o.length - 2] : null;
+        }
+        children(t) {
+            let o = cs(t, this._root);
+            return o ? o.children.map((e) => e.value) : [];
+        }
+        firstChild(t) {
+            let o = cs(t, this._root);
+            return o && o.children.length > 0 ? o.children[0].value : null;
+        }
+        siblings(t) {
+            let o = ds(t, this._root);
+            return o.length < 2
+                ? []
+                : o[o.length - 2].children
+                      .map((i) => i.value)
+                      .filter((i) => i !== t);
+        }
+        pathFromRoot(t) {
+            return ds(t, this._root).map((o) => o.value);
+        }
+    };
+function cs(n, t) {
+    if (n === t.value) return t;
+    for (let o of t.children) {
+        let e = cs(n, o);
+        if (e) return e;
+    }
+    return null;
+}
+function ds(n, t) {
+    if (n === t.value) return [t];
+    for (let o of t.children) {
+        let e = ds(n, o);
+        if (e.length) return e.unshift(t), e;
+    }
+    return [];
+}
+var Tt = class {
+    constructor(t, o) {
+        (this.value = t), (this.children = o);
+    }
+    toString() {
+        return `TreeNode(${this.value})`;
+    }
+};
+function ni(n) {
+    let t = {};
+    return n && n.children.forEach((o) => (t[o.value.outlet] = o)), t;
+}
+var fo = class extends mo {
+    constructor(t, o) {
+        super(t), (this.snapshot = o), ys(this, t);
+    }
+    toString() {
+        return this.snapshot.toString();
+    }
+};
+function ic(n) {
+    let t = Jh(n),
+        o = new rt([new Ne("", {})]),
+        e = new rt({}),
+        i = new rt({}),
+        r = new rt({}),
+        s = new rt(""),
+        a = new ee(o, e, r, s, i, O, n, t.root);
+    return (a.snapshot = t.root), new fo(new Tt(a, []), t);
+}
+function Jh(n) {
+    let t = {},
+        o = {},
+        e = {},
+        i = "",
+        r = new tn([], t, e, i, o, O, n, null, {});
+    return new po("", new Tt(r, []));
+}
+var ee = class {
+    constructor(t, o, e, i, r, s, a, l) {
+        (this.urlSubject = t),
+            (this.paramsSubject = o),
+            (this.queryParamsSubject = e),
+            (this.fragmentSubject = i),
+            (this.dataSubject = r),
+            (this.outlet = s),
+            (this.component = a),
+            (this._futureSnapshot = l),
+            (this.title = this.dataSubject?.pipe(M((c) => c[on])) ?? v(void 0)),
+            (this.url = t),
+            (this.params = o),
+            (this.queryParams = e),
+            (this.fragment = i),
+            (this.data = r);
+    }
+    get routeConfig() {
+        return this._futureSnapshot.routeConfig;
+    }
+    get root() {
+        return this._routerState.root;
+    }
+    get parent() {
+        return this._routerState.parent(this);
+    }
+    get firstChild() {
+        return this._routerState.firstChild(this);
+    }
+    get children() {
+        return this._routerState.children(this);
+    }
+    get pathFromRoot() {
+        return this._routerState.pathFromRoot(this);
+    }
+    get paramMap() {
+        return (
+            (this._paramMap ??= this.params.pipe(M((t) => si(t)))),
+            this._paramMap
+        );
+    }
+    get queryParamMap() {
+        return (
+            (this._queryParamMap ??= this.queryParams.pipe(M((t) => si(t)))),
+            this._queryParamMap
+        );
+    }
+    toString() {
+        return this.snapshot
+            ? this.snapshot.toString()
+            : `Future(${this._futureSnapshot})`;
+    }
+};
+function _s(n, t, o = "emptyOnly") {
+    let e,
+        { routeConfig: i } = n;
+    return (
+        t !== null &&
+        (o === "always" ||
+            i?.path === "" ||
+            (!t.component && !t.routeConfig?.loadComponent))
+            ? (e = {
+                  params: p(p({}, t.params), n.params),
+                  data: p(p({}, t.data), n.data),
+                  resolve: p(
+                      p(p(p({}, n.data), t.data), i?.data),
+                      n._resolvedData
+                  ),
+              })
+            : (e = {
+                  params: p({}, n.params),
+                  data: p({}, n.data),
+                  resolve: p(p({}, n.data), n._resolvedData ?? {}),
+              }),
+        i && oc(i) && (e.resolve[on] = i.title),
+        e
+    );
+}
+var tn = class {
+        get title() {
+            return this.data?.[on];
+        }
+        constructor(t, o, e, i, r, s, a, l, c) {
+            (this.url = t),
+                (this.params = o),
+                (this.queryParams = e),
+                (this.fragment = i),
+                (this.data = r),
+                (this.outlet = s),
+                (this.component = a),
+                (this.routeConfig = l),
+                (this._resolve = c);
+        }
+        get root() {
+            return this._routerState.root;
+        }
+        get parent() {
+            return this._routerState.parent(this);
+        }
+        get firstChild() {
+            return this._routerState.firstChild(this);
+        }
+        get children() {
+            return this._routerState.children(this);
+        }
+        get pathFromRoot() {
+            return this._routerState.pathFromRoot(this);
+        }
+        get paramMap() {
+            return (this._paramMap ??= si(this.params)), this._paramMap;
+        }
+        get queryParamMap() {
+            return (
+                (this._queryParamMap ??= si(this.queryParams)),
+                this._queryParamMap
+            );
+        }
+        toString() {
+            let t = this.url.map((e) => e.toString()).join("/"),
+                o = this.routeConfig ? this.routeConfig.path : "";
+            return `Route(url:'${t}', path:'${o}')`;
+        }
+    },
+    po = class extends mo {
+        constructor(t, o) {
+            super(o), (this.url = t), ys(this, o);
+        }
+        toString() {
+            return nc(this._root);
+        }
+    };
+function ys(n, t) {
+    (t.value._routerState = n), t.children.forEach((o) => ys(n, o));
+}
+function nc(n) {
+    let t =
+        n.children.length > 0 ? ` { ${n.children.map(nc).join(", ")} } ` : "";
+    return `${n.value}${t}`;
+}
+function Wr(n) {
+    if (n.snapshot) {
+        let t = n.snapshot,
+            o = n._futureSnapshot;
+        (n.snapshot = o),
+            $t(t.queryParams, o.queryParams) ||
+                n.queryParamsSubject.next(o.queryParams),
+            t.fragment !== o.fragment && n.fragmentSubject.next(o.fragment),
+            $t(t.params, o.params) || n.paramsSubject.next(o.params),
+            Rh(t.url, o.url) || n.urlSubject.next(o.url),
+            $t(t.data, o.data) || n.dataSubject.next(o.data);
+    } else
+        (n.snapshot = n._futureSnapshot),
+            n.dataSubject.next(n._futureSnapshot.data);
+}
+function us(n, t) {
+    let o = $t(n.params, t.params) && Ah(n.url, t.url),
+        e = !n.parent != !t.parent;
+    return o && !e && (!n.parent || us(n.parent, t.parent));
+}
+function oc(n) {
+    return typeof n.title == "string" || n.title === null;
+}
+var xs = (() => {
+        let t = class t {
+            constructor() {
+                (this.activated = null),
+                    (this._activatedRoute = null),
+                    (this.name = O),
+                    (this.activateEvents = new it()),
+                    (this.deactivateEvents = new it()),
+                    (this.attachEvents = new it()),
+                    (this.detachEvents = new it()),
+                    (this.parentContexts = g(sn)),
+                    (this.location = g(kt)),
+                    (this.changeDetector = g(Dt)),
+                    (this.environmentInjector = g(ce)),
+                    (this.inputBinder = g(yo, { optional: !0 })),
+                    (this.supportsBindingToComponentInputs = !0);
+            }
+            get activatedComponentRef() {
+                return this.activated;
+            }
+            ngOnChanges(e) {
+                if (e.name) {
+                    let { firstChange: i, previousValue: r } = e.name;
+                    if (i) return;
+                    this.isTrackedInParentContexts(r) &&
+                        (this.deactivate(),
+                        this.parentContexts.onChildOutletDestroyed(r)),
+                        this.initializeOutletWithName();
+                }
+            }
+            ngOnDestroy() {
+                this.isTrackedInParentContexts(this.name) &&
+                    this.parentContexts.onChildOutletDestroyed(this.name),
+                    this.inputBinder?.unsubscribeFromRouteData(this);
+            }
+            isTrackedInParentContexts(e) {
+                return this.parentContexts.getContext(e)?.outlet === this;
+            }
+            ngOnInit() {
+                this.initializeOutletWithName();
+            }
+            initializeOutletWithName() {
+                if (
+                    (this.parentContexts.onChildOutletCreated(this.name, this),
+                    this.activated)
+                )
+                    return;
+                let e = this.parentContexts.getContext(this.name);
+                e?.route &&
+                    (e.attachRef
+                        ? this.attach(e.attachRef, e.route)
+                        : this.activateWith(e.route, e.injector));
+            }
+            get isActivated() {
+                return !!this.activated;
+            }
+            get component() {
+                if (!this.activated) throw new $(4012, !1);
+                return this.activated.instance;
+            }
+            get activatedRoute() {
+                if (!this.activated) throw new $(4012, !1);
+                return this._activatedRoute;
+            }
+            get activatedRouteData() {
+                return this._activatedRoute
+                    ? this._activatedRoute.snapshot.data
+                    : {};
+            }
+            detach() {
+                if (!this.activated) throw new $(4012, !1);
+                this.location.detach();
+                let e = this.activated;
+                return (
+                    (this.activated = null),
+                    (this._activatedRoute = null),
+                    this.detachEvents.emit(e.instance),
+                    e
+                );
+            }
+            attach(e, i) {
+                (this.activated = e),
+                    (this._activatedRoute = i),
+                    this.location.insert(e.hostView),
+                    this.inputBinder?.bindActivatedRouteToOutletComponent(this),
+                    this.attachEvents.emit(e.instance);
+            }
+            deactivate() {
+                if (this.activated) {
+                    let e = this.component;
+                    this.activated.destroy(),
+                        (this.activated = null),
+                        (this._activatedRoute = null),
+                        this.deactivateEvents.emit(e);
+                }
+            }
+            activateWith(e, i) {
+                if (this.isActivated) throw new $(4013, !1);
+                this._activatedRoute = e;
+                let r = this.location,
+                    a = e.snapshot.component,
+                    l = this.parentContexts.getOrCreateContext(
+                        this.name
+                    ).children,
+                    c = new hs(e, l, r.injector);
+                (this.activated = r.createComponent(a, {
+                    index: r.length,
+                    injector: c,
+                    environmentInjector: i ?? this.environmentInjector,
+                })),
+                    this.changeDetector.markForCheck(),
+                    this.inputBinder?.bindActivatedRouteToOutletComponent(this),
+                    this.activateEvents.emit(this.activated.instance);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["router-outlet"]],
+                inputs: { name: "name" },
+                outputs: {
+                    activateEvents: "activate",
+                    deactivateEvents: "deactivate",
+                    attachEvents: "attach",
+                    detachEvents: "detach",
+                },
+                exportAs: ["outlet"],
+                standalone: !0,
+                features: [yt],
+            }));
+        let n = t;
+        return n;
+    })(),
+    hs = class n {
+        __ngOutletInjector(t) {
+            return new n(this.route, this.childContexts, t);
+        }
+        constructor(t, o, e) {
+            (this.route = t), (this.childContexts = o), (this.parent = e);
+        }
+        get(t, o) {
+            return t === ee
+                ? this.route
+                : t === sn
+                  ? this.childContexts
+                  : this.parent.get(t, o);
+        }
+    },
+    yo = new C(""),
+    jl = (() => {
+        let t = class t {
+            constructor() {
+                this.outletDataSubscriptions = new Map();
+            }
+            bindActivatedRouteToOutletComponent(e) {
+                this.unsubscribeFromRouteData(e), this.subscribeToRouteData(e);
+            }
+            unsubscribeFromRouteData(e) {
+                this.outletDataSubscriptions.get(e)?.unsubscribe(),
+                    this.outletDataSubscriptions.delete(e);
+            }
+            subscribeToRouteData(e) {
+                let { activatedRoute: i } = e,
+                    r = Vt([i.queryParams, i.params, i.data])
+                        .pipe(
+                            vt(
+                                ([s, a, l], c) => (
+                                    (l = p(p(p({}, s), a), l)),
+                                    c === 0 ? v(l) : Promise.resolve(l)
+                                )
+                            )
+                        )
+                        .subscribe((s) => {
+                            if (
+                                !e.isActivated ||
+                                !e.activatedComponentRef ||
+                                e.activatedRoute !== i ||
+                                i.component === null
+                            ) {
+                                this.unsubscribeFromRouteData(e);
+                                return;
+                            }
+                            let a = rl(i.component);
+                            if (!a) {
+                                this.unsubscribeFromRouteData(e);
+                                return;
+                            }
+                            for (let { templateName: l } of a.inputs)
+                                e.activatedComponentRef.setInput(l, s[l]);
+                        });
+                this.outletDataSubscriptions.set(e, r);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })();
+function tm(n, t, o) {
+    let e = en(n, t._root, o ? o._root : void 0);
+    return new fo(e, t);
+}
+function en(n, t, o) {
+    if (o && n.shouldReuseRoute(t.value, o.value.snapshot)) {
+        let e = o.value;
+        e._futureSnapshot = t.value;
+        let i = em(n, t, o);
+        return new Tt(e, i);
+    } else {
+        if (n.shouldAttach(t.value)) {
+            let r = n.retrieve(t.value);
+            if (r !== null) {
+                let s = r.route;
+                return (
+                    (s.value._futureSnapshot = t.value),
+                    (s.children = t.children.map((a) => en(n, a))),
+                    s
+                );
+            }
+        }
+        let e = im(t.value),
+            i = t.children.map((r) => en(n, r));
+        return new Tt(e, i);
+    }
+}
+function em(n, t, o) {
+    return t.children.map((e) => {
+        for (let i of o.children)
+            if (n.shouldReuseRoute(e.value, i.value.snapshot))
+                return en(n, e, i);
+        return en(n, e);
+    });
+}
+function im(n) {
+    return new ee(
+        new rt(n.url),
+        new rt(n.params),
+        new rt(n.queryParams),
+        new rt(n.fragment),
+        new rt(n.data),
+        n.outlet,
+        n.component,
+        n
+    );
+}
+var rc = "ngNavigationCancelingError";
+function sc(n, t) {
+    let { redirectTo: o, navigationBehaviorOptions: e } = ai(t)
+            ? { redirectTo: t, navigationBehaviorOptions: void 0 }
+            : t,
+        i = ac(!1, At.Redirect);
+    return (i.url = o), (i.navigationBehaviorOptions = e), i;
+}
+function ac(n, t) {
+    let o = new Error(`NavigationCancelingError: ${n || ""}`);
+    return (o[rc] = !0), (o.cancellationCode = t), o;
+}
+function nm(n) {
+    return lc(n) && ai(n.url);
+}
+function lc(n) {
+    return !!n && n[rc];
+}
+var om = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["ng-component"]],
+            standalone: !0,
+            features: [tt],
+            decls: 1,
+            vars: 0,
+            template: function (i, r) {
+                i & 1 && H(0, "router-outlet");
+            },
+            dependencies: [xs],
+            encapsulation: 2,
+        }));
+    let n = t;
+    return n;
+})();
+function rm(n, t) {
+    return (
+        n.providers &&
+            !n._injector &&
+            (n._injector = _r(n.providers, t, `Route: ${n.path}`)),
+        n._injector ?? t
+    );
+}
+function ws(n) {
+    let t = n.children && n.children.map(ws),
+        o = t ? q(p({}, n), { children: t }) : p({}, n);
+    return (
+        !o.component &&
+            !o.loadComponent &&
+            (t || o.loadChildren) &&
+            o.outlet &&
+            o.outlet !== O &&
+            (o.component = om),
+        o
+    );
+}
+function Gt(n) {
+    return n.outlet || O;
+}
+function sm(n, t) {
+    let o = n.filter((e) => Gt(e) === t);
+    return o.push(...n.filter((e) => Gt(e) !== t)), o;
+}
+function an(n) {
+    if (!n) return null;
+    if (n.routeConfig?._injector) return n.routeConfig._injector;
+    for (let t = n.parent; t; t = t.parent) {
+        let o = t.routeConfig;
+        if (o?._loadedInjector) return o._loadedInjector;
+        if (o?._injector) return o._injector;
+    }
+    return null;
+}
+var am = (n, t, o, e) =>
+        M(
+            (i) => (
+                new ms(
+                    t,
+                    i.targetRouterState,
+                    i.currentRouterState,
+                    o,
+                    e
+                ).activate(n),
+                i
+            )
+        ),
+    ms = class {
+        constructor(t, o, e, i, r) {
+            (this.routeReuseStrategy = t),
+                (this.futureState = o),
+                (this.currState = e),
+                (this.forwardEvent = i),
+                (this.inputBindingEnabled = r);
+        }
+        activate(t) {
+            let o = this.futureState._root,
+                e = this.currState ? this.currState._root : null;
+            this.deactivateChildRoutes(o, e, t),
+                Wr(this.futureState.root),
+                this.activateChildRoutes(o, e, t);
+        }
+        deactivateChildRoutes(t, o, e) {
+            let i = ni(o);
+            t.children.forEach((r) => {
+                let s = r.value.outlet;
+                this.deactivateRoutes(r, i[s], e), delete i[s];
+            }),
+                Object.values(i).forEach((r) => {
+                    this.deactivateRouteAndItsChildren(r, e);
+                });
+        }
+        deactivateRoutes(t, o, e) {
+            let i = t.value,
+                r = o ? o.value : null;
+            if (i === r)
+                if (i.component) {
+                    let s = e.getContext(i.outlet);
+                    s && this.deactivateChildRoutes(t, o, s.children);
+                } else this.deactivateChildRoutes(t, o, e);
+            else r && this.deactivateRouteAndItsChildren(o, e);
+        }
+        deactivateRouteAndItsChildren(t, o) {
+            t.value.component &&
+            this.routeReuseStrategy.shouldDetach(t.value.snapshot)
+                ? this.detachAndStoreRouteSubtree(t, o)
+                : this.deactivateRouteAndOutlet(t, o);
+        }
+        detachAndStoreRouteSubtree(t, o) {
+            let e = o.getContext(t.value.outlet),
+                i = e && t.value.component ? e.children : o,
+                r = ni(t);
+            for (let s of Object.values(r))
+                this.deactivateRouteAndItsChildren(s, i);
+            if (e && e.outlet) {
+                let s = e.outlet.detach(),
+                    a = e.children.onOutletDeactivated();
+                this.routeReuseStrategy.store(t.value.snapshot, {
+                    componentRef: s,
+                    route: t,
+                    contexts: a,
+                });
+            }
+        }
+        deactivateRouteAndOutlet(t, o) {
+            let e = o.getContext(t.value.outlet),
+                i = e && t.value.component ? e.children : o,
+                r = ni(t);
+            for (let s of Object.values(r))
+                this.deactivateRouteAndItsChildren(s, i);
+            e &&
+                (e.outlet &&
+                    (e.outlet.deactivate(), e.children.onOutletDeactivated()),
+                (e.attachRef = null),
+                (e.route = null));
+        }
+        activateChildRoutes(t, o, e) {
+            let i = ni(o);
+            t.children.forEach((r) => {
+                this.activateRoutes(r, i[r.value.outlet], e),
+                    this.forwardEvent(new as(r.value.snapshot));
+            }),
+                t.children.length &&
+                    this.forwardEvent(new rs(t.value.snapshot));
+        }
+        activateRoutes(t, o, e) {
+            let i = t.value,
+                r = o ? o.value : null;
+            if ((Wr(i), i === r))
+                if (i.component) {
+                    let s = e.getOrCreateContext(i.outlet);
+                    this.activateChildRoutes(t, o, s.children);
+                } else this.activateChildRoutes(t, o, e);
+            else if (i.component) {
+                let s = e.getOrCreateContext(i.outlet);
+                if (this.routeReuseStrategy.shouldAttach(i.snapshot)) {
+                    let a = this.routeReuseStrategy.retrieve(i.snapshot);
+                    this.routeReuseStrategy.store(i.snapshot, null),
+                        s.children.onOutletReAttached(a.contexts),
+                        (s.attachRef = a.componentRef),
+                        (s.route = a.route.value),
+                        s.outlet &&
+                            s.outlet.attach(a.componentRef, a.route.value),
+                        Wr(a.route.value),
+                        this.activateChildRoutes(t, null, s.children);
+                } else {
+                    let a = an(i.snapshot);
+                    (s.attachRef = null),
+                        (s.route = i),
+                        (s.injector = a),
+                        s.outlet && s.outlet.activateWith(i, s.injector),
+                        this.activateChildRoutes(t, null, s.children);
+                }
+            } else this.activateChildRoutes(t, null, e);
+        }
+    },
+    go = class {
+        constructor(t) {
+            (this.path = t), (this.route = this.path[this.path.length - 1]);
+        }
+    },
+    ri = class {
+        constructor(t, o) {
+            (this.component = t), (this.route = o);
+        }
+    };
+function lm(n, t, o) {
+    let e = n._root,
+        i = t ? t._root : null;
+    return $i(e, i, o, [e.value]);
+}
+function cm(n) {
+    let t = n.routeConfig ? n.routeConfig.canActivateChild : null;
+    return !t || t.length === 0 ? null : { node: n, guards: t };
+}
+function di(n, t) {
+    let o = Symbol(),
+        e = t.get(n, o);
+    return e === o ? (typeof n == "function" && !Na(n) ? n : t.get(n)) : e;
+}
+function $i(
+    n,
+    t,
+    o,
+    e,
+    i = { canDeactivateChecks: [], canActivateChecks: [] }
+) {
+    let r = ni(t);
+    return (
+        n.children.forEach((s) => {
+            dm(s, r[s.value.outlet], o, e.concat([s.value]), i),
+                delete r[s.value.outlet];
+        }),
+        Object.entries(r).forEach(([s, a]) => qi(a, o.getContext(s), i)),
+        i
+    );
+}
+function dm(
+    n,
+    t,
+    o,
+    e,
+    i = { canDeactivateChecks: [], canActivateChecks: [] }
+) {
+    let r = n.value,
+        s = t ? t.value : null,
+        a = o ? o.getContext(n.value.outlet) : null;
+    if (s && r.routeConfig === s.routeConfig) {
+        let l = um(s, r, r.routeConfig.runGuardsAndResolvers);
+        l
+            ? i.canActivateChecks.push(new go(e))
+            : ((r.data = s.data), (r._resolvedData = s._resolvedData)),
+            r.component
+                ? $i(n, t, a ? a.children : null, e, i)
+                : $i(n, t, o, e, i),
+            l &&
+                a &&
+                a.outlet &&
+                a.outlet.isActivated &&
+                i.canDeactivateChecks.push(new ri(a.outlet.component, s));
+    } else
+        s && qi(t, a, i),
+            i.canActivateChecks.push(new go(e)),
+            r.component
+                ? $i(n, null, a ? a.children : null, e, i)
+                : $i(n, null, o, e, i);
+    return i;
+}
+function um(n, t, o) {
+    if (typeof o == "function") return o(n, t);
+    switch (o) {
+        case "pathParamsChange":
+            return !Pe(n.url, t.url);
+        case "pathParamsOrQueryParamsChange":
+            return !Pe(n.url, t.url) || !$t(n.queryParams, t.queryParams);
+        case "always":
+            return !0;
+        case "paramsOrQueryParamsChange":
+            return !us(n, t) || !$t(n.queryParams, t.queryParams);
+        case "paramsChange":
+        default:
+            return !us(n, t);
+    }
+}
+function qi(n, t, o) {
+    let e = ni(n),
+        i = n.value;
+    Object.entries(e).forEach(([r, s]) => {
+        i.component
+            ? t
+                ? qi(s, t.children.getContext(r), o)
+                : qi(s, null, o)
+            : qi(s, t, o);
+    }),
+        i.component
+            ? t && t.outlet && t.outlet.isActivated
+                ? o.canDeactivateChecks.push(new ri(t.outlet.component, i))
+                : o.canDeactivateChecks.push(new ri(null, i))
+            : o.canDeactivateChecks.push(new ri(null, i));
+}
+function ln(n) {
+    return typeof n == "function";
+}
+function hm(n) {
+    return typeof n == "boolean";
+}
+function mm(n) {
+    return n && ln(n.canLoad);
+}
+function fm(n) {
+    return n && ln(n.canActivate);
+}
+function pm(n) {
+    return n && ln(n.canActivateChild);
+}
+function gm(n) {
+    return n && ln(n.canDeactivate);
+}
+function bm(n) {
+    return n && ln(n.canMatch);
+}
+function cc(n) {
+    return n instanceof Ma || n?.name === "EmptyError";
+}
+var no = Symbol("INITIAL_VALUE");
+function ci() {
+    return vt((n) =>
+        Vt(n.map((t) => t.pipe(ut(1), Xt(no)))).pipe(
+            M((t) => {
+                for (let o of t)
+                    if (o !== !0) {
+                        if (o === no) return no;
+                        if (o === !1 || o instanceof pe) return o;
+                    }
+                return !0;
+            }),
+            dt((t) => t !== no),
+            ut(1)
+        )
+    );
+}
+function vm(n, t) {
+    return Rt((o) => {
+        let {
+            targetSnapshot: e,
+            currentSnapshot: i,
+            guards: { canActivateChecks: r, canDeactivateChecks: s },
+        } = o;
+        return s.length === 0 && r.length === 0
+            ? v(q(p({}, o), { guardsResult: !0 }))
+            : _m(s, e, i, n).pipe(
+                  Rt((a) => (a && hm(a) ? ym(e, r, n, t) : v(a))),
+                  M((a) => q(p({}, o), { guardsResult: a }))
+              );
+    });
+}
+function _m(n, t, o, e) {
+    return ht(n).pipe(
+        Rt((i) => Em(i.component, i.route, o, t, e)),
+        ae((i) => i !== !0, !0)
+    );
+}
+function ym(n, t, o, e) {
+    return ht(t).pipe(
+        se((i) =>
+            kn(
+                wm(i.route.parent, e),
+                xm(i.route, e),
+                Dm(n, i.path, o),
+                Cm(n, i.route, o)
+            )
+        ),
+        ae((i) => i !== !0, !0)
+    );
+}
+function xm(n, t) {
+    return n !== null && t && t(new ss(n)), v(!0);
+}
+function wm(n, t) {
+    return n !== null && t && t(new os(n)), v(!0);
+}
+function Cm(n, t, o) {
+    let e = t.routeConfig ? t.routeConfig.canActivate : null;
+    if (!e || e.length === 0) return v(!0);
+    let i = e.map((r) =>
+        lr(() => {
+            let s = an(t) ?? o,
+                a = di(r, s),
+                l = fm(a) ? a.canActivate(t, n) : zt(s, () => a(t, n));
+            return ve(l).pipe(ae());
+        })
+    );
+    return v(i).pipe(ci());
+}
+function Dm(n, t, o) {
+    let e = t[t.length - 1],
+        r = t
+            .slice(0, t.length - 1)
+            .reverse()
+            .map((s) => cm(s))
+            .filter((s) => s !== null)
+            .map((s) =>
+                lr(() => {
+                    let a = s.guards.map((l) => {
+                        let c = an(s.node) ?? o,
+                            d = di(l, c),
+                            h = pm(d)
+                                ? d.canActivateChild(e, n)
+                                : zt(c, () => d(e, n));
+                        return ve(h).pipe(ae());
+                    });
+                    return v(a).pipe(ci());
+                })
+            );
+    return v(r).pipe(ci());
+}
+function Em(n, t, o, e, i) {
+    let r = t && t.routeConfig ? t.routeConfig.canDeactivate : null;
+    if (!r || r.length === 0) return v(!0);
+    let s = r.map((a) => {
+        let l = an(t) ?? i,
+            c = di(a, l),
+            d = gm(c)
+                ? c.canDeactivate(n, t, o, e)
+                : zt(l, () => c(n, t, o, e));
+        return ve(d).pipe(ae());
+    });
+    return v(s).pipe(ci());
+}
+function Sm(n, t, o, e) {
+    let i = t.canLoad;
+    if (i === void 0 || i.length === 0) return v(!0);
+    let r = i.map((s) => {
+        let a = di(s, n),
+            l = mm(a) ? a.canLoad(t, o) : zt(n, () => a(t, o));
+        return ve(l);
+    });
+    return v(r).pipe(ci(), dc(e));
+}
+function dc(n) {
+    return Ra(
+        et((t) => {
+            if (ai(t)) throw sc(n, t);
+        }),
+        M((t) => t === !0)
+    );
+}
+function Im(n, t, o, e) {
+    let i = t.canMatch;
+    if (!i || i.length === 0) return v(!0);
+    let r = i.map((s) => {
+        let a = di(s, n),
+            l = bm(a) ? a.canMatch(t, o) : zt(n, () => a(t, o));
+        return ve(l);
+    });
+    return v(r).pipe(ci(), dc(e));
+}
+var nn = class {
+        constructor(t) {
+            this.segmentGroup = t || null;
+        }
+    },
+    bo = class extends Error {
+        constructor(t) {
+            super(), (this.urlTree = t);
+        }
+    };
+function ii(n) {
+    return Ce(new nn(n));
+}
+function Rm(n) {
+    return Ce(new $(4e3, !1));
+}
+function Mm(n) {
+    return Ce(ac(!1, At.GuardRejected));
+}
+var fs = class {
+        constructor(t, o) {
+            (this.urlSerializer = t), (this.urlTree = o);
+        }
+        lineralizeSegments(t, o) {
+            let e = [],
+                i = o.root;
+            for (;;) {
+                if (((e = e.concat(i.segments)), i.numberOfChildren === 0))
+                    return v(e);
+                if (i.numberOfChildren > 1 || !i.children[O])
+                    return Rm(t.redirectTo);
+                i = i.children[O];
+            }
+        }
+        applyRedirectCommands(t, o, e) {
+            let i = this.applyRedirectCreateUrlTree(
+                o,
+                this.urlSerializer.parse(o),
+                t,
+                e
+            );
+            if (o.startsWith("/")) throw new bo(i);
+            return i;
+        }
+        applyRedirectCreateUrlTree(t, o, e, i) {
+            let r = this.createSegmentGroup(t, o.root, e, i);
+            return new pe(
+                r,
+                this.createQueryParams(o.queryParams, this.urlTree.queryParams),
+                o.fragment
+            );
+        }
+        createQueryParams(t, o) {
+            let e = {};
+            return (
+                Object.entries(t).forEach(([i, r]) => {
+                    if (typeof r == "string" && r.startsWith(":")) {
+                        let a = r.substring(1);
+                        e[i] = o[a];
+                    } else e[i] = r;
+                }),
+                e
+            );
+        }
+        createSegmentGroup(t, o, e, i) {
+            let r = this.createSegments(t, o.segments, e, i),
+                s = {};
+            return (
+                Object.entries(o.children).forEach(([a, l]) => {
+                    s[a] = this.createSegmentGroup(t, l, e, i);
+                }),
+                new G(r, s)
+            );
+        }
+        createSegments(t, o, e, i) {
+            return o.map((r) =>
+                r.path.startsWith(":")
+                    ? this.findPosParam(t, r, i)
+                    : this.findOrReturn(r, e)
+            );
+        }
+        findPosParam(t, o, e) {
+            let i = e[o.path.substring(1)];
+            if (!i) throw new $(4001, !1);
+            return i;
+        }
+        findOrReturn(t, o) {
+            let e = 0;
+            for (let i of o) {
+                if (i.path === t.path) return o.splice(e), i;
+                e++;
+            }
+            return t;
+        }
+    },
+    ps = {
+        matched: !1,
+        consumedSegments: [],
+        remainingSegments: [],
+        parameters: {},
+        positionalParamSegments: {},
+    };
+function km(n, t, o, e, i) {
+    let r = Cs(n, t, o);
+    return r.matched
+        ? ((e = rm(t, e)),
+          Im(e, t, o, i).pipe(M((s) => (s === !0 ? r : p({}, ps)))))
+        : v(r);
+}
+function Cs(n, t, o) {
+    if (t.path === "**") return Tm(o);
+    if (t.path === "")
+        return t.pathMatch === "full" && (n.hasChildren() || o.length > 0)
+            ? p({}, ps)
+            : {
+                  matched: !0,
+                  consumedSegments: [],
+                  remainingSegments: o,
+                  parameters: {},
+                  positionalParamSegments: {},
+              };
+    let i = (t.matcher || Ih)(o, n, t);
+    if (!i) return p({}, ps);
+    let r = {};
+    Object.entries(i.posParams ?? {}).forEach(([a, l]) => {
+        r[a] = l.path;
+    });
+    let s =
+        i.consumed.length > 0
+            ? p(p({}, r), i.consumed[i.consumed.length - 1].parameters)
+            : r;
+    return {
+        matched: !0,
+        consumedSegments: i.consumed,
+        remainingSegments: o.slice(i.consumed.length),
+        parameters: s,
+        positionalParamSegments: i.posParams ?? {},
+    };
+}
+function Tm(n) {
+    return {
+        matched: !0,
+        parameters: n.length > 0 ? Hl(n).parameters : {},
+        consumedSegments: n,
+        remainingSegments: [],
+        positionalParamSegments: {},
+    };
+}
+function Vl(n, t, o, e) {
+    return o.length > 0 && Om(n, o, e)
+        ? {
+              segmentGroup: new G(t, Fm(e, new G(o, n.children))),
+              slicedSegments: [],
+          }
+        : o.length === 0 && Nm(n, o, e)
+          ? {
+                segmentGroup: new G(n.segments, Am(n, o, e, n.children)),
+                slicedSegments: o,
+            }
+          : { segmentGroup: new G(n.segments, n.children), slicedSegments: o };
+}
+function Am(n, t, o, e) {
+    let i = {};
+    for (let r of o)
+        if (xo(n, t, r) && !e[Gt(r)]) {
+            let s = new G([], {});
+            i[Gt(r)] = s;
+        }
+    return p(p({}, e), i);
+}
+function Fm(n, t) {
+    let o = {};
+    o[O] = t;
+    for (let e of n)
+        if (e.path === "" && Gt(e) !== O) {
+            let i = new G([], {});
+            o[Gt(e)] = i;
+        }
+    return o;
+}
+function Om(n, t, o) {
+    return o.some((e) => xo(n, t, e) && Gt(e) !== O);
+}
+function Nm(n, t, o) {
+    return o.some((e) => xo(n, t, e));
+}
+function xo(n, t, o) {
+    return (n.hasChildren() || t.length > 0) && o.pathMatch === "full"
+        ? !1
+        : o.path === "";
+}
+function Pm(n, t, o, e) {
+    return Gt(n) !== e && (e === O || !xo(t, o, n)) ? !1 : Cs(t, n, o).matched;
+}
+function Lm(n, t, o) {
+    return t.length === 0 && !n.children[o];
+}
+var gs = class {};
+function jm(n, t, o, e, i, r, s = "emptyOnly") {
+    return new bs(n, t, o, e, i, s, r).recognize();
+}
+var Vm = 31,
+    bs = class {
+        constructor(t, o, e, i, r, s, a) {
+            (this.injector = t),
+                (this.configLoader = o),
+                (this.rootComponentType = e),
+                (this.config = i),
+                (this.urlTree = r),
+                (this.paramsInheritanceStrategy = s),
+                (this.urlSerializer = a),
+                (this.applyRedirects = new fs(
+                    this.urlSerializer,
+                    this.urlTree
+                )),
+                (this.absoluteRedirectCount = 0),
+                (this.allowRedirects = !0);
+        }
+        noMatchError(t) {
+            return new $(4002, `'${t.segmentGroup}'`);
+        }
+        recognize() {
+            let t = Vl(this.urlTree.root, [], [], this.config).segmentGroup;
+            return this.match(t).pipe(
+                M((o) => {
+                    let e = new tn(
+                            [],
+                            Object.freeze({}),
+                            Object.freeze(p({}, this.urlTree.queryParams)),
+                            this.urlTree.fragment,
+                            {},
+                            O,
+                            this.rootComponentType,
+                            null,
+                            {}
+                        ),
+                        i = new Tt(e, o),
+                        r = new po("", i),
+                        s = Gh(
+                            e,
+                            [],
+                            this.urlTree.queryParams,
+                            this.urlTree.fragment
+                        );
+                    return (
+                        (s.queryParams = this.urlTree.queryParams),
+                        (r.url = this.urlSerializer.serialize(s)),
+                        this.inheritParamsAndData(r._root, null),
+                        { state: r, tree: s }
+                    );
+                })
+            );
+        }
+        match(t) {
+            return this.processSegmentGroup(
+                this.injector,
+                this.config,
+                t,
+                O
+            ).pipe(
+                re((e) => {
+                    if (e instanceof bo)
+                        return (
+                            (this.urlTree = e.urlTree),
+                            this.match(e.urlTree.root)
+                        );
+                    throw e instanceof nn ? this.noMatchError(e) : e;
+                })
+            );
+        }
+        inheritParamsAndData(t, o) {
+            let e = t.value,
+                i = _s(e, o, this.paramsInheritanceStrategy);
+            (e.params = Object.freeze(i.params)),
+                (e.data = Object.freeze(i.data)),
+                t.children.forEach((r) => this.inheritParamsAndData(r, e));
+        }
+        processSegmentGroup(t, o, e, i) {
+            return e.segments.length === 0 && e.hasChildren()
+                ? this.processChildren(t, o, e)
+                : this.processSegment(t, o, e, e.segments, i, !0).pipe(
+                      M((r) => (r instanceof Tt ? [r] : []))
+                  );
+        }
+        processChildren(t, o, e) {
+            let i = [];
+            for (let r of Object.keys(e.children))
+                r === "primary" ? i.unshift(r) : i.push(r);
+            return ht(i).pipe(
+                se((r) => {
+                    let s = e.children[r],
+                        a = sm(o, r);
+                    return this.processSegmentGroup(t, a, s, r);
+                }),
+                Fa((r, s) => (r.push(...s), r)),
+                dr(null),
+                Aa(),
+                Rt((r) => {
+                    if (r === null) return ii(e);
+                    let s = uc(r);
+                    return zm(s), v(s);
+                })
+            );
+        }
+        processSegment(t, o, e, i, r, s) {
+            return ht(o).pipe(
+                se((a) =>
+                    this.processSegmentAgainstRoute(
+                        a._injector ?? t,
+                        o,
+                        a,
+                        e,
+                        i,
+                        r,
+                        s
+                    ).pipe(
+                        re((l) => {
+                            if (l instanceof nn) return v(null);
+                            throw l;
+                        })
+                    )
+                ),
+                ae((a) => !!a),
+                re((a) => {
+                    if (cc(a)) return Lm(e, i, r) ? v(new gs()) : ii(e);
+                    throw a;
+                })
+            );
+        }
+        processSegmentAgainstRoute(t, o, e, i, r, s, a) {
+            return Pm(e, i, r, s)
+                ? e.redirectTo === void 0
+                    ? this.matchSegmentAgainstRoute(t, i, e, r, s)
+                    : this.allowRedirects && a
+                      ? this.expandSegmentAgainstRouteUsingRedirect(
+                            t,
+                            i,
+                            o,
+                            e,
+                            r,
+                            s
+                        )
+                      : ii(i)
+                : ii(i);
+        }
+        expandSegmentAgainstRouteUsingRedirect(t, o, e, i, r, s) {
+            let {
+                matched: a,
+                consumedSegments: l,
+                positionalParamSegments: c,
+                remainingSegments: d,
+            } = Cs(o, i, r);
+            if (!a) return ii(o);
+            i.redirectTo.startsWith("/") &&
+                (this.absoluteRedirectCount++,
+                this.absoluteRedirectCount > Vm && (this.allowRedirects = !1));
+            let h = this.applyRedirects.applyRedirectCommands(
+                l,
+                i.redirectTo,
+                c
+            );
+            return this.applyRedirects
+                .lineralizeSegments(i, h)
+                .pipe(
+                    Rt((f) => this.processSegment(t, e, o, f.concat(d), s, !1))
+                );
+        }
+        matchSegmentAgainstRoute(t, o, e, i, r) {
+            let s = km(o, e, i, t, this.urlSerializer);
+            return (
+                e.path === "**" && (o.children = {}),
+                s.pipe(
+                    vt((a) =>
+                        a.matched
+                            ? ((t = e._injector ?? t),
+                              this.getChildConfig(t, e, i).pipe(
+                                  vt(({ routes: l }) => {
+                                      let c = e._loadedInjector ?? t,
+                                          {
+                                              consumedSegments: d,
+                                              remainingSegments: h,
+                                              parameters: f,
+                                          } = a,
+                                          w = new tn(
+                                              d,
+                                              f,
+                                              Object.freeze(
+                                                  p(
+                                                      {},
+                                                      this.urlTree.queryParams
+                                                  )
+                                              ),
+                                              this.urlTree.fragment,
+                                              Um(e),
+                                              Gt(e),
+                                              e.component ??
+                                                  e._loadedComponent ??
+                                                  null,
+                                              e,
+                                              Hm(e)
+                                          ),
+                                          {
+                                              segmentGroup: j,
+                                              slicedSegments: z,
+                                          } = Vl(o, d, h, l);
+                                      if (z.length === 0 && j.hasChildren())
+                                          return this.processChildren(
+                                              c,
+                                              l,
+                                              j
+                                          ).pipe(
+                                              M((V) =>
+                                                  V === null
+                                                      ? null
+                                                      : new Tt(w, V)
+                                              )
+                                          );
+                                      if (l.length === 0 && z.length === 0)
+                                          return v(new Tt(w, []));
+                                      let k = Gt(e) === r;
+                                      return this.processSegment(
+                                          c,
+                                          l,
+                                          j,
+                                          z,
+                                          k ? O : r,
+                                          !0
+                                      ).pipe(
+                                          M(
+                                              (V) =>
+                                                  new Tt(
+                                                      w,
+                                                      V instanceof Tt ? [V] : []
+                                                  )
+                                          )
+                                      );
+                                  })
+                              ))
+                            : ii(o)
+                    )
+                )
+            );
+        }
+        getChildConfig(t, o, e) {
+            return o.children
+                ? v({ routes: o.children, injector: t })
+                : o.loadChildren
+                  ? o._loadedRoutes !== void 0
+                      ? v({
+                            routes: o._loadedRoutes,
+                            injector: o._loadedInjector,
+                        })
+                      : Sm(t, o, e, this.urlSerializer).pipe(
+                            Rt((i) =>
+                                i
+                                    ? this.configLoader.loadChildren(t, o).pipe(
+                                          et((r) => {
+                                              (o._loadedRoutes = r.routes),
+                                                  (o._loadedInjector =
+                                                      r.injector);
+                                          })
+                                      )
+                                    : Mm(o)
+                            )
+                        )
+                  : v({ routes: [], injector: t });
+        }
+    };
+function zm(n) {
+    n.sort((t, o) =>
+        t.value.outlet === O
+            ? -1
+            : o.value.outlet === O
+              ? 1
+              : t.value.outlet.localeCompare(o.value.outlet)
+    );
+}
+function Bm(n) {
+    let t = n.value.routeConfig;
+    return t && t.path === "";
+}
+function uc(n) {
+    let t = [],
+        o = new Set();
+    for (let e of n) {
+        if (!Bm(e)) {
+            t.push(e);
+            continue;
+        }
+        let i = t.find((r) => e.value.routeConfig === r.value.routeConfig);
+        i !== void 0 ? (i.children.push(...e.children), o.add(i)) : t.push(e);
+    }
+    for (let e of o) {
+        let i = uc(e.children);
+        t.push(new Tt(e.value, i));
+    }
+    return t.filter((e) => !o.has(e));
+}
+function Um(n) {
+    return n.data || {};
+}
+function Hm(n) {
+    return n.resolve || {};
+}
+function $m(n, t, o, e, i, r) {
+    return Rt((s) =>
+        jm(n, t, o, e, s.extractedUrl, i, r).pipe(
+            M(({ state: a, tree: l }) =>
+                q(p({}, s), { targetSnapshot: a, urlAfterRedirects: l })
+            )
+        )
+    );
+}
+function Wm(n, t) {
+    return Rt((o) => {
+        let {
+            targetSnapshot: e,
+            guards: { canActivateChecks: i },
+        } = o;
+        if (!i.length) return v(o);
+        let r = new Set(i.map((l) => l.route)),
+            s = new Set();
+        for (let l of r) if (!s.has(l)) for (let c of hc(l)) s.add(c);
+        let a = 0;
+        return ht(s).pipe(
+            se((l) =>
+                r.has(l)
+                    ? Gm(l, e, n, t)
+                    : ((l.data = _s(l, l.parent, n).resolve), v(void 0))
+            ),
+            et(() => a++),
+            mr(1),
+            Rt((l) => (a === s.size ? v(o) : oe))
+        );
+    });
+}
+function hc(n) {
+    let t = n.children.map((o) => hc(o)).flat();
+    return [n, ...t];
+}
+function Gm(n, t, o, e) {
+    let i = n.routeConfig,
+        r = n._resolve;
+    return (
+        i?.title !== void 0 && !oc(i) && (r[on] = i.title),
+        Ym(r, n, t, e).pipe(
+            M(
+                (s) => (
+                    (n._resolvedData = s),
+                    (n.data = _s(n, n.parent, o).resolve),
+                    null
+                )
+            )
+        )
+    );
+}
+function Ym(n, t, o, e) {
+    let i = qr(n);
+    if (i.length === 0) return v({});
+    let r = {};
+    return ht(i).pipe(
+        Rt((s) =>
+            qm(n[s], t, o, e).pipe(
+                ae(),
+                et((a) => {
+                    r[s] = a;
+                })
+            )
+        ),
+        mr(1),
+        Ta(r),
+        re((s) => (cc(s) ? oe : Ce(s)))
+    );
+}
+function qm(n, t, o, e) {
+    let i = an(t) ?? e,
+        r = di(n, i),
+        s = r.resolve ? r.resolve(t, o) : zt(i, () => r(t, o));
+    return ve(s);
+}
+function Gr(n) {
+    return vt((t) => {
+        let o = n(t);
+        return o ? ht(o).pipe(M(() => t)) : v(t);
+    });
+}
+var mc = (() => {
+        let t = class t {
+            buildTitle(e) {
+                let i,
+                    r = e.root;
+                for (; r !== void 0; )
+                    (i = this.getResolvedTitleForRoute(r) ?? i),
+                        (r = r.children.find((s) => s.outlet === O));
+                return i;
+            }
+            getResolvedTitleForRoute(e) {
+                return e.data[on];
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({
+                token: t,
+                factory: () => g(Zm),
+                providedIn: "root",
+            }));
+        let n = t;
+        return n;
+    })(),
+    Zm = (() => {
+        let t = class t extends mc {
+            constructor(e) {
+                super(), (this.title = e);
+            }
+            updateTitle(e) {
+                let i = this.buildTitle(e);
+                i !== void 0 && this.title.setTitle(i);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(Fl));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    cn = new C("", { providedIn: "root", factory: () => ({}) }),
+    vo = new C(""),
+    Ds = (() => {
+        let t = class t {
+            constructor() {
+                (this.componentLoaders = new WeakMap()),
+                    (this.childrenLoaders = new WeakMap()),
+                    (this.compiler = g(Bn));
+            }
+            loadComponent(e) {
+                if (this.componentLoaders.get(e))
+                    return this.componentLoaders.get(e);
+                if (e._loadedComponent) return v(e._loadedComponent);
+                this.onLoadStartListener && this.onLoadStartListener(e);
+                let i = ve(e.loadComponent()).pipe(
+                        M(fc),
+                        et((s) => {
+                            this.onLoadEndListener && this.onLoadEndListener(e),
+                                (e._loadedComponent = s);
+                        }),
+                        Zt(() => {
+                            this.componentLoaders.delete(e);
+                        })
+                    ),
+                    r = new Ei(i, () => new N()).pipe(sr());
+                return this.componentLoaders.set(e, r), r;
+            }
+            loadChildren(e, i) {
+                if (this.childrenLoaders.get(i))
+                    return this.childrenLoaders.get(i);
+                if (i._loadedRoutes)
+                    return v({
+                        routes: i._loadedRoutes,
+                        injector: i._loadedInjector,
+                    });
+                this.onLoadStartListener && this.onLoadStartListener(i);
+                let s = Xm(i, this.compiler, e, this.onLoadEndListener).pipe(
+                        Zt(() => {
+                            this.childrenLoaders.delete(i);
+                        })
+                    ),
+                    a = new Ei(s, () => new N()).pipe(sr());
+                return this.childrenLoaders.set(i, a), a;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+function Xm(n, t, o, e) {
+    return ve(n.loadChildren()).pipe(
+        M(fc),
+        Rt((i) =>
+            i instanceof Za || Array.isArray(i)
+                ? v(i)
+                : ht(t.compileModuleAsync(i))
+        ),
+        M((i) => {
+            e && e(n);
+            let r,
+                s,
+                a = !1;
+            return (
+                Array.isArray(i)
+                    ? ((s = i), (a = !0))
+                    : ((r = i.create(o).injector),
+                      (s = r.get(vo, [], { optional: !0, self: !0 }).flat())),
+                { routes: s.map(ws), injector: r }
+            );
+        })
+    );
+}
+function Km(n) {
+    return n && typeof n == "object" && "default" in n;
+}
+function fc(n) {
+    return Km(n) ? n.default : n;
+}
+var Es = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({
+                token: t,
+                factory: () => g(Qm),
+                providedIn: "root",
+            }));
+        let n = t;
+        return n;
+    })(),
+    Qm = (() => {
+        let t = class t {
+            shouldProcessUrl(e) {
+                return !0;
+            }
+            extract(e) {
+                return e;
+            }
+            merge(e, i) {
+                return e;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    pc = new C(""),
+    gc = new C("");
+function Jm(n, t, o) {
+    let e = n.get(gc),
+        i = n.get(T);
+    return n.get(I).runOutsideAngular(() => {
+        if (!i.startViewTransition || e.skipNextTransition)
+            return (
+                (e.skipNextTransition = !1), new Promise((c) => setTimeout(c))
+            );
+        let r,
+            s = new Promise((c) => {
+                r = c;
+            }),
+            a = i.startViewTransition(() => (r(), tf(n))),
+            { onViewTransitionCreated: l } = e;
+        return l && zt(n, () => l({ transition: a, from: t, to: o })), s;
+    });
+}
+function tf(n) {
+    return new Promise((t) => {
+        br(t, { injector: n });
+    });
+}
+var Ss = (() => {
+    let t = class t {
+        get hasRequestedNavigation() {
+            return this.navigationId !== 0;
+        }
+        constructor() {
+            (this.currentNavigation = null),
+                (this.currentTransition = null),
+                (this.lastSuccessfulNavigation = null),
+                (this.events = new N()),
+                (this.transitionAbortSubject = new N()),
+                (this.configLoader = g(Ds)),
+                (this.environmentInjector = g(ce)),
+                (this.urlSerializer = g(rn)),
+                (this.rootContexts = g(sn)),
+                (this.location = g(Te)),
+                (this.inputBindingEnabled = g(yo, { optional: !0 }) !== null),
+                (this.titleStrategy = g(mc)),
+                (this.options = g(cn, { optional: !0 }) || {}),
+                (this.paramsInheritanceStrategy =
+                    this.options.paramsInheritanceStrategy || "emptyOnly"),
+                (this.urlHandlingStrategy = g(Es)),
+                (this.createViewTransition = g(pc, { optional: !0 })),
+                (this.navigationId = 0),
+                (this.afterPreactivation = () => v(void 0)),
+                (this.rootComponentType = null);
+            let e = (r) => this.events.next(new is(r)),
+                i = (r) => this.events.next(new ns(r));
+            (this.configLoader.onLoadEndListener = i),
+                (this.configLoader.onLoadStartListener = e);
+        }
+        complete() {
+            this.transitions?.complete();
+        }
+        handleNavigationRequest(e) {
+            let i = ++this.navigationId;
+            this.transitions?.next(
+                q(p(p({}, this.transitions.value), e), { id: i })
+            );
+        }
+        setupNavigations(e, i, r) {
+            return (
+                (this.transitions = new rt({
+                    id: 0,
+                    currentUrlTree: i,
+                    currentRawUrl: i,
+                    extractedUrl: this.urlHandlingStrategy.extract(i),
+                    urlAfterRedirects: this.urlHandlingStrategy.extract(i),
+                    rawUrl: i,
+                    extras: {},
+                    resolve: null,
+                    reject: null,
+                    promise: Promise.resolve(!0),
+                    source: Yi,
+                    restoredState: null,
+                    currentSnapshot: r.snapshot,
+                    targetSnapshot: null,
+                    currentRouterState: r,
+                    targetRouterState: null,
+                    guards: { canActivateChecks: [], canDeactivateChecks: [] },
+                    guardsResult: null,
+                })),
+                this.transitions.pipe(
+                    dt((s) => s.id !== 0),
+                    M((s) =>
+                        q(p({}, s), {
+                            extractedUrl: this.urlHandlingStrategy.extract(
+                                s.rawUrl
+                            ),
+                        })
+                    ),
+                    vt((s) => {
+                        let a = !1,
+                            l = !1;
+                        return v(s).pipe(
+                            vt((c) => {
+                                if (this.navigationId > s.id)
+                                    return (
+                                        this.cancelNavigationTransition(
+                                            s,
+                                            "",
+                                            At.SupersededByNewNavigation
+                                        ),
+                                        oe
+                                    );
+                                (this.currentTransition = s),
+                                    (this.currentNavigation = {
+                                        id: c.id,
+                                        initialUrl: c.rawUrl,
+                                        extractedUrl: c.extractedUrl,
+                                        trigger: c.source,
+                                        extras: c.extras,
+                                        previousNavigation: this
+                                            .lastSuccessfulNavigation
+                                            ? q(
+                                                  p(
+                                                      {},
+                                                      this
+                                                          .lastSuccessfulNavigation
+                                                  ),
+                                                  { previousNavigation: null }
+                                              )
+                                            : null,
+                                    });
+                                let d =
+                                        !e.navigated ||
+                                        this.isUpdatingInternalState() ||
+                                        this.isUpdatedBrowserUrl(),
+                                    h =
+                                        c.extras.onSameUrlNavigation ??
+                                        e.onSameUrlNavigation;
+                                if (!d && h !== "reload") {
+                                    let f = "";
+                                    return (
+                                        this.events.next(
+                                            new be(
+                                                c.id,
+                                                this.urlSerializer.serialize(
+                                                    c.rawUrl
+                                                ),
+                                                f,
+                                                co.IgnoredSameUrlNavigation
+                                            )
+                                        ),
+                                        c.resolve(null),
+                                        oe
+                                    );
+                                }
+                                if (
+                                    this.urlHandlingStrategy.shouldProcessUrl(
+                                        c.rawUrl
+                                    )
+                                )
+                                    return v(c).pipe(
+                                        vt((f) => {
+                                            let w =
+                                                this.transitions?.getValue();
+                                            return (
+                                                this.events.next(
+                                                    new li(
+                                                        f.id,
+                                                        this.urlSerializer.serialize(
+                                                            f.extractedUrl
+                                                        ),
+                                                        f.source,
+                                                        f.restoredState
+                                                    )
+                                                ),
+                                                w !==
+                                                this.transitions?.getValue()
+                                                    ? oe
+                                                    : Promise.resolve(f)
+                                            );
+                                        }),
+                                        $m(
+                                            this.environmentInjector,
+                                            this.configLoader,
+                                            this.rootComponentType,
+                                            e.config,
+                                            this.urlSerializer,
+                                            this.paramsInheritanceStrategy
+                                        ),
+                                        et((f) => {
+                                            (s.targetSnapshot =
+                                                f.targetSnapshot),
+                                                (s.urlAfterRedirects =
+                                                    f.urlAfterRedirects),
+                                                (this.currentNavigation = q(
+                                                    p(
+                                                        {},
+                                                        this.currentNavigation
+                                                    ),
+                                                    {
+                                                        finalUrl:
+                                                            f.urlAfterRedirects,
+                                                    }
+                                                ));
+                                            let w = new uo(
+                                                f.id,
+                                                this.urlSerializer.serialize(
+                                                    f.extractedUrl
+                                                ),
+                                                this.urlSerializer.serialize(
+                                                    f.urlAfterRedirects
+                                                ),
+                                                f.targetSnapshot
+                                            );
+                                            this.events.next(w);
+                                        })
+                                    );
+                                if (
+                                    d &&
+                                    this.urlHandlingStrategy.shouldProcessUrl(
+                                        c.currentRawUrl
+                                    )
+                                ) {
+                                    let {
+                                            id: f,
+                                            extractedUrl: w,
+                                            source: j,
+                                            restoredState: z,
+                                            extras: k,
+                                        } = c,
+                                        V = new li(
+                                            f,
+                                            this.urlSerializer.serialize(w),
+                                            j,
+                                            z
+                                        );
+                                    this.events.next(V);
+                                    let Pt = ic(
+                                        this.rootComponentType
+                                    ).snapshot;
+                                    return (
+                                        (this.currentTransition = s =
+                                            q(p({}, c), {
+                                                targetSnapshot: Pt,
+                                                urlAfterRedirects: w,
+                                                extras: q(p({}, k), {
+                                                    skipLocationChange: !1,
+                                                    replaceUrl: !1,
+                                                }),
+                                            })),
+                                        (this.currentNavigation.finalUrl = w),
+                                        v(s)
+                                    );
+                                } else {
+                                    let f = "";
+                                    return (
+                                        this.events.next(
+                                            new be(
+                                                c.id,
+                                                this.urlSerializer.serialize(
+                                                    c.extractedUrl
+                                                ),
+                                                f,
+                                                co.IgnoredByUrlHandlingStrategy
+                                            )
+                                        ),
+                                        c.resolve(null),
+                                        oe
+                                    );
+                                }
+                            }),
+                            et((c) => {
+                                let d = new Qr(
+                                    c.id,
+                                    this.urlSerializer.serialize(
+                                        c.extractedUrl
+                                    ),
+                                    this.urlSerializer.serialize(
+                                        c.urlAfterRedirects
+                                    ),
+                                    c.targetSnapshot
+                                );
+                                this.events.next(d);
+                            }),
+                            M(
+                                (c) => (
+                                    (this.currentTransition = s =
+                                        q(p({}, c), {
+                                            guards: lm(
+                                                c.targetSnapshot,
+                                                c.currentSnapshot,
+                                                this.rootContexts
+                                            ),
+                                        })),
+                                    s
+                                )
+                            ),
+                            vm(this.environmentInjector, (c) =>
+                                this.events.next(c)
+                            ),
+                            et((c) => {
+                                if (
+                                    ((s.guardsResult = c.guardsResult),
+                                    ai(c.guardsResult))
+                                )
+                                    throw sc(
+                                        this.urlSerializer,
+                                        c.guardsResult
+                                    );
+                                let d = new Jr(
+                                    c.id,
+                                    this.urlSerializer.serialize(
+                                        c.extractedUrl
+                                    ),
+                                    this.urlSerializer.serialize(
+                                        c.urlAfterRedirects
+                                    ),
+                                    c.targetSnapshot,
+                                    !!c.guardsResult
+                                );
+                                this.events.next(d);
+                            }),
+                            dt((c) =>
+                                c.guardsResult
+                                    ? !0
+                                    : (this.cancelNavigationTransition(
+                                          c,
+                                          "",
+                                          At.GuardRejected
+                                      ),
+                                      !1)
+                            ),
+                            Gr((c) => {
+                                if (c.guards.canActivateChecks.length)
+                                    return v(c).pipe(
+                                        et((d) => {
+                                            let h = new ts(
+                                                d.id,
+                                                this.urlSerializer.serialize(
+                                                    d.extractedUrl
+                                                ),
+                                                this.urlSerializer.serialize(
+                                                    d.urlAfterRedirects
+                                                ),
+                                                d.targetSnapshot
+                                            );
+                                            this.events.next(h);
+                                        }),
+                                        vt((d) => {
+                                            let h = !1;
+                                            return v(d).pipe(
+                                                Wm(
+                                                    this
+                                                        .paramsInheritanceStrategy,
+                                                    this.environmentInjector
+                                                ),
+                                                et({
+                                                    next: () => (h = !0),
+                                                    complete: () => {
+                                                        h ||
+                                                            this.cancelNavigationTransition(
+                                                                d,
+                                                                "",
+                                                                At.NoDataFromResolver
+                                                            );
+                                                    },
+                                                })
+                                            );
+                                        }),
+                                        et((d) => {
+                                            let h = new es(
+                                                d.id,
+                                                this.urlSerializer.serialize(
+                                                    d.extractedUrl
+                                                ),
+                                                this.urlSerializer.serialize(
+                                                    d.urlAfterRedirects
+                                                ),
+                                                d.targetSnapshot
+                                            );
+                                            this.events.next(h);
+                                        })
+                                    );
+                            }),
+                            Gr((c) => {
+                                let d = (h) => {
+                                    let f = [];
+                                    h.routeConfig?.loadComponent &&
+                                        !h.routeConfig._loadedComponent &&
+                                        f.push(
+                                            this.configLoader
+                                                .loadComponent(h.routeConfig)
+                                                .pipe(
+                                                    et((w) => {
+                                                        h.component = w;
+                                                    }),
+                                                    M(() => {})
+                                                )
+                                        );
+                                    for (let w of h.children) f.push(...d(w));
+                                    return f;
+                                };
+                                return Vt(d(c.targetSnapshot.root)).pipe(
+                                    dr(null),
+                                    ut(1)
+                                );
+                            }),
+                            Gr(() => this.afterPreactivation()),
+                            vt(() => {
+                                let { currentSnapshot: c, targetSnapshot: d } =
+                                        s,
+                                    h = this.createViewTransition?.(
+                                        this.environmentInjector,
+                                        c.root,
+                                        d.root
+                                    );
+                                return h ? ht(h).pipe(M(() => s)) : v(s);
+                            }),
+                            M((c) => {
+                                let d = tm(
+                                    e.routeReuseStrategy,
+                                    c.targetSnapshot,
+                                    c.currentRouterState
+                                );
+                                return (
+                                    (this.currentTransition = s =
+                                        q(p({}, c), { targetRouterState: d })),
+                                    (this.currentNavigation.targetRouterState =
+                                        d),
+                                    s
+                                );
+                            }),
+                            et(() => {
+                                this.events.next(new Qi());
+                            }),
+                            am(
+                                this.rootContexts,
+                                e.routeReuseStrategy,
+                                (c) => this.events.next(c),
+                                this.inputBindingEnabled
+                            ),
+                            ut(1),
+                            et({
+                                next: (c) => {
+                                    (a = !0),
+                                        (this.lastSuccessfulNavigation =
+                                            this.currentNavigation),
+                                        this.events.next(
+                                            new Wt(
+                                                c.id,
+                                                this.urlSerializer.serialize(
+                                                    c.extractedUrl
+                                                ),
+                                                this.urlSerializer.serialize(
+                                                    c.urlAfterRedirects
+                                                )
+                                            )
+                                        ),
+                                        this.titleStrategy?.updateTitle(
+                                            c.targetRouterState.snapshot
+                                        ),
+                                        c.resolve(!0);
+                                },
+                                complete: () => {
+                                    a = !0;
+                                },
+                            }),
+                            mt(
+                                this.transitionAbortSubject.pipe(
+                                    et((c) => {
+                                        throw c;
+                                    })
+                                )
+                            ),
+                            Zt(() => {
+                                !a &&
+                                    !l &&
+                                    this.cancelNavigationTransition(
+                                        s,
+                                        "",
+                                        At.SupersededByNewNavigation
+                                    ),
+                                    this.currentTransition?.id === s.id &&
+                                        ((this.currentNavigation = null),
+                                        (this.currentTransition = null));
+                            }),
+                            re((c) => {
+                                if (((l = !0), lc(c)))
+                                    this.events.next(
+                                        new ge(
+                                            s.id,
+                                            this.urlSerializer.serialize(
+                                                s.extractedUrl
+                                            ),
+                                            c.message,
+                                            c.cancellationCode
+                                        )
+                                    ),
+                                        nm(c)
+                                            ? this.events.next(new Ji(c.url))
+                                            : s.resolve(!1);
+                                else {
+                                    this.events.next(
+                                        new Ki(
+                                            s.id,
+                                            this.urlSerializer.serialize(
+                                                s.extractedUrl
+                                            ),
+                                            c,
+                                            s.targetSnapshot ?? void 0
+                                        )
+                                    );
+                                    try {
+                                        s.resolve(e.errorHandler(c));
+                                    } catch (d) {
+                                        this.options
+                                            .resolveNavigationPromiseOnError
+                                            ? s.resolve(!1)
+                                            : s.reject(d);
+                                    }
+                                }
+                                return oe;
+                            })
+                        );
+                    })
+                )
+            );
+        }
+        cancelNavigationTransition(e, i, r) {
+            let s = new ge(
+                e.id,
+                this.urlSerializer.serialize(e.extractedUrl),
+                i,
+                r
+            );
+            this.events.next(s), e.resolve(!1);
+        }
+        isUpdatingInternalState() {
+            return (
+                this.currentTransition?.extractedUrl.toString() !==
+                this.currentTransition?.currentUrlTree.toString()
+            );
+        }
+        isUpdatedBrowserUrl() {
+            return (
+                this.urlHandlingStrategy
+                    .extract(this.urlSerializer.parse(this.location.path(!0)))
+                    .toString() !==
+                    this.currentTransition?.extractedUrl.toString() &&
+                !this.currentTransition?.extras.skipLocationChange
+            );
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+function ef(n) {
+    return n !== Yi;
+}
+var nf = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({
+                token: t,
+                factory: () => g(of),
+                providedIn: "root",
+            }));
+        let n = t;
+        return n;
+    })(),
+    vs = class {
+        shouldDetach(t) {
+            return !1;
+        }
+        store(t, o) {}
+        shouldAttach(t) {
+            return !1;
+        }
+        retrieve(t) {
+            return null;
+        }
+        shouldReuseRoute(t, o) {
+            return t.routeConfig === o.routeConfig;
+        }
+    },
+    of = (() => {
+        let t = class t extends vs {};
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    bc = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({
+                token: t,
+                factory: () => g(rf),
+                providedIn: "root",
+            }));
+        let n = t;
+        return n;
+    })(),
+    rf = (() => {
+        let t = class t extends bc {
+            constructor() {
+                super(...arguments),
+                    (this.location = g(Te)),
+                    (this.urlSerializer = g(rn)),
+                    (this.options = g(cn, { optional: !0 }) || {}),
+                    (this.canceledNavigationResolution =
+                        this.options.canceledNavigationResolution || "replace"),
+                    (this.urlHandlingStrategy = g(Es)),
+                    (this.urlUpdateStrategy =
+                        this.options.urlUpdateStrategy || "deferred"),
+                    (this.currentUrlTree = new pe()),
+                    (this.rawUrlTree = this.currentUrlTree),
+                    (this.currentPageId = 0),
+                    (this.lastSuccessfulId = -1),
+                    (this.routerState = ic(null)),
+                    (this.stateMemento = this.createStateMemento());
+            }
+            getCurrentUrlTree() {
+                return this.currentUrlTree;
+            }
+            getRawUrlTree() {
+                return this.rawUrlTree;
+            }
+            restoredState() {
+                return this.location.getState();
+            }
+            get browserPageId() {
+                return this.canceledNavigationResolution !== "computed"
+                    ? this.currentPageId
+                    : (this.restoredState()?.ɵrouterPageId ??
+                          this.currentPageId);
+            }
+            getRouterState() {
+                return this.routerState;
+            }
+            createStateMemento() {
+                return {
+                    rawUrlTree: this.rawUrlTree,
+                    currentUrlTree: this.currentUrlTree,
+                    routerState: this.routerState,
+                };
+            }
+            registerNonRouterCurrentEntryChangeListener(e) {
+                return this.location.subscribe((i) => {
+                    i.type === "popstate" && e(i.url, i.state);
+                });
+            }
+            handleRouterEvent(e, i) {
+                if (e instanceof li)
+                    this.stateMemento = this.createStateMemento();
+                else if (e instanceof be) this.rawUrlTree = i.initialUrl;
+                else if (e instanceof uo) {
+                    if (
+                        this.urlUpdateStrategy === "eager" &&
+                        !i.extras.skipLocationChange
+                    ) {
+                        let r = this.urlHandlingStrategy.merge(
+                            i.finalUrl,
+                            i.initialUrl
+                        );
+                        this.setBrowserUrl(r, i);
+                    }
+                } else
+                    e instanceof Qi
+                        ? ((this.currentUrlTree = i.finalUrl),
+                          (this.rawUrlTree = this.urlHandlingStrategy.merge(
+                              i.finalUrl,
+                              i.initialUrl
+                          )),
+                          (this.routerState = i.targetRouterState),
+                          this.urlUpdateStrategy === "deferred" &&
+                              (i.extras.skipLocationChange ||
+                                  this.setBrowserUrl(this.rawUrlTree, i)))
+                        : e instanceof ge &&
+                            (e.code === At.GuardRejected ||
+                                e.code === At.NoDataFromResolver)
+                          ? this.restoreHistory(i)
+                          : e instanceof Ki
+                            ? this.restoreHistory(i, !0)
+                            : e instanceof Wt &&
+                              ((this.lastSuccessfulId = e.id),
+                              (this.currentPageId = this.browserPageId));
+            }
+            setBrowserUrl(e, i) {
+                let r = this.urlSerializer.serialize(e);
+                if (
+                    this.location.isCurrentPathEqualTo(r) ||
+                    i.extras.replaceUrl
+                ) {
+                    let s = this.browserPageId,
+                        a = p(
+                            p({}, i.extras.state),
+                            this.generateNgRouterState(i.id, s)
+                        );
+                    this.location.replaceState(r, "", a);
+                } else {
+                    let s = p(
+                        p({}, i.extras.state),
+                        this.generateNgRouterState(i.id, this.browserPageId + 1)
+                    );
+                    this.location.go(r, "", s);
+                }
+            }
+            restoreHistory(e, i = !1) {
+                if (this.canceledNavigationResolution === "computed") {
+                    let r = this.browserPageId,
+                        s = this.currentPageId - r;
+                    s !== 0
+                        ? this.location.historyGo(s)
+                        : this.currentUrlTree === e.finalUrl &&
+                          s === 0 &&
+                          (this.resetState(e), this.resetUrlToCurrentUrlTree());
+                } else
+                    this.canceledNavigationResolution === "replace" &&
+                        (i && this.resetState(e),
+                        this.resetUrlToCurrentUrlTree());
+            }
+            resetState(e) {
+                (this.routerState = this.stateMemento.routerState),
+                    (this.currentUrlTree = this.stateMemento.currentUrlTree),
+                    (this.rawUrlTree = this.urlHandlingStrategy.merge(
+                        this.currentUrlTree,
+                        e.finalUrl ?? this.rawUrlTree
+                    ));
+            }
+            resetUrlToCurrentUrlTree() {
+                this.location.replaceState(
+                    this.urlSerializer.serialize(this.rawUrlTree),
+                    "",
+                    this.generateNgRouterState(
+                        this.lastSuccessfulId,
+                        this.currentPageId
+                    )
+                );
+            }
+            generateNgRouterState(e, i) {
+                return this.canceledNavigationResolution === "computed"
+                    ? { navigationId: e, ɵrouterPageId: i }
+                    : { navigationId: e };
+            }
+        };
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    Wi = (function (n) {
+        return (
+            (n[(n.COMPLETE = 0)] = "COMPLETE"),
+            (n[(n.FAILED = 1)] = "FAILED"),
+            (n[(n.REDIRECTING = 2)] = "REDIRECTING"),
+            n
+        );
+    })(Wi || {});
+function vc(n, t) {
+    n.events
+        .pipe(
+            dt(
+                (o) =>
+                    o instanceof Wt ||
+                    o instanceof ge ||
+                    o instanceof Ki ||
+                    o instanceof be
+            ),
+            M((o) =>
+                o instanceof Wt || o instanceof be
+                    ? Wi.COMPLETE
+                    : (
+                            o instanceof ge
+                                ? o.code === At.Redirect ||
+                                  o.code === At.SupersededByNewNavigation
+                                : !1
+                        )
+                      ? Wi.REDIRECTING
+                      : Wi.FAILED
+            ),
+            dt((o) => o !== Wi.REDIRECTING),
+            ut(1)
+        )
+        .subscribe(() => {
+            t();
+        });
+}
+function sf(n) {
+    throw n;
+}
+var af = {
+        paths: "exact",
+        fragment: "ignored",
+        matrixParams: "ignored",
+        queryParams: "exact",
+    },
+    lf = {
+        paths: "subset",
+        fragment: "ignored",
+        matrixParams: "ignored",
+        queryParams: "subset",
+    },
+    Yt = (() => {
+        let t = class t {
+            get currentUrlTree() {
+                return this.stateManager.getCurrentUrlTree();
+            }
+            get rawUrlTree() {
+                return this.stateManager.getRawUrlTree();
+            }
+            get events() {
+                return this._events;
+            }
+            get routerState() {
+                return this.stateManager.getRouterState();
+            }
+            constructor() {
+                (this.disposed = !1),
+                    (this.isNgZoneEnabled = !1),
+                    (this.console = g(Ln)),
+                    (this.stateManager = g(bc)),
+                    (this.options = g(cn, { optional: !0 }) || {}),
+                    (this.pendingTasks = g(Fi)),
+                    (this.urlUpdateStrategy =
+                        this.options.urlUpdateStrategy || "deferred"),
+                    (this.navigationTransitions = g(Ss)),
+                    (this.urlSerializer = g(rn)),
+                    (this.location = g(Te)),
+                    (this.urlHandlingStrategy = g(Es)),
+                    (this._events = new N()),
+                    (this.errorHandler = this.options.errorHandler || sf),
+                    (this.navigated = !1),
+                    (this.routeReuseStrategy = g(nf)),
+                    (this.onSameUrlNavigation =
+                        this.options.onSameUrlNavigation || "ignore"),
+                    (this.config = g(vo, { optional: !0 })?.flat() ?? []),
+                    (this.componentInputBindingEnabled = !!g(yo, {
+                        optional: !0,
+                    })),
+                    (this.eventsSubscription = new St()),
+                    (this.isNgZoneEnabled =
+                        g(I) instanceof I && I.isInAngularZone()),
+                    this.resetConfig(this.config),
+                    this.navigationTransitions
+                        .setupNavigations(
+                            this,
+                            this.currentUrlTree,
+                            this.routerState
+                        )
+                        .subscribe({
+                            error: (e) => {
+                                this.console.warn(e);
+                            },
+                        }),
+                    this.subscribeToNavigationEvents();
+            }
+            subscribeToNavigationEvents() {
+                let e = this.navigationTransitions.events.subscribe((i) => {
+                    try {
+                        let r = this.navigationTransitions.currentTransition,
+                            s = this.navigationTransitions.currentNavigation;
+                        if (r !== null && s !== null) {
+                            if (
+                                (this.stateManager.handleRouterEvent(i, s),
+                                i instanceof ge &&
+                                    i.code !== At.Redirect &&
+                                    i.code !== At.SupersededByNewNavigation)
+                            )
+                                this.navigated = !0;
+                            else if (i instanceof Wt) this.navigated = !0;
+                            else if (i instanceof Ji) {
+                                let a = this.urlHandlingStrategy.merge(
+                                        i.url,
+                                        r.currentRawUrl
+                                    ),
+                                    l = {
+                                        info: r.extras.info,
+                                        skipLocationChange:
+                                            r.extras.skipLocationChange,
+                                        replaceUrl:
+                                            this.urlUpdateStrategy ===
+                                                "eager" || ef(r.source),
+                                    };
+                                this.scheduleNavigation(a, Yi, null, l, {
+                                    resolve: r.resolve,
+                                    reject: r.reject,
+                                    promise: r.promise,
+                                });
+                            }
+                        }
+                        df(i) && this._events.next(i);
+                    } catch (r) {
+                        this.navigationTransitions.transitionAbortSubject.next(
+                            r
+                        );
+                    }
+                });
+                this.eventsSubscription.add(e);
+            }
+            resetRootComponentType(e) {
+                (this.routerState.root.component = e),
+                    (this.navigationTransitions.rootComponentType = e);
+            }
+            initialNavigation() {
+                this.setUpLocationChangeListener(),
+                    this.navigationTransitions.hasRequestedNavigation ||
+                        this.navigateToSyncWithBrowser(
+                            this.location.path(!0),
+                            Yi,
+                            this.stateManager.restoredState()
+                        );
+            }
+            setUpLocationChangeListener() {
+                this.nonRouterCurrentEntryChangeSubscription ??=
+                    this.stateManager.registerNonRouterCurrentEntryChangeListener(
+                        (e, i) => {
+                            setTimeout(() => {
+                                this.navigateToSyncWithBrowser(
+                                    e,
+                                    "popstate",
+                                    i
+                                );
+                            }, 0);
+                        }
+                    );
+            }
+            navigateToSyncWithBrowser(e, i, r) {
+                let s = { replaceUrl: !0 },
+                    a = r?.navigationId ? r : null;
+                if (r) {
+                    let c = p({}, r);
+                    delete c.navigationId,
+                        delete c.ɵrouterPageId,
+                        Object.keys(c).length !== 0 && (s.state = c);
+                }
+                let l = this.parseUrl(e);
+                this.scheduleNavigation(l, i, a, s);
+            }
+            get url() {
+                return this.serializeUrl(this.currentUrlTree);
+            }
+            getCurrentNavigation() {
+                return this.navigationTransitions.currentNavigation;
+            }
+            get lastSuccessfulNavigation() {
+                return this.navigationTransitions.lastSuccessfulNavigation;
+            }
+            resetConfig(e) {
+                (this.config = e.map(ws)), (this.navigated = !1);
+            }
+            ngOnDestroy() {
+                this.dispose();
+            }
+            dispose() {
+                this.navigationTransitions.complete(),
+                    this.nonRouterCurrentEntryChangeSubscription &&
+                        (this.nonRouterCurrentEntryChangeSubscription.unsubscribe(),
+                        (this.nonRouterCurrentEntryChangeSubscription =
+                            void 0)),
+                    (this.disposed = !0),
+                    this.eventsSubscription.unsubscribe();
+            }
+            createUrlTree(e, i = {}) {
+                let {
+                        relativeTo: r,
+                        queryParams: s,
+                        fragment: a,
+                        queryParamsHandling: l,
+                        preserveFragment: c,
+                    } = i,
+                    d = c ? this.currentUrlTree.fragment : a,
+                    h = null;
+                switch (l) {
+                    case "merge":
+                        h = p(p({}, this.currentUrlTree.queryParams), s);
+                        break;
+                    case "preserve":
+                        h = this.currentUrlTree.queryParams;
+                        break;
+                    default:
+                        h = s || null;
+                }
+                h !== null && (h = this.removeEmptyProps(h));
+                let f;
+                try {
+                    let w = r ? r.snapshot : this.routerState.snapshot.root;
+                    f = Ql(w);
+                } catch {
+                    (typeof e[0] != "string" || !e[0].startsWith("/")) &&
+                        (e = []),
+                        (f = this.currentUrlTree.root);
+                }
+                return Jl(f, e, h, d ?? null);
+            }
+            navigateByUrl(e, i = { skipLocationChange: !1 }) {
+                let r = ai(e) ? e : this.parseUrl(e),
+                    s = this.urlHandlingStrategy.merge(r, this.rawUrlTree);
+                return this.scheduleNavigation(s, Yi, null, i);
+            }
+            navigate(e, i = { skipLocationChange: !1 }) {
+                return cf(e), this.navigateByUrl(this.createUrlTree(e, i), i);
+            }
+            serializeUrl(e) {
+                return this.urlSerializer.serialize(e);
+            }
+            parseUrl(e) {
+                try {
+                    return this.urlSerializer.parse(e);
+                } catch {
+                    return this.urlSerializer.parse("/");
+                }
+            }
+            isActive(e, i) {
+                let r;
+                if (
+                    (i === !0
+                        ? (r = p({}, af))
+                        : i === !1
+                          ? (r = p({}, lf))
+                          : (r = i),
+                    ai(e))
+                )
+                    return Ol(this.currentUrlTree, e, r);
+                let s = this.parseUrl(e);
+                return Ol(this.currentUrlTree, s, r);
+            }
+            removeEmptyProps(e) {
+                return Object.entries(e).reduce(
+                    (i, [r, s]) => (s != null && (i[r] = s), i),
+                    {}
+                );
+            }
+            scheduleNavigation(e, i, r, s, a) {
+                if (this.disposed) return Promise.resolve(!1);
+                let l, c, d;
+                a
+                    ? ((l = a.resolve), (c = a.reject), (d = a.promise))
+                    : (d = new Promise((f, w) => {
+                          (l = f), (c = w);
+                      }));
+                let h = this.pendingTasks.add();
+                return (
+                    vc(this, () => {
+                        queueMicrotask(() => this.pendingTasks.remove(h));
+                    }),
+                    this.navigationTransitions.handleNavigationRequest({
+                        source: i,
+                        restoredState: r,
+                        currentUrlTree: this.currentUrlTree,
+                        currentRawUrl: this.currentUrlTree,
+                        rawUrl: e,
+                        extras: s,
+                        resolve: l,
+                        reject: c,
+                        promise: d,
+                        currentSnapshot: this.routerState.snapshot,
+                        currentRouterState: this.routerState,
+                    }),
+                    d.catch((f) => Promise.reject(f))
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+function cf(n) {
+    for (let t = 0; t < n.length; t++) if (n[t] == null) throw new $(4008, !1);
+}
+function df(n) {
+    return !(n instanceof Qi) && !(n instanceof Ji);
+}
+var ui = (() => {
+    let t = class t {
+        constructor(e, i, r, s, a, l) {
+            (this.router = e),
+                (this.route = i),
+                (this.tabIndexAttribute = r),
+                (this.renderer = s),
+                (this.el = a),
+                (this.locationStrategy = l),
+                (this.href = null),
+                (this.commands = null),
+                (this.onChanges = new N()),
+                (this.preserveFragment = !1),
+                (this.skipLocationChange = !1),
+                (this.replaceUrl = !1);
+            let c = a.nativeElement.tagName?.toLowerCase();
+            (this.isAnchorElement = c === "a" || c === "area"),
+                this.isAnchorElement
+                    ? (this.subscription = e.events.subscribe((d) => {
+                          d instanceof Wt && this.updateHref();
+                      }))
+                    : this.setTabIndexIfNotOnNativeEl("0");
+        }
+        setTabIndexIfNotOnNativeEl(e) {
+            this.tabIndexAttribute != null ||
+                this.isAnchorElement ||
+                this.applyAttributeValue("tabindex", e);
+        }
+        ngOnChanges(e) {
+            this.isAnchorElement && this.updateHref(),
+                this.onChanges.next(this);
+        }
+        set routerLink(e) {
+            e != null
+                ? ((this.commands = Array.isArray(e) ? e : [e]),
+                  this.setTabIndexIfNotOnNativeEl("0"))
+                : ((this.commands = null),
+                  this.setTabIndexIfNotOnNativeEl(null));
+        }
+        onClick(e, i, r, s, a) {
+            let l = this.urlTree;
+            if (
+                l === null ||
+                (this.isAnchorElement &&
+                    (e !== 0 ||
+                        i ||
+                        r ||
+                        s ||
+                        a ||
+                        (typeof this.target == "string" &&
+                            this.target != "_self")))
+            )
+                return !0;
+            let c = {
+                skipLocationChange: this.skipLocationChange,
+                replaceUrl: this.replaceUrl,
+                state: this.state,
+                info: this.info,
+            };
+            return this.router.navigateByUrl(l, c), !this.isAnchorElement;
+        }
+        ngOnDestroy() {
+            this.subscription?.unsubscribe();
+        }
+        updateHref() {
+            let e = this.urlTree;
+            this.href =
+                e !== null && this.locationStrategy
+                    ? this.locationStrategy?.prepareExternalUrl(
+                          this.router.serializeUrl(e)
+                      )
+                    : null;
+            let i =
+                this.href === null
+                    ? null
+                    : Ya(
+                          this.href,
+                          this.el.nativeElement.tagName.toLowerCase(),
+                          "href"
+                      );
+            this.applyAttributeValue("href", i);
+        }
+        applyAttributeValue(e, i) {
+            let r = this.renderer,
+                s = this.el.nativeElement;
+            i !== null ? r.setAttribute(s, e, i) : r.removeAttribute(s, e);
+        }
+        get urlTree() {
+            return this.commands === null
+                ? null
+                : this.router.createUrlTree(this.commands, {
+                      relativeTo:
+                          this.relativeTo !== void 0
+                              ? this.relativeTo
+                              : this.route,
+                      queryParams: this.queryParams,
+                      fragment: this.fragment,
+                      queryParamsHandling: this.queryParamsHandling,
+                      preserveFragment: this.preserveFragment,
+                  });
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(u(Yt), u(ee), De("tabindex"), u(Ai), u(A), u(Pi));
+    }),
+        (t.ɵdir = D({
+            type: t,
+            selectors: [["", "routerLink", ""]],
+            hostVars: 1,
+            hostBindings: function (i, r) {
+                i & 1 &&
+                    Z("click", function (a) {
+                        return r.onClick(
+                            a.button,
+                            a.ctrlKey,
+                            a.shiftKey,
+                            a.altKey,
+                            a.metaKey
+                        );
+                    }),
+                    i & 2 && ft("target", r.target);
+            },
+            inputs: {
+                target: "target",
+                queryParams: "queryParams",
+                fragment: "fragment",
+                queryParamsHandling: "queryParamsHandling",
+                state: "state",
+                info: "info",
+                relativeTo: "relativeTo",
+                preserveFragment: [
+                    y.HasDecoratorInputTransform,
+                    "preserveFragment",
+                    "preserveFragment",
+                    W,
+                ],
+                skipLocationChange: [
+                    y.HasDecoratorInputTransform,
+                    "skipLocationChange",
+                    "skipLocationChange",
+                    W,
+                ],
+                replaceUrl: [
+                    y.HasDecoratorInputTransform,
+                    "replaceUrl",
+                    "replaceUrl",
+                    W,
+                ],
+                routerLink: "routerLink",
+            },
+            standalone: !0,
+            features: [nt, yt],
+        }));
+    let n = t;
+    return n;
+})();
+var _o = class {};
+var uf = (() => {
+        let t = class t {
+            constructor(e, i, r, s, a) {
+                (this.router = e),
+                    (this.injector = r),
+                    (this.preloadingStrategy = s),
+                    (this.loader = a);
+            }
+            setUpPreloading() {
+                this.subscription = this.router.events
+                    .pipe(
+                        dt((e) => e instanceof Wt),
+                        se(() => this.preload())
+                    )
+                    .subscribe(() => {});
+            }
+            preload() {
+                return this.processRoutes(this.injector, this.router.config);
+            }
+            ngOnDestroy() {
+                this.subscription && this.subscription.unsubscribe();
+            }
+            processRoutes(e, i) {
+                let r = [];
+                for (let s of i) {
+                    s.providers &&
+                        !s._injector &&
+                        (s._injector = _r(s.providers, e, `Route: ${s.path}`));
+                    let a = s._injector ?? e,
+                        l = s._loadedInjector ?? a;
+                    ((s.loadChildren &&
+                        !s._loadedRoutes &&
+                        s.canLoad === void 0) ||
+                        (s.loadComponent && !s._loadedComponent)) &&
+                        r.push(this.preloadConfig(a, s)),
+                        (s.children || s._loadedRoutes) &&
+                            r.push(
+                                this.processRoutes(
+                                    l,
+                                    s.children ?? s._loadedRoutes
+                                )
+                            );
+                }
+                return ht(r).pipe(ar());
+            }
+            preloadConfig(e, i) {
+                return this.preloadingStrategy.preload(i, () => {
+                    let r;
+                    i.loadChildren && i.canLoad === void 0
+                        ? (r = this.loader.loadChildren(e, i))
+                        : (r = v(null));
+                    let s = r.pipe(
+                        Rt((a) =>
+                            a === null
+                                ? v(void 0)
+                                : ((i._loadedRoutes = a.routes),
+                                  (i._loadedInjector = a.injector),
+                                  this.processRoutes(a.injector ?? e, a.routes))
+                        )
+                    );
+                    if (i.loadComponent && !i._loadedComponent) {
+                        let a = this.loader.loadComponent(i);
+                        return ht([s, a]).pipe(ar());
+                    } else return s;
+                });
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(Yt), m(Bn), m(ce), m(_o), m(Ds));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    _c = new C(""),
+    hf = (() => {
+        let t = class t {
+            constructor(e, i, r, s, a = {}) {
+                (this.urlSerializer = e),
+                    (this.transitions = i),
+                    (this.viewportScroller = r),
+                    (this.zone = s),
+                    (this.options = a),
+                    (this.lastId = 0),
+                    (this.lastSource = "imperative"),
+                    (this.restoredId = 0),
+                    (this.store = {}),
+                    (this.environmentInjector = g(ce)),
+                    (a.scrollPositionRestoration ||= "disabled"),
+                    (a.anchorScrolling ||= "disabled");
+            }
+            init() {
+                this.options.scrollPositionRestoration !== "disabled" &&
+                    this.viewportScroller.setHistoryScrollRestoration("manual"),
+                    (this.routerEventsSubscription = this.createScrollEvents()),
+                    (this.scrollEventsSubscription =
+                        this.consumeScrollEvents());
+            }
+            createScrollEvents() {
+                return this.transitions.events.subscribe((e) => {
+                    e instanceof li
+                        ? ((this.store[this.lastId] =
+                              this.viewportScroller.getScrollPosition()),
+                          (this.lastSource = e.navigationTrigger),
+                          (this.restoredId = e.restoredState
+                              ? e.restoredState.navigationId
+                              : 0))
+                        : e instanceof Wt
+                          ? ((this.lastId = e.id),
+                            this.scheduleScrollEvent(
+                                e,
+                                this.urlSerializer.parse(e.urlAfterRedirects)
+                                    .fragment
+                            ))
+                          : e instanceof be &&
+                            e.code === co.IgnoredSameUrlNavigation &&
+                            ((this.lastSource = void 0),
+                            (this.restoredId = 0),
+                            this.scheduleScrollEvent(
+                                e,
+                                this.urlSerializer.parse(e.url).fragment
+                            ));
+                });
+            }
+            consumeScrollEvents() {
+                return this.transitions.events.subscribe((e) => {
+                    e instanceof ho &&
+                        (e.position
+                            ? this.options.scrollPositionRestoration === "top"
+                                ? this.viewportScroller.scrollToPosition([0, 0])
+                                : this.options.scrollPositionRestoration ===
+                                      "enabled" &&
+                                  this.viewportScroller.scrollToPosition(
+                                      e.position
+                                  )
+                            : e.anchor &&
+                                this.options.anchorScrolling === "enabled"
+                              ? this.viewportScroller.scrollToAnchor(e.anchor)
+                              : this.options.scrollPositionRestoration !==
+                                    "disabled" &&
+                                this.viewportScroller.scrollToPosition([0, 0]));
+                });
+            }
+            scheduleScrollEvent(e, i) {
+                this.zone.runOutsideAngular(() =>
+                    rr(this, null, function* () {
+                        yield new Promise((r) => {
+                            setTimeout(() => {
+                                r();
+                            }),
+                                br(
+                                    () => {
+                                        r();
+                                    },
+                                    { injector: this.environmentInjector }
+                                );
+                        }),
+                            this.zone.run(() => {
+                                this.transitions.events.next(
+                                    new ho(
+                                        e,
+                                        this.lastSource === "popstate"
+                                            ? this.store[this.restoredId]
+                                            : null,
+                                        i
+                                    )
+                                );
+                            });
+                    })
+                );
+            }
+            ngOnDestroy() {
+                this.routerEventsSubscription?.unsubscribe(),
+                    this.scrollEventsSubscription?.unsubscribe();
+            }
+        };
+        (t.ɵfac = function (i) {
+            Ie();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })();
+function mf(n) {
+    return n.routerState.root;
+}
+function dn(n, t) {
+    return { ɵkind: n, ɵproviders: t };
+}
+function ff() {
+    let n = g(Kt);
+    return (t) => {
+        let o = n.get(Re);
+        if (t !== o.components[0]) return;
+        let e = n.get(Yt),
+            i = n.get(yc);
+        n.get(Is) === 1 && e.initialNavigation(),
+            n.get(xc, null, fr.Optional)?.setUpPreloading(),
+            n.get(_c, null, fr.Optional)?.init(),
+            e.resetRootComponentType(o.componentTypes[0]),
+            i.closed || (i.next(), i.complete(), i.unsubscribe());
+    };
+}
+var yc = new C("", { factory: () => new N() }),
+    Is = new C("", { providedIn: "root", factory: () => 1 });
+function pf() {
+    return dn(2, [
+        { provide: Is, useValue: 0 },
+        {
+            provide: xr,
+            multi: !0,
+            deps: [Kt],
+            useFactory: (t) => {
+                let o = t.get(ll, Promise.resolve());
+                return () =>
+                    o.then(
+                        () =>
+                            new Promise((e) => {
+                                let i = t.get(Yt),
+                                    r = t.get(yc);
+                                vc(i, () => {
+                                    e(!0);
+                                }),
+                                    (t.get(Ss).afterPreactivation = () => (
+                                        e(!0), r.closed ? v(void 0) : r
+                                    )),
+                                    i.initialNavigation();
+                            })
+                    );
+            },
+        },
+    ]);
+}
+function gf() {
+    return dn(3, [
+        {
+            provide: xr,
+            multi: !0,
+            useFactory: () => {
+                let t = g(Yt);
+                return () => {
+                    t.setUpLocationChangeListener();
+                };
+            },
+        },
+        { provide: Is, useValue: 2 },
+    ]);
+}
+var xc = new C("");
+function bf(n) {
+    return dn(0, [
+        { provide: xc, useExisting: uf },
+        { provide: _o, useExisting: n },
+    ]);
+}
+function vf() {
+    return dn(8, [jl, { provide: yo, useExisting: jl }]);
+}
+function _f(n) {
+    let t = [
+        { provide: pc, useValue: Jm },
+        {
+            provide: gc,
+            useValue: p({ skipNextTransition: !!n?.skipInitialTransition }, n),
+        },
+    ];
+    return dn(9, t);
+}
+var zl = new C("ROUTER_FORROOT_GUARD"),
+    yf = [
+        Te,
+        { provide: rn, useClass: Zi },
+        Yt,
+        sn,
+        { provide: ee, useFactory: mf, deps: [Yt] },
+        Ds,
+        [],
+    ],
+    Rs = (() => {
+        let t = class t {
+            constructor(e) {}
+            static forRoot(e, i) {
+                return {
+                    ngModule: t,
+                    providers: [
+                        yf,
+                        [],
+                        { provide: vo, multi: !0, useValue: e },
+                        {
+                            provide: zl,
+                            useFactory: Df,
+                            deps: [[Yt, new On(), new pr()]],
+                        },
+                        { provide: cn, useValue: i || {} },
+                        i?.useHash ? wf() : Cf(),
+                        xf(),
+                        i?.preloadingStrategy
+                            ? bf(i.preloadingStrategy).ɵproviders
+                            : [],
+                        i?.initialNavigation ? Ef(i) : [],
+                        i?.bindToComponentInputs ? vf().ɵproviders : [],
+                        i?.enableViewTransitions ? _f().ɵproviders : [],
+                        Sf(),
+                    ],
+                };
+            }
+            static forChild(e) {
+                return {
+                    ngModule: t,
+                    providers: [{ provide: vo, multi: !0, useValue: e }],
+                };
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(zl, 8));
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({}));
+        let n = t;
+        return n;
+    })();
+function xf() {
+    return {
+        provide: _c,
+        useFactory: () => {
+            let n = g(ml),
+                t = g(I),
+                o = g(cn),
+                e = g(Ss),
+                i = g(rn);
+            return (
+                o.scrollOffset && n.setOffset(o.scrollOffset),
+                new hf(i, e, n, t, o)
+            );
+        },
+    };
+}
+function wf() {
+    return { provide: Pi, useClass: dl };
+}
+function Cf() {
+    return { provide: Pi, useClass: cl };
+}
+function Df(n) {
+    return "guarded";
+}
+function Ef(n) {
+    return [
+        n.initialNavigation === "disabled" ? gf().ɵproviders : [],
+        n.initialNavigation === "enabledBlocking" ? pf().ɵproviders : [],
+    ];
+}
+var Bl = new C("");
+function Sf() {
+    return [
+        { provide: Bl, useFactory: ff },
+        { provide: wr, multi: !0, useExisting: Bl },
+    ];
+}
+var kc = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this._renderer = e),
+                    (this._elementRef = i),
+                    (this.onChange = (r) => {}),
+                    (this.onTouched = () => {});
+            }
+            setProperty(e, i) {
+                this._renderer.setProperty(
+                    this._elementRef.nativeElement,
+                    e,
+                    i
+                );
+            }
+            registerOnTouched(e) {
+                this.onTouched = e;
+            }
+            registerOnChange(e) {
+                this.onChange = e;
+            }
+            setDisabledState(e) {
+                this.setProperty("disabled", e);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ai), u(A));
+        }),
+            (t.ɵdir = D({ type: t }));
+        let n = t;
+        return n;
+    })(),
+    If = (() => {
+        let t = class t extends kc {};
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵdir = D({ type: t, features: [U] }));
+        let n = t;
+        return n;
+    })(),
+    Fs = new C("");
+var Rf = { provide: Fs, useExisting: Si(() => pi), multi: !0 };
+function Mf() {
+    let n = ke() ? ke().getUserAgent() : "";
+    return /android (\d+)/.test(n.toLowerCase());
+}
+var kf = new C(""),
+    pi = (() => {
+        let t = class t extends kc {
+            constructor(e, i, r) {
+                super(e, i),
+                    (this._compositionMode = r),
+                    (this._composing = !1),
+                    this._compositionMode == null &&
+                        (this._compositionMode = !Mf());
+            }
+            writeValue(e) {
+                let i = e ?? "";
+                this.setProperty("value", i);
+            }
+            _handleInput(e) {
+                (!this._compositionMode ||
+                    (this._compositionMode && !this._composing)) &&
+                    this.onChange(e);
+            }
+            _compositionStart() {
+                this._composing = !0;
+            }
+            _compositionEnd(e) {
+                (this._composing = !1),
+                    this._compositionMode && this.onChange(e);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ai), u(A), u(kf, 8));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [
+                    ["input", "formControlName", "", 3, "type", "checkbox"],
+                    ["textarea", "formControlName", ""],
+                    ["input", "formControl", "", 3, "type", "checkbox"],
+                    ["textarea", "formControl", ""],
+                    ["input", "ngModel", "", 3, "type", "checkbox"],
+                    ["textarea", "ngModel", ""],
+                    ["", "ngDefaultControl", ""],
+                ],
+                hostBindings: function (i, r) {
+                    i & 1 &&
+                        Z("input", function (a) {
+                            return r._handleInput(a.target.value);
+                        })("blur", function () {
+                            return r.onTouched();
+                        })("compositionstart", function () {
+                            return r._compositionStart();
+                        })("compositionend", function (a) {
+                            return r._compositionEnd(a.target.value);
+                        });
+                },
+                features: [Q([Rf]), U],
+            }));
+        let n = t;
+        return n;
+    })();
+var Os = new C(""),
+    Ns = new C("");
+function Tc(n) {
+    return n != null;
+}
+function Ac(n) {
+    return zn(n) ? ht(n) : n;
+}
+function Fc(n) {
+    let t = {};
+    return (
+        n.forEach((o) => {
+            t = o != null ? p(p({}, t), o) : t;
+        }),
+        Object.keys(t).length === 0 ? null : t
+    );
+}
+function Oc(n, t) {
+    return t.map((o) => o(n));
+}
+function Tf(n) {
+    return !n.validate;
+}
+function Nc(n) {
+    return n.map((t) => (Tf(t) ? t : (o) => t.validate(o)));
+}
+function Af(n) {
+    if (!n) return null;
+    let t = n.filter(Tc);
+    return t.length == 0
+        ? null
+        : function (o) {
+              return Fc(Oc(o, t));
+          };
+}
+function Pc(n) {
+    return n != null ? Af(Nc(n)) : null;
+}
+function Ff(n) {
+    if (!n) return null;
+    let t = n.filter(Tc);
+    return t.length == 0
+        ? null
+        : function (o) {
+              let e = Oc(o, t).map(Ac);
+              return Tn(e).pipe(M(Fc));
+          };
+}
+function Lc(n) {
+    return n != null ? Ff(Nc(n)) : null;
+}
+function wc(n, t) {
+    return n === null ? [t] : Array.isArray(n) ? [...n, t] : [n, t];
+}
+function jc(n) {
+    return n._rawValidators;
+}
+function Vc(n) {
+    return n._rawAsyncValidators;
+}
+function Ms(n) {
+    return n ? (Array.isArray(n) ? n : [n]) : [];
+}
+function Co(n, t) {
+    return Array.isArray(n) ? n.includes(t) : n === t;
+}
+function Cc(n, t) {
+    let o = Ms(t);
+    return (
+        Ms(n).forEach((i) => {
+            Co(o, i) || o.push(i);
+        }),
+        o
+    );
+}
+function Dc(n, t) {
+    return Ms(t).filter((o) => !Co(n, o));
+}
+var Do = class {
+        constructor() {
+            (this._rawValidators = []),
+                (this._rawAsyncValidators = []),
+                (this._onDestroyCallbacks = []);
+        }
+        get value() {
+            return this.control ? this.control.value : null;
+        }
+        get valid() {
+            return this.control ? this.control.valid : null;
+        }
+        get invalid() {
+            return this.control ? this.control.invalid : null;
+        }
+        get pending() {
+            return this.control ? this.control.pending : null;
+        }
+        get disabled() {
+            return this.control ? this.control.disabled : null;
+        }
+        get enabled() {
+            return this.control ? this.control.enabled : null;
+        }
+        get errors() {
+            return this.control ? this.control.errors : null;
+        }
+        get pristine() {
+            return this.control ? this.control.pristine : null;
+        }
+        get dirty() {
+            return this.control ? this.control.dirty : null;
+        }
+        get touched() {
+            return this.control ? this.control.touched : null;
+        }
+        get status() {
+            return this.control ? this.control.status : null;
+        }
+        get untouched() {
+            return this.control ? this.control.untouched : null;
+        }
+        get statusChanges() {
+            return this.control ? this.control.statusChanges : null;
+        }
+        get valueChanges() {
+            return this.control ? this.control.valueChanges : null;
+        }
+        get path() {
+            return null;
+        }
+        _setValidators(t) {
+            (this._rawValidators = t || []),
+                (this._composedValidatorFn = Pc(this._rawValidators));
+        }
+        _setAsyncValidators(t) {
+            (this._rawAsyncValidators = t || []),
+                (this._composedAsyncValidatorFn = Lc(this._rawAsyncValidators));
+        }
+        get validator() {
+            return this._composedValidatorFn || null;
+        }
+        get asyncValidator() {
+            return this._composedAsyncValidatorFn || null;
+        }
+        _registerOnDestroy(t) {
+            this._onDestroyCallbacks.push(t);
+        }
+        _invokeOnDestroyCallbacks() {
+            this._onDestroyCallbacks.forEach((t) => t()),
+                (this._onDestroyCallbacks = []);
+        }
+        reset(t = void 0) {
+            this.control && this.control.reset(t);
+        }
+        hasError(t, o) {
+            return this.control ? this.control.hasError(t, o) : !1;
+        }
+        getError(t, o) {
+            return this.control ? this.control.getError(t, o) : null;
+        }
+    },
+    Le = class extends Do {
+        get formDirective() {
+            return null;
+        }
+        get path() {
+            return null;
+        }
+    },
+    je = class extends Do {
+        constructor() {
+            super(...arguments),
+                (this._parent = null),
+                (this.name = null),
+                (this.valueAccessor = null);
+        }
+    },
+    Eo = class {
+        constructor(t) {
+            this._cd = t;
+        }
+        get isTouched() {
+            return !!this._cd?.control?.touched;
+        }
+        get isUntouched() {
+            return !!this._cd?.control?.untouched;
+        }
+        get isPristine() {
+            return !!this._cd?.control?.pristine;
+        }
+        get isDirty() {
+            return !!this._cd?.control?.dirty;
+        }
+        get isValid() {
+            return !!this._cd?.control?.valid;
+        }
+        get isInvalid() {
+            return !!this._cd?.control?.invalid;
+        }
+        get isPending() {
+            return !!this._cd?.control?.pending;
+        }
+        get isSubmitted() {
+            return !!this._cd?.submitted;
+        }
+    },
+    Of = {
+        "[class.ng-untouched]": "isUntouched",
+        "[class.ng-touched]": "isTouched",
+        "[class.ng-pristine]": "isPristine",
+        "[class.ng-dirty]": "isDirty",
+        "[class.ng-valid]": "isValid",
+        "[class.ng-invalid]": "isInvalid",
+        "[class.ng-pending]": "isPending",
+    },
+    mv = q(p({}, Of), { "[class.ng-submitted]": "isSubmitted" }),
+    Mo = (() => {
+        let t = class t extends Eo {
+            constructor(e) {
+                super(e);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(je, 2));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [
+                    ["", "formControlName", ""],
+                    ["", "ngModel", ""],
+                    ["", "formControl", ""],
+                ],
+                hostVars: 14,
+                hostBindings: function (i, r) {
+                    i & 2 &&
+                        st("ng-untouched", r.isUntouched)(
+                            "ng-touched",
+                            r.isTouched
+                        )("ng-pristine", r.isPristine)("ng-dirty", r.isDirty)(
+                            "ng-valid",
+                            r.isValid
+                        )("ng-invalid", r.isInvalid)("ng-pending", r.isPending);
+                },
+                features: [U],
+            }));
+        let n = t;
+        return n;
+    })(),
+    zc = (() => {
+        let t = class t extends Eo {
+            constructor(e) {
+                super(e);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Le, 10));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [
+                    ["", "formGroupName", ""],
+                    ["", "formArrayName", ""],
+                    ["", "ngModelGroup", ""],
+                    ["", "formGroup", ""],
+                    ["form", 3, "ngNoForm", ""],
+                    ["", "ngForm", ""],
+                ],
+                hostVars: 16,
+                hostBindings: function (i, r) {
+                    i & 2 &&
+                        st("ng-untouched", r.isUntouched)(
+                            "ng-touched",
+                            r.isTouched
+                        )("ng-pristine", r.isPristine)("ng-dirty", r.isDirty)(
+                            "ng-valid",
+                            r.isValid
+                        )("ng-invalid", r.isInvalid)("ng-pending", r.isPending)(
+                            "ng-submitted",
+                            r.isSubmitted
+                        );
+                },
+                features: [U],
+            }));
+        let n = t;
+        return n;
+    })();
+var un = "VALID",
+    wo = "INVALID",
+    mi = "PENDING",
+    hn = "DISABLED";
+function Ps(n) {
+    return (ko(n) ? n.validators : n) || null;
+}
+function Nf(n) {
+    return Array.isArray(n) ? Pc(n) : n || null;
+}
+function Ls(n, t) {
+    return (ko(t) ? t.asyncValidators : n) || null;
+}
+function Pf(n) {
+    return Array.isArray(n) ? Lc(n) : n || null;
+}
+function ko(n) {
+    return n != null && !Array.isArray(n) && typeof n == "object";
+}
+function Bc(n, t, o) {
+    let e = n.controls;
+    if (!(t ? Object.keys(e) : e).length) throw new $(1e3, "");
+    if (!e[o]) throw new $(1001, "");
+}
+function Uc(n, t, o) {
+    n._forEachChild((e, i) => {
+        if (o[i] === void 0) throw new $(1002, "");
+    });
+}
+var fi = class {
+        constructor(t, o) {
+            (this._pendingDirty = !1),
+                (this._hasOwnPendingAsyncValidator = !1),
+                (this._pendingTouched = !1),
+                (this._onCollectionChange = () => {}),
+                (this._parent = null),
+                (this.pristine = !0),
+                (this.touched = !1),
+                (this._onDisabledChange = []),
+                this._assignValidators(t),
+                this._assignAsyncValidators(o);
+        }
+        get validator() {
+            return this._composedValidatorFn;
+        }
+        set validator(t) {
+            this._rawValidators = this._composedValidatorFn = t;
+        }
+        get asyncValidator() {
+            return this._composedAsyncValidatorFn;
+        }
+        set asyncValidator(t) {
+            this._rawAsyncValidators = this._composedAsyncValidatorFn = t;
+        }
+        get parent() {
+            return this._parent;
+        }
+        get valid() {
+            return this.status === un;
+        }
+        get invalid() {
+            return this.status === wo;
+        }
+        get pending() {
+            return this.status == mi;
+        }
+        get disabled() {
+            return this.status === hn;
+        }
+        get enabled() {
+            return this.status !== hn;
+        }
+        get dirty() {
+            return !this.pristine;
+        }
+        get untouched() {
+            return !this.touched;
+        }
+        get updateOn() {
+            return this._updateOn
+                ? this._updateOn
+                : this.parent
+                  ? this.parent.updateOn
+                  : "change";
+        }
+        setValidators(t) {
+            this._assignValidators(t);
+        }
+        setAsyncValidators(t) {
+            this._assignAsyncValidators(t);
+        }
+        addValidators(t) {
+            this.setValidators(Cc(t, this._rawValidators));
+        }
+        addAsyncValidators(t) {
+            this.setAsyncValidators(Cc(t, this._rawAsyncValidators));
+        }
+        removeValidators(t) {
+            this.setValidators(Dc(t, this._rawValidators));
+        }
+        removeAsyncValidators(t) {
+            this.setAsyncValidators(Dc(t, this._rawAsyncValidators));
+        }
+        hasValidator(t) {
+            return Co(this._rawValidators, t);
+        }
+        hasAsyncValidator(t) {
+            return Co(this._rawAsyncValidators, t);
+        }
+        clearValidators() {
+            this.validator = null;
+        }
+        clearAsyncValidators() {
+            this.asyncValidator = null;
+        }
+        markAsTouched(t = {}) {
+            (this.touched = !0),
+                this._parent && !t.onlySelf && this._parent.markAsTouched(t);
+        }
+        markAllAsTouched() {
+            this.markAsTouched({ onlySelf: !0 }),
+                this._forEachChild((t) => t.markAllAsTouched());
+        }
+        markAsUntouched(t = {}) {
+            (this.touched = !1),
+                (this._pendingTouched = !1),
+                this._forEachChild((o) => {
+                    o.markAsUntouched({ onlySelf: !0 });
+                }),
+                this._parent && !t.onlySelf && this._parent._updateTouched(t);
+        }
+        markAsDirty(t = {}) {
+            (this.pristine = !1),
+                this._parent && !t.onlySelf && this._parent.markAsDirty(t);
+        }
+        markAsPristine(t = {}) {
+            (this.pristine = !0),
+                (this._pendingDirty = !1),
+                this._forEachChild((o) => {
+                    o.markAsPristine({ onlySelf: !0 });
+                }),
+                this._parent && !t.onlySelf && this._parent._updatePristine(t);
+        }
+        markAsPending(t = {}) {
+            (this.status = mi),
+                t.emitEvent !== !1 && this.statusChanges.emit(this.status),
+                this._parent && !t.onlySelf && this._parent.markAsPending(t);
+        }
+        disable(t = {}) {
+            let o = this._parentMarkedDirty(t.onlySelf);
+            (this.status = hn),
+                (this.errors = null),
+                this._forEachChild((e) => {
+                    e.disable(q(p({}, t), { onlySelf: !0 }));
+                }),
+                this._updateValue(),
+                t.emitEvent !== !1 &&
+                    (this.valueChanges.emit(this.value),
+                    this.statusChanges.emit(this.status)),
+                this._updateAncestors(q(p({}, t), { skipPristineCheck: o })),
+                this._onDisabledChange.forEach((e) => e(!0));
+        }
+        enable(t = {}) {
+            let o = this._parentMarkedDirty(t.onlySelf);
+            (this.status = un),
+                this._forEachChild((e) => {
+                    e.enable(q(p({}, t), { onlySelf: !0 }));
+                }),
+                this.updateValueAndValidity({
+                    onlySelf: !0,
+                    emitEvent: t.emitEvent,
+                }),
+                this._updateAncestors(q(p({}, t), { skipPristineCheck: o })),
+                this._onDisabledChange.forEach((e) => e(!1));
+        }
+        _updateAncestors(t) {
+            this._parent &&
+                !t.onlySelf &&
+                (this._parent.updateValueAndValidity(t),
+                t.skipPristineCheck || this._parent._updatePristine(),
+                this._parent._updateTouched());
+        }
+        setParent(t) {
+            this._parent = t;
+        }
+        getRawValue() {
+            return this.value;
+        }
+        updateValueAndValidity(t = {}) {
+            this._setInitialStatus(),
+                this._updateValue(),
+                this.enabled &&
+                    (this._cancelExistingSubscription(),
+                    (this.errors = this._runValidator()),
+                    (this.status = this._calculateStatus()),
+                    (this.status === un || this.status === mi) &&
+                        this._runAsyncValidator(t.emitEvent)),
+                t.emitEvent !== !1 &&
+                    (this.valueChanges.emit(this.value),
+                    this.statusChanges.emit(this.status)),
+                this._parent &&
+                    !t.onlySelf &&
+                    this._parent.updateValueAndValidity(t);
+        }
+        _updateTreeValidity(t = { emitEvent: !0 }) {
+            this._forEachChild((o) => o._updateTreeValidity(t)),
+                this.updateValueAndValidity({
+                    onlySelf: !0,
+                    emitEvent: t.emitEvent,
+                });
+        }
+        _setInitialStatus() {
+            this.status = this._allControlsDisabled() ? hn : un;
+        }
+        _runValidator() {
+            return this.validator ? this.validator(this) : null;
+        }
+        _runAsyncValidator(t) {
+            if (this.asyncValidator) {
+                (this.status = mi), (this._hasOwnPendingAsyncValidator = !0);
+                let o = Ac(this.asyncValidator(this));
+                this._asyncValidationSubscription = o.subscribe((e) => {
+                    (this._hasOwnPendingAsyncValidator = !1),
+                        this.setErrors(e, { emitEvent: t });
+                });
+            }
+        }
+        _cancelExistingSubscription() {
+            this._asyncValidationSubscription &&
+                (this._asyncValidationSubscription.unsubscribe(),
+                (this._hasOwnPendingAsyncValidator = !1));
+        }
+        setErrors(t, o = {}) {
+            (this.errors = t), this._updateControlsErrors(o.emitEvent !== !1);
+        }
+        get(t) {
+            let o = t;
+            return o == null ||
+                (Array.isArray(o) || (o = o.split(".")), o.length === 0)
+                ? null
+                : o.reduce((e, i) => e && e._find(i), this);
+        }
+        getError(t, o) {
+            let e = o ? this.get(o) : this;
+            return e && e.errors ? e.errors[t] : null;
+        }
+        hasError(t, o) {
+            return !!this.getError(t, o);
+        }
+        get root() {
+            let t = this;
+            for (; t._parent; ) t = t._parent;
+            return t;
+        }
+        _updateControlsErrors(t) {
+            (this.status = this._calculateStatus()),
+                t && this.statusChanges.emit(this.status),
+                this._parent && this._parent._updateControlsErrors(t);
+        }
+        _initObservables() {
+            (this.valueChanges = new it()), (this.statusChanges = new it());
+        }
+        _calculateStatus() {
+            return this._allControlsDisabled()
+                ? hn
+                : this.errors
+                  ? wo
+                  : this._hasOwnPendingAsyncValidator ||
+                      this._anyControlsHaveStatus(mi)
+                    ? mi
+                    : this._anyControlsHaveStatus(wo)
+                      ? wo
+                      : un;
+        }
+        _anyControlsHaveStatus(t) {
+            return this._anyControls((o) => o.status === t);
+        }
+        _anyControlsDirty() {
+            return this._anyControls((t) => t.dirty);
+        }
+        _anyControlsTouched() {
+            return this._anyControls((t) => t.touched);
+        }
+        _updatePristine(t = {}) {
+            (this.pristine = !this._anyControlsDirty()),
+                this._parent && !t.onlySelf && this._parent._updatePristine(t);
+        }
+        _updateTouched(t = {}) {
+            (this.touched = this._anyControlsTouched()),
+                this._parent && !t.onlySelf && this._parent._updateTouched(t);
+        }
+        _registerOnCollectionChange(t) {
+            this._onCollectionChange = t;
+        }
+        _setUpdateStrategy(t) {
+            ko(t) && t.updateOn != null && (this._updateOn = t.updateOn);
+        }
+        _parentMarkedDirty(t) {
+            let o = this._parent && this._parent.dirty;
+            return !t && !!o && !this._parent._anyControlsDirty();
+        }
+        _find(t) {
+            return null;
+        }
+        _assignValidators(t) {
+            (this._rawValidators = Array.isArray(t) ? t.slice() : t),
+                (this._composedValidatorFn = Nf(this._rawValidators));
+        }
+        _assignAsyncValidators(t) {
+            (this._rawAsyncValidators = Array.isArray(t) ? t.slice() : t),
+                (this._composedAsyncValidatorFn = Pf(this._rawAsyncValidators));
+        }
+    },
+    So = class extends fi {
+        constructor(t, o, e) {
+            super(Ps(o), Ls(e, o)),
+                (this.controls = t),
+                this._initObservables(),
+                this._setUpdateStrategy(o),
+                this._setUpControls(),
+                this.updateValueAndValidity({
+                    onlySelf: !0,
+                    emitEvent: !!this.asyncValidator,
+                });
+        }
+        registerControl(t, o) {
+            return this.controls[t]
+                ? this.controls[t]
+                : ((this.controls[t] = o),
+                  o.setParent(this),
+                  o._registerOnCollectionChange(this._onCollectionChange),
+                  o);
+        }
+        addControl(t, o, e = {}) {
+            this.registerControl(t, o),
+                this.updateValueAndValidity({ emitEvent: e.emitEvent }),
+                this._onCollectionChange();
+        }
+        removeControl(t, o = {}) {
+            this.controls[t] &&
+                this.controls[t]._registerOnCollectionChange(() => {}),
+                delete this.controls[t],
+                this.updateValueAndValidity({ emitEvent: o.emitEvent }),
+                this._onCollectionChange();
+        }
+        setControl(t, o, e = {}) {
+            this.controls[t] &&
+                this.controls[t]._registerOnCollectionChange(() => {}),
+                delete this.controls[t],
+                o && this.registerControl(t, o),
+                this.updateValueAndValidity({ emitEvent: e.emitEvent }),
+                this._onCollectionChange();
+        }
+        contains(t) {
+            return this.controls.hasOwnProperty(t) && this.controls[t].enabled;
+        }
+        setValue(t, o = {}) {
+            Uc(this, !0, t),
+                Object.keys(t).forEach((e) => {
+                    Bc(this, !0, e),
+                        this.controls[e].setValue(t[e], {
+                            onlySelf: !0,
+                            emitEvent: o.emitEvent,
+                        });
+                }),
+                this.updateValueAndValidity(o);
+        }
+        patchValue(t, o = {}) {
+            t != null &&
+                (Object.keys(t).forEach((e) => {
+                    let i = this.controls[e];
+                    i &&
+                        i.patchValue(t[e], {
+                            onlySelf: !0,
+                            emitEvent: o.emitEvent,
+                        });
+                }),
+                this.updateValueAndValidity(o));
+        }
+        reset(t = {}, o = {}) {
+            this._forEachChild((e, i) => {
+                e.reset(t ? t[i] : null, {
+                    onlySelf: !0,
+                    emitEvent: o.emitEvent,
+                });
+            }),
+                this._updatePristine(o),
+                this._updateTouched(o),
+                this.updateValueAndValidity(o);
+        }
+        getRawValue() {
+            return this._reduceChildren(
+                {},
+                (t, o, e) => ((t[e] = o.getRawValue()), t)
+            );
+        }
+        _syncPendingControls() {
+            let t = this._reduceChildren(!1, (o, e) =>
+                e._syncPendingControls() ? !0 : o
+            );
+            return t && this.updateValueAndValidity({ onlySelf: !0 }), t;
+        }
+        _forEachChild(t) {
+            Object.keys(this.controls).forEach((o) => {
+                let e = this.controls[o];
+                e && t(e, o);
+            });
+        }
+        _setUpControls() {
+            this._forEachChild((t) => {
+                t.setParent(this),
+                    t._registerOnCollectionChange(this._onCollectionChange);
+            });
+        }
+        _updateValue() {
+            this.value = this._reduceValue();
+        }
+        _anyControls(t) {
+            for (let [o, e] of Object.entries(this.controls))
+                if (this.contains(o) && t(e)) return !0;
+            return !1;
+        }
+        _reduceValue() {
+            let t = {};
+            return this._reduceChildren(
+                t,
+                (o, e, i) => (
+                    (e.enabled || this.disabled) && (o[i] = e.value), o
+                )
+            );
+        }
+        _reduceChildren(t, o) {
+            let e = t;
+            return (
+                this._forEachChild((i, r) => {
+                    e = o(e, i, r);
+                }),
+                e
+            );
+        }
+        _allControlsDisabled() {
+            for (let t of Object.keys(this.controls))
+                if (this.controls[t].enabled) return !1;
+            return Object.keys(this.controls).length > 0 || this.disabled;
+        }
+        _find(t) {
+            return this.controls.hasOwnProperty(t) ? this.controls[t] : null;
+        }
+    };
+var ks = class extends So {};
+var To = new C("CallSetDisabledState", {
+        providedIn: "root",
+        factory: () => Ao,
+    }),
+    Ao = "always";
+function Hc(n, t) {
+    return [...t.path, n];
+}
+function Ts(n, t, o = Ao) {
+    js(n, t),
+        t.valueAccessor.writeValue(n.value),
+        (n.disabled || o === "always") &&
+            t.valueAccessor.setDisabledState?.(n.disabled),
+        jf(n, t),
+        zf(n, t),
+        Vf(n, t),
+        Lf(n, t);
+}
+function Ec(n, t, o = !0) {
+    let e = () => {};
+    t.valueAccessor &&
+        (t.valueAccessor.registerOnChange(e),
+        t.valueAccessor.registerOnTouched(e)),
+        Ro(n, t),
+        n &&
+            (t._invokeOnDestroyCallbacks(),
+            n._registerOnCollectionChange(() => {}));
+}
+function Io(n, t) {
+    n.forEach((o) => {
+        o.registerOnValidatorChange && o.registerOnValidatorChange(t);
+    });
+}
+function Lf(n, t) {
+    if (t.valueAccessor.setDisabledState) {
+        let o = (e) => {
+            t.valueAccessor.setDisabledState(e);
+        };
+        n.registerOnDisabledChange(o),
+            t._registerOnDestroy(() => {
+                n._unregisterOnDisabledChange(o);
+            });
+    }
+}
+function js(n, t) {
+    let o = jc(n);
+    t.validator !== null
+        ? n.setValidators(wc(o, t.validator))
+        : typeof o == "function" && n.setValidators([o]);
+    let e = Vc(n);
+    t.asyncValidator !== null
+        ? n.setAsyncValidators(wc(e, t.asyncValidator))
+        : typeof e == "function" && n.setAsyncValidators([e]);
+    let i = () => n.updateValueAndValidity();
+    Io(t._rawValidators, i), Io(t._rawAsyncValidators, i);
+}
+function Ro(n, t) {
+    let o = !1;
+    if (n !== null) {
+        if (t.validator !== null) {
+            let i = jc(n);
+            if (Array.isArray(i) && i.length > 0) {
+                let r = i.filter((s) => s !== t.validator);
+                r.length !== i.length && ((o = !0), n.setValidators(r));
+            }
+        }
+        if (t.asyncValidator !== null) {
+            let i = Vc(n);
+            if (Array.isArray(i) && i.length > 0) {
+                let r = i.filter((s) => s !== t.asyncValidator);
+                r.length !== i.length && ((o = !0), n.setAsyncValidators(r));
+            }
+        }
+    }
+    let e = () => {};
+    return Io(t._rawValidators, e), Io(t._rawAsyncValidators, e), o;
+}
+function jf(n, t) {
+    t.valueAccessor.registerOnChange((o) => {
+        (n._pendingValue = o),
+            (n._pendingChange = !0),
+            (n._pendingDirty = !0),
+            n.updateOn === "change" && $c(n, t);
+    });
+}
+function Vf(n, t) {
+    t.valueAccessor.registerOnTouched(() => {
+        (n._pendingTouched = !0),
+            n.updateOn === "blur" && n._pendingChange && $c(n, t),
+            n.updateOn !== "submit" && n.markAsTouched();
+    });
+}
+function $c(n, t) {
+    n._pendingDirty && n.markAsDirty(),
+        n.setValue(n._pendingValue, { emitModelToViewChange: !1 }),
+        t.viewToModelUpdate(n._pendingValue),
+        (n._pendingChange = !1);
+}
+function zf(n, t) {
+    let o = (e, i) => {
+        t.valueAccessor.writeValue(e), i && t.viewToModelUpdate(e);
+    };
+    n.registerOnChange(o),
+        t._registerOnDestroy(() => {
+            n._unregisterOnChange(o);
+        });
+}
+function Bf(n, t) {
+    n == null, js(n, t);
+}
+function Uf(n, t) {
+    return Ro(n, t);
+}
+function Wc(n, t) {
+    if (!n.hasOwnProperty("model")) return !1;
+    let o = n.model;
+    return o.isFirstChange() ? !0 : !Object.is(t, o.currentValue);
+}
+function Hf(n) {
+    return Object.getPrototypeOf(n.constructor) === If;
+}
+function $f(n, t) {
+    n._syncPendingControls(),
+        t.forEach((o) => {
+            let e = o.control;
+            e.updateOn === "submit" &&
+                e._pendingChange &&
+                (o.viewToModelUpdate(e._pendingValue), (e._pendingChange = !1));
+        });
+}
+function Gc(n, t) {
+    if (!t) return null;
+    Array.isArray(t);
+    let o, e, i;
+    return (
+        t.forEach((r) => {
+            r.constructor === pi ? (o = r) : Hf(r) ? (e = r) : (i = r);
+        }),
+        i || e || o || null
+    );
+}
+function Wf(n, t) {
+    let o = n.indexOf(t);
+    o > -1 && n.splice(o, 1);
+}
+function Sc(n, t) {
+    let o = n.indexOf(t);
+    o > -1 && n.splice(o, 1);
+}
+function Ic(n) {
+    return (
+        typeof n == "object" &&
+        n !== null &&
+        Object.keys(n).length === 2 &&
+        "value" in n &&
+        "disabled" in n
+    );
+}
+var mn = class extends fi {
+    constructor(t = null, o, e) {
+        super(Ps(o), Ls(e, o)),
+            (this.defaultValue = null),
+            (this._onChange = []),
+            (this._pendingChange = !1),
+            this._applyFormState(t),
+            this._setUpdateStrategy(o),
+            this._initObservables(),
+            this.updateValueAndValidity({
+                onlySelf: !0,
+                emitEvent: !!this.asyncValidator,
+            }),
+            ko(o) &&
+                (o.nonNullable || o.initialValueIsDefault) &&
+                (Ic(t)
+                    ? (this.defaultValue = t.value)
+                    : (this.defaultValue = t));
+    }
+    setValue(t, o = {}) {
+        (this.value = this._pendingValue = t),
+            this._onChange.length &&
+                o.emitModelToViewChange !== !1 &&
+                this._onChange.forEach((e) =>
+                    e(this.value, o.emitViewToModelChange !== !1)
+                ),
+            this.updateValueAndValidity(o);
+    }
+    patchValue(t, o = {}) {
+        this.setValue(t, o);
+    }
+    reset(t = this.defaultValue, o = {}) {
+        this._applyFormState(t),
+            this.markAsPristine(o),
+            this.markAsUntouched(o),
+            this.setValue(this.value, o),
+            (this._pendingChange = !1);
+    }
+    _updateValue() {}
+    _anyControls(t) {
+        return !1;
+    }
+    _allControlsDisabled() {
+        return this.disabled;
+    }
+    registerOnChange(t) {
+        this._onChange.push(t);
+    }
+    _unregisterOnChange(t) {
+        Sc(this._onChange, t);
+    }
+    registerOnDisabledChange(t) {
+        this._onDisabledChange.push(t);
+    }
+    _unregisterOnDisabledChange(t) {
+        Sc(this._onDisabledChange, t);
+    }
+    _forEachChild(t) {}
+    _syncPendingControls() {
+        return this.updateOn === "submit" &&
+            (this._pendingDirty && this.markAsDirty(),
+            this._pendingTouched && this.markAsTouched(),
+            this._pendingChange)
+            ? (this.setValue(this._pendingValue, {
+                  onlySelf: !0,
+                  emitModelToViewChange: !1,
+              }),
+              !0)
+            : !1;
+    }
+    _applyFormState(t) {
+        Ic(t)
+            ? ((this.value = this._pendingValue = t.value),
+              t.disabled
+                  ? this.disable({ onlySelf: !0, emitEvent: !1 })
+                  : this.enable({ onlySelf: !0, emitEvent: !1 }))
+            : (this.value = this._pendingValue = t);
+    }
+};
+var Gf = (n) => n instanceof mn;
+var Yf = { provide: je, useExisting: Si(() => Vs) },
+    Rc = Promise.resolve(),
+    Vs = (() => {
+        let t = class t extends je {
+            constructor(e, i, r, s, a, l) {
+                super(),
+                    (this._changeDetectorRef = a),
+                    (this.callSetDisabledState = l),
+                    (this.control = new mn()),
+                    (this._registered = !1),
+                    (this.name = ""),
+                    (this.update = new it()),
+                    (this._parent = e),
+                    this._setValidators(i),
+                    this._setAsyncValidators(r),
+                    (this.valueAccessor = Gc(this, s));
+            }
+            ngOnChanges(e) {
+                if (
+                    (this._checkForErrors(), !this._registered || "name" in e)
+                ) {
+                    if (
+                        this._registered &&
+                        (this._checkName(), this.formDirective)
+                    ) {
+                        let i = e.name.previousValue;
+                        this.formDirective.removeControl({
+                            name: i,
+                            path: this._getPath(i),
+                        });
+                    }
+                    this._setUpControl();
+                }
+                "isDisabled" in e && this._updateDisabled(e),
+                    Wc(e, this.viewModel) &&
+                        (this._updateValue(this.model),
+                        (this.viewModel = this.model));
+            }
+            ngOnDestroy() {
+                this.formDirective && this.formDirective.removeControl(this);
+            }
+            get path() {
+                return this._getPath(this.name);
+            }
+            get formDirective() {
+                return this._parent ? this._parent.formDirective : null;
+            }
+            viewToModelUpdate(e) {
+                (this.viewModel = e), this.update.emit(e);
+            }
+            _setUpControl() {
+                this._setUpdateStrategy(),
+                    this._isStandalone()
+                        ? this._setUpStandalone()
+                        : this.formDirective.addControl(this),
+                    (this._registered = !0);
+            }
+            _setUpdateStrategy() {
+                this.options &&
+                    this.options.updateOn != null &&
+                    (this.control._updateOn = this.options.updateOn);
+            }
+            _isStandalone() {
+                return (
+                    !this._parent || !!(this.options && this.options.standalone)
+                );
+            }
+            _setUpStandalone() {
+                Ts(this.control, this, this.callSetDisabledState),
+                    this.control.updateValueAndValidity({ emitEvent: !1 });
+            }
+            _checkForErrors() {
+                this._isStandalone() || this._checkParentType(),
+                    this._checkName();
+            }
+            _checkParentType() {}
+            _checkName() {
+                this.options &&
+                    this.options.name &&
+                    (this.name = this.options.name),
+                    !this._isStandalone() && this.name;
+            }
+            _updateValue(e) {
+                Rc.then(() => {
+                    this.control.setValue(e, { emitViewToModelChange: !1 }),
+                        this._changeDetectorRef?.markForCheck();
+                });
+            }
+            _updateDisabled(e) {
+                let i = e.isDisabled.currentValue,
+                    r = i !== 0 && W(i);
+                Rc.then(() => {
+                    r && !this.control.disabled
+                        ? this.control.disable()
+                        : !r && this.control.disabled && this.control.enable(),
+                        this._changeDetectorRef?.markForCheck();
+                });
+            }
+            _getPath(e) {
+                return this._parent ? Hc(e, this._parent) : [e];
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(
+                u(Le, 9),
+                u(Os, 10),
+                u(Ns, 10),
+                u(Fs, 10),
+                u(Dt, 8),
+                u(To, 8)
+            );
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [
+                    [
+                        "",
+                        "ngModel",
+                        "",
+                        3,
+                        "formControlName",
+                        "",
+                        3,
+                        "formControl",
+                        "",
+                    ],
+                ],
+                inputs: {
+                    name: "name",
+                    isDisabled: [y.None, "disabled", "isDisabled"],
+                    model: [y.None, "ngModel", "model"],
+                    options: [y.None, "ngModelOptions", "options"],
+                },
+                outputs: { update: "ngModelChange" },
+                exportAs: ["ngModel"],
+                features: [Q([Yf]), U, yt],
+            }));
+        let n = t;
+        return n;
+    })(),
+    Yc = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [
+                    ["form", 3, "ngNoForm", "", 3, "ngNativeValidate", ""],
+                ],
+                hostAttrs: ["novalidate", ""],
+            }));
+        let n = t;
+        return n;
+    })();
+var qc = new C("");
+var qf = { provide: Le, useExisting: Si(() => zs) },
+    zs = (() => {
+        let t = class t extends Le {
+            constructor(e, i, r) {
+                super(),
+                    (this.callSetDisabledState = r),
+                    (this.submitted = !1),
+                    (this._onCollectionChange = () => this._updateDomValue()),
+                    (this.directives = []),
+                    (this.form = null),
+                    (this.ngSubmit = new it()),
+                    this._setValidators(e),
+                    this._setAsyncValidators(i);
+            }
+            ngOnChanges(e) {
+                this._checkFormPresent(),
+                    e.hasOwnProperty("form") &&
+                        (this._updateValidators(),
+                        this._updateDomValue(),
+                        this._updateRegistrations(),
+                        (this._oldForm = this.form));
+            }
+            ngOnDestroy() {
+                this.form &&
+                    (Ro(this.form, this),
+                    this.form._onCollectionChange ===
+                        this._onCollectionChange &&
+                        this.form._registerOnCollectionChange(() => {}));
+            }
+            get formDirective() {
+                return this;
+            }
+            get control() {
+                return this.form;
+            }
+            get path() {
+                return [];
+            }
+            addControl(e) {
+                let i = this.form.get(e.path);
+                return (
+                    Ts(i, e, this.callSetDisabledState),
+                    i.updateValueAndValidity({ emitEvent: !1 }),
+                    this.directives.push(e),
+                    i
+                );
+            }
+            getControl(e) {
+                return this.form.get(e.path);
+            }
+            removeControl(e) {
+                Ec(e.control || null, e, !1), Wf(this.directives, e);
+            }
+            addFormGroup(e) {
+                this._setUpFormContainer(e);
+            }
+            removeFormGroup(e) {
+                this._cleanUpFormContainer(e);
+            }
+            getFormGroup(e) {
+                return this.form.get(e.path);
+            }
+            addFormArray(e) {
+                this._setUpFormContainer(e);
+            }
+            removeFormArray(e) {
+                this._cleanUpFormContainer(e);
+            }
+            getFormArray(e) {
+                return this.form.get(e.path);
+            }
+            updateModel(e, i) {
+                this.form.get(e.path).setValue(i);
+            }
+            onSubmit(e) {
+                return (
+                    (this.submitted = !0),
+                    $f(this.form, this.directives),
+                    this.ngSubmit.emit(e),
+                    e?.target?.method === "dialog"
+                );
+            }
+            onReset() {
+                this.resetForm();
+            }
+            resetForm(e = void 0) {
+                this.form.reset(e), (this.submitted = !1);
+            }
+            _updateDomValue() {
+                this.directives.forEach((e) => {
+                    let i = e.control,
+                        r = this.form.get(e.path);
+                    i !== r &&
+                        (Ec(i || null, e),
+                        Gf(r) &&
+                            (Ts(r, e, this.callSetDisabledState),
+                            (e.control = r)));
+                }),
+                    this.form._updateTreeValidity({ emitEvent: !1 });
+            }
+            _setUpFormContainer(e) {
+                let i = this.form.get(e.path);
+                Bf(i, e), i.updateValueAndValidity({ emitEvent: !1 });
+            }
+            _cleanUpFormContainer(e) {
+                if (this.form) {
+                    let i = this.form.get(e.path);
+                    i &&
+                        Uf(i, e) &&
+                        i.updateValueAndValidity({ emitEvent: !1 });
+                }
+            }
+            _updateRegistrations() {
+                this.form._registerOnCollectionChange(this._onCollectionChange),
+                    this._oldForm &&
+                        this._oldForm._registerOnCollectionChange(() => {});
+            }
+            _updateValidators() {
+                js(this.form, this), this._oldForm && Ro(this._oldForm, this);
+            }
+            _checkFormPresent() {
+                this.form;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Os, 10), u(Ns, 10), u(To, 8));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "formGroup", ""]],
+                hostBindings: function (i, r) {
+                    i & 1 &&
+                        Z("submit", function (a) {
+                            return r.onSubmit(a);
+                        })("reset", function () {
+                            return r.onReset();
+                        });
+                },
+                inputs: { form: [y.None, "formGroup", "form"] },
+                outputs: { ngSubmit: "ngSubmit" },
+                exportAs: ["ngForm"],
+                features: [Q([qf]), U, yt],
+            }));
+        let n = t;
+        return n;
+    })();
+var Zf = { provide: je, useExisting: Si(() => Bs) },
+    Bs = (() => {
+        let t = class t extends je {
+            set isDisabled(e) {}
+            constructor(e, i, r, s, a) {
+                super(),
+                    (this._ngModelWarningConfig = a),
+                    (this._added = !1),
+                    (this.name = null),
+                    (this.update = new it()),
+                    (this._ngModelWarningSent = !1),
+                    (this._parent = e),
+                    this._setValidators(i),
+                    this._setAsyncValidators(r),
+                    (this.valueAccessor = Gc(this, s));
+            }
+            ngOnChanges(e) {
+                this._added || this._setUpControl(),
+                    Wc(e, this.viewModel) &&
+                        ((this.viewModel = this.model),
+                        this.formDirective.updateModel(this, this.model));
+            }
+            ngOnDestroy() {
+                this.formDirective && this.formDirective.removeControl(this);
+            }
+            viewToModelUpdate(e) {
+                (this.viewModel = e), this.update.emit(e);
+            }
+            get path() {
+                return Hc(
+                    this.name == null ? this.name : this.name.toString(),
+                    this._parent
+                );
+            }
+            get formDirective() {
+                return this._parent ? this._parent.formDirective : null;
+            }
+            _checkParentType() {}
+            _setUpControl() {
+                this._checkParentType(),
+                    (this.control = this.formDirective.addControl(this)),
+                    (this._added = !0);
+            }
+        };
+        (t._ngModelWarningSentOnce = !1),
+            (t.ɵfac = function (i) {
+                return new (i || t)(
+                    u(Le, 13),
+                    u(Os, 10),
+                    u(Ns, 10),
+                    u(Fs, 10),
+                    u(qc, 8)
+                );
+            }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "formControlName", ""]],
+                inputs: {
+                    name: [y.None, "formControlName", "name"],
+                    isDisabled: [y.None, "disabled", "isDisabled"],
+                    model: [y.None, "ngModel", "model"],
+                },
+                outputs: { update: "ngModelChange" },
+                features: [Q([Zf]), U, yt],
+            }));
+        let n = t;
+        return n;
+    })();
+var Zc = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({}));
+        let n = t;
+        return n;
+    })(),
+    As = class extends fi {
+        constructor(t, o, e) {
+            super(Ps(o), Ls(e, o)),
+                (this.controls = t),
+                this._initObservables(),
+                this._setUpdateStrategy(o),
+                this._setUpControls(),
+                this.updateValueAndValidity({
+                    onlySelf: !0,
+                    emitEvent: !!this.asyncValidator,
+                });
+        }
+        at(t) {
+            return this.controls[this._adjustIndex(t)];
+        }
+        push(t, o = {}) {
+            this.controls.push(t),
+                this._registerControl(t),
+                this.updateValueAndValidity({ emitEvent: o.emitEvent }),
+                this._onCollectionChange();
+        }
+        insert(t, o, e = {}) {
+            this.controls.splice(t, 0, o),
+                this._registerControl(o),
+                this.updateValueAndValidity({ emitEvent: e.emitEvent });
+        }
+        removeAt(t, o = {}) {
+            let e = this._adjustIndex(t);
+            e < 0 && (e = 0),
+                this.controls[e] &&
+                    this.controls[e]._registerOnCollectionChange(() => {}),
+                this.controls.splice(e, 1),
+                this.updateValueAndValidity({ emitEvent: o.emitEvent });
+        }
+        setControl(t, o, e = {}) {
+            let i = this._adjustIndex(t);
+            i < 0 && (i = 0),
+                this.controls[i] &&
+                    this.controls[i]._registerOnCollectionChange(() => {}),
+                this.controls.splice(i, 1),
+                o && (this.controls.splice(i, 0, o), this._registerControl(o)),
+                this.updateValueAndValidity({ emitEvent: e.emitEvent }),
+                this._onCollectionChange();
+        }
+        get length() {
+            return this.controls.length;
+        }
+        setValue(t, o = {}) {
+            Uc(this, !1, t),
+                t.forEach((e, i) => {
+                    Bc(this, !1, i),
+                        this.at(i).setValue(e, {
+                            onlySelf: !0,
+                            emitEvent: o.emitEvent,
+                        });
+                }),
+                this.updateValueAndValidity(o);
+        }
+        patchValue(t, o = {}) {
+            t != null &&
+                (t.forEach((e, i) => {
+                    this.at(i) &&
+                        this.at(i).patchValue(e, {
+                            onlySelf: !0,
+                            emitEvent: o.emitEvent,
+                        });
+                }),
+                this.updateValueAndValidity(o));
+        }
+        reset(t = [], o = {}) {
+            this._forEachChild((e, i) => {
+                e.reset(t[i], { onlySelf: !0, emitEvent: o.emitEvent });
+            }),
+                this._updatePristine(o),
+                this._updateTouched(o),
+                this.updateValueAndValidity(o);
+        }
+        getRawValue() {
+            return this.controls.map((t) => t.getRawValue());
+        }
+        clear(t = {}) {
+            this.controls.length < 1 ||
+                (this._forEachChild((o) =>
+                    o._registerOnCollectionChange(() => {})
+                ),
+                this.controls.splice(0),
+                this.updateValueAndValidity({ emitEvent: t.emitEvent }));
+        }
+        _adjustIndex(t) {
+            return t < 0 ? t + this.length : t;
+        }
+        _syncPendingControls() {
+            let t = this.controls.reduce(
+                (o, e) => (e._syncPendingControls() ? !0 : o),
+                !1
+            );
+            return t && this.updateValueAndValidity({ onlySelf: !0 }), t;
+        }
+        _forEachChild(t) {
+            this.controls.forEach((o, e) => {
+                t(o, e);
+            });
+        }
+        _updateValue() {
+            this.value = this.controls
+                .filter((t) => t.enabled || this.disabled)
+                .map((t) => t.value);
+        }
+        _anyControls(t) {
+            return this.controls.some((o) => o.enabled && t(o));
+        }
+        _setUpControls() {
+            this._forEachChild((t) => this._registerControl(t));
+        }
+        _allControlsDisabled() {
+            for (let t of this.controls) if (t.enabled) return !1;
+            return this.controls.length > 0 || this.disabled;
+        }
+        _registerControl(t) {
+            t.setParent(this),
+                t._registerOnCollectionChange(this._onCollectionChange);
+        }
+        _find(t) {
+            return this.at(t) ?? null;
+        }
+    };
+function Mc(n) {
+    return (
+        !!n &&
+        (n.asyncValidators !== void 0 ||
+            n.validators !== void 0 ||
+            n.updateOn !== void 0)
+    );
+}
+var Xc = (() => {
+    let t = class t {
+        constructor() {
+            this.useNonNullable = !1;
+        }
+        get nonNullable() {
+            let e = new t();
+            return (e.useNonNullable = !0), e;
+        }
+        group(e, i = null) {
+            let r = this._reduceControls(e),
+                s = {};
+            return (
+                Mc(i)
+                    ? (s = i)
+                    : i !== null &&
+                      ((s.validators = i.validator),
+                      (s.asyncValidators = i.asyncValidator)),
+                new So(r, s)
+            );
+        }
+        record(e, i = null) {
+            let r = this._reduceControls(e);
+            return new ks(r, i);
+        }
+        control(e, i, r) {
+            let s = {};
+            return this.useNonNullable
+                ? (Mc(i)
+                      ? (s = i)
+                      : ((s.validators = i), (s.asyncValidators = r)),
+                  new mn(e, q(p({}, s), { nonNullable: !0 })))
+                : new mn(e, i, r);
+        }
+        array(e, i, r) {
+            let s = e.map((a) => this._createControl(a));
+            return new As(s, i, r);
+        }
+        _reduceControls(e) {
+            let i = {};
+            return (
+                Object.keys(e).forEach((r) => {
+                    i[r] = this._createControl(e[r]);
+                }),
+                i
+            );
+        }
+        _createControl(e) {
+            if (e instanceof mn) return e;
+            if (e instanceof fi) return e;
+            if (Array.isArray(e)) {
+                let i = e[0],
+                    r = e.length > 1 ? e[1] : null,
+                    s = e.length > 2 ? e[2] : null;
+                return this.control(i, r, s);
+            } else return this.control(e);
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+var Kc = (() => {
+        let t = class t {
+            static withConfig(e) {
+                return {
+                    ngModule: t,
+                    providers: [
+                        { provide: To, useValue: e.callSetDisabledState ?? Ao },
+                    ],
+                };
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Zc] }));
+        let n = t;
+        return n;
+    })(),
+    Qc = (() => {
+        let t = class t {
+            static withConfig(e) {
+                return {
+                    ngModule: t,
+                    providers: [
+                        {
+                            provide: qc,
+                            useValue:
+                                e.warnOnNgModelWithFormControl ?? "always",
+                        },
+                        { provide: To, useValue: e.callSetDisabledState ?? Ao },
+                    ],
+                };
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Zc] }));
+        let n = t;
+        return n;
+    })();
+var td = (n) => ["/Product-Stores", n];
+function Xf(n, t) {
+    if (
+        (n & 1 &&
+            (x(0, "div", 8)(1, "div", 9)(2, "div")(3, "a", 10),
+            H(4, "img", 11),
+            _()(),
+            x(5, "div")(6, "a", 10),
+            F(7),
+            _()()()()),
+        n & 2)
+    ) {
+        let o = t.$implicit;
+        R(3),
+            L("routerLink", Ni(5, td, o.productID)),
+            R(),
+            Ze("alt", o.productName),
+            L("src", o.productImage, Se),
+            R(2),
+            L("routerLink", Ni(7, td, o.productID)),
+            R(),
+            te(o.productName);
+    }
+}
+function Kf(n, t) {
+    n & 1 &&
+        (x(0, "div", 12)(1, "div", 13),
+        F(
+            2,
+            "No products found matching your search criteria. Please try again."
+        ),
+        _()());
+}
+var ed = (() => {
+    let t = class t {
+        constructor(e) {
+            (this.productService = e),
+                (this.products = []),
+                (this.filteredProducts = []),
+                (this.searchFilter = "");
+        }
+        ngOnInit() {
+            this.getAllProducts();
+        }
+        getAllProducts() {
+            this.productService.getAllProducts().subscribe({
+                next: (e) => {
+                    (this.products = e),
+                        (this.filteredProducts = [...this.products]);
+                },
+                error: (e) => {
+                    console.error("Error fetching products:", e);
+                },
+            });
+        }
+        filterProducts() {
+            this.searchFilter && this.products
+                ? (this.filteredProducts = this.products.filter((e) =>
+                      e.productName
+                          .toLowerCase()
+                          .includes(this.searchFilter.toLowerCase())
+                  ))
+                : (this.filteredProducts = [...this.products]);
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(u(fe));
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["app-home"]],
+            decls: 9,
+            vars: 3,
+            consts: [
+                [1, "container"],
+                [1, "row", "justify-content-center"],
+                [1, "col-sm-8"],
+                [1, "input-group", "search-input-field"],
+                [
+                    "type",
+                    "text",
+                    "placeholder",
+                    "Search Product",
+                    1,
+                    "form-control",
+                    3,
+                    "ngModelChange",
+                    "input",
+                    "ngModel",
+                ],
+                [1, "row", "mt-5"],
+                ["class", "col-sm-3  mb-4", 4, "ngFor", "ngForOf"],
+                ["class", "col-sm-12 text-center", 4, "ngIf"],
+                [1, "col-sm-3", "mb-4"],
+                [1, "products", "text-center"],
+                [3, "routerLink"],
+                [1, "img-fluid", "image-property", 3, "src", "alt"],
+                [1, "col-sm-12", "text-center"],
+                ["id", "noDataMessage", 1, "alert", "alert-info"],
+            ],
+            template: function (i, r) {
+                i & 1 &&
+                    (x(0, "div", 0)(1, "div", 1)(2, "div", 2)(3, "div", 3)(
+                        4,
+                        "input",
+                        4
+                    ),
+                    Qa("ngModelChange", function (a) {
+                        return Ka(r.searchFilter, a) || (r.searchFilter = a), a;
+                    }),
+                    Z("input", function () {
+                        return r.filterProducts();
+                    }),
+                    _()()()()(),
+                    x(5, "div", 0)(6, "div", 5),
+                    ot(7, Xf, 8, 9, "div", 6)(8, Kf, 3, 0, "div", 7),
+                    _()()),
+                    i & 2 &&
+                        (R(4),
+                        Xa("ngModel", r.searchFilter),
+                        R(3),
+                        L("ngForOf", r.filteredProducts),
+                        R(),
+                        L("ngIf", r.filteredProducts.length === 0));
+            },
+            dependencies: [Qe, Ht, ui, pi, Mo, Vs],
+            styles: [
+                ".search-input-field[_ngcontent-%COMP%]{width:800px;margin-top:60px;margin-bottom:50px}.products[_ngcontent-%COMP%]{height:300px;padding:20px;border-radius:5px;font-weight:700;background-color:#f9f9f9;box-shadow:0 0 10px #0000001a;margin-bottom:10px}.image-property[_ngcontent-%COMP%]{height:200px;width:180px;margin-bottom:20px}.products[_ngcontent-%COMP%]:hover{box-shadow:0 0 15px #032cb133;background-color:#e9ebf5}#noDataMessage[_ngcontent-%COMP%]{text-align:center;margin:auto;width:fit-content}",
+            ],
+        }));
+    let n = t;
+    return n;
+})();
+var Qf = new C("cdk-dir-doc", { providedIn: "root", factory: Jf });
+function Jf() {
+    return g(T);
+}
+var tp =
+    /^(ar|ckb|dv|he|iw|fa|nqo|ps|sd|ug|ur|yi|.*[-_](Adlm|Arab|Hebr|Nkoo|Rohg|Thaa))(?!.*[-_](Latn|Cyrl)($|-|_))($|-|_)/i;
+function ep(n) {
+    let t = n?.toLowerCase() || "";
+    return t === "auto" && typeof navigator < "u" && navigator?.language
+        ? tp.test(navigator.language)
+            ? "rtl"
+            : "ltr"
+        : t === "rtl"
+          ? "rtl"
+          : "ltr";
+}
+var gi = (() => {
+    let t = class t {
+        constructor(e) {
+            if (((this.value = "ltr"), (this.change = new it()), e)) {
+                let i = e.body ? e.body.dir : null,
+                    r = e.documentElement ? e.documentElement.dir : null;
+                this.value = ep(i || r || "ltr");
+            }
+        }
+        ngOnDestroy() {
+            this.change.complete();
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(Qf, 8));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+var _e = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({}));
+    let n = t;
+    return n;
+})();
+var Fo = class {};
+function Oo(n) {
+    return n && typeof n.connect == "function" && !(n instanceof Ei);
+}
+var bi = (function (n) {
+        return (
+            (n[(n.REPLACED = 0)] = "REPLACED"),
+            (n[(n.INSERTED = 1)] = "INSERTED"),
+            (n[(n.MOVED = 2)] = "MOVED"),
+            (n[(n.REMOVED = 3)] = "REMOVED"),
+            n
+        );
+    })(bi || {}),
+    fn = new C("_ViewRepeater"),
+    vi = class {
+        applyChanges(t, o, e, i, r) {
+            t.forEachOperation((s, a, l) => {
+                let c, d;
+                if (s.previousIndex == null) {
+                    let h = e(s, a, l);
+                    (c = o.createEmbeddedView(
+                        h.templateRef,
+                        h.context,
+                        h.index
+                    )),
+                        (d = bi.INSERTED);
+                } else
+                    l == null
+                        ? (o.remove(a), (d = bi.REMOVED))
+                        : ((c = o.get(a)), o.move(c, l), (d = bi.MOVED));
+                r && r({ context: c?.context, operation: d, record: s });
+            });
+        }
+        detach() {}
+    };
+var $s;
+try {
+    $s = typeof Intl < "u" && Intl.v8BreakIterator;
+} catch {
+    $s = !1;
+}
+var J = (() => {
+    let t = class t {
+        constructor(e) {
+            (this._platformId = e),
+                (this.isBrowser = this._platformId
+                    ? hl(this._platformId)
+                    : typeof document == "object" && !!document),
+                (this.EDGE =
+                    this.isBrowser && /(edge)/i.test(navigator.userAgent)),
+                (this.TRIDENT =
+                    this.isBrowser &&
+                    /(msie|trident)/i.test(navigator.userAgent)),
+                (this.BLINK =
+                    this.isBrowser &&
+                    !!(window.chrome || $s) &&
+                    typeof CSS < "u" &&
+                    !this.EDGE &&
+                    !this.TRIDENT),
+                (this.WEBKIT =
+                    this.isBrowser &&
+                    /AppleWebKit/i.test(navigator.userAgent) &&
+                    !this.BLINK &&
+                    !this.EDGE &&
+                    !this.TRIDENT),
+                (this.IOS =
+                    this.isBrowser &&
+                    /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+                    !("MSStream" in window)),
+                (this.FIREFOX =
+                    this.isBrowser &&
+                    /(firefox|minefield)/i.test(navigator.userAgent)),
+                (this.ANDROID =
+                    this.isBrowser &&
+                    /android/i.test(navigator.userAgent) &&
+                    !this.TRIDENT),
+                (this.SAFARI =
+                    this.isBrowser &&
+                    /safari/i.test(navigator.userAgent) &&
+                    this.WEBKIT);
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(Qt));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+var pn;
+function ip() {
+    if (pn == null && typeof window < "u")
+        try {
+            window.addEventListener(
+                "test",
+                null,
+                Object.defineProperty({}, "passive", { get: () => (pn = !0) })
+            );
+        } finally {
+            pn = pn || !1;
+        }
+    return pn;
+}
+function ye(n) {
+    return ip() ? n : !!n.capture;
+}
+var Ve;
+function id() {
+    if (Ve == null) {
+        if (
+            typeof document != "object" ||
+            !document ||
+            typeof Element != "function" ||
+            !Element
+        )
+            return (Ve = !1), Ve;
+        if ("scrollBehavior" in document.documentElement.style) Ve = !0;
+        else {
+            let n = Element.prototype.scrollTo;
+            n
+                ? (Ve = !/\{\s*\[native code\]\s*\}/.test(n.toString()))
+                : (Ve = !1);
+        }
+    }
+    return Ve;
+}
+var Hs;
+function np() {
+    if (Hs == null) {
+        let n = typeof document < "u" ? document.head : null;
+        Hs = !!(n && (n.createShadowRoot || n.attachShadow));
+    }
+    return Hs;
+}
+function nd(n) {
+    if (np()) {
+        let t = n.getRootNode ? n.getRootNode() : null;
+        if (typeof ShadowRoot < "u" && ShadowRoot && t instanceof ShadowRoot)
+            return t;
+    }
+    return null;
+}
+function Lt(n) {
+    return n.composedPath ? n.composedPath()[0] : n.target;
+}
+function gn() {
+    return (
+        (typeof __karma__ < "u" && !!__karma__) ||
+        (typeof jasmine < "u" && !!jasmine) ||
+        (typeof jest < "u" && !!jest) ||
+        (typeof Mocha < "u" && !!Mocha)
+    );
+}
+function od(n) {
+    return !isNaN(parseFloat(n)) && !isNaN(Number(n));
+}
+function _i(n) {
+    return Array.isArray(n) ? n : [n];
+}
+function ct(n) {
+    return n == null ? "" : typeof n == "string" ? n : `${n}px`;
+}
+function ie(n) {
+    return n instanceof A ? n.nativeElement : n;
+}
+var rp = 20,
+    sd = (() => {
+        let t = class t {
+            constructor(e, i, r) {
+                (this._ngZone = e),
+                    (this._platform = i),
+                    (this._scrolled = new N()),
+                    (this._globalSubscription = null),
+                    (this._scrolledCount = 0),
+                    (this.scrollContainers = new Map()),
+                    (this._document = r);
+            }
+            register(e) {
+                this.scrollContainers.has(e) ||
+                    this.scrollContainers.set(
+                        e,
+                        e
+                            .elementScrolled()
+                            .subscribe(() => this._scrolled.next(e))
+                    );
+            }
+            deregister(e) {
+                let i = this.scrollContainers.get(e);
+                i && (i.unsubscribe(), this.scrollContainers.delete(e));
+            }
+            scrolled(e = rp) {
+                return this._platform.isBrowser
+                    ? new $e((i) => {
+                          this._globalSubscription || this._addGlobalListener();
+                          let r =
+                              e > 0
+                                  ? this._scrolled.pipe(cr(e)).subscribe(i)
+                                  : this._scrolled.subscribe(i);
+                          return (
+                              this._scrolledCount++,
+                              () => {
+                                  r.unsubscribe(),
+                                      this._scrolledCount--,
+                                      this._scrolledCount ||
+                                          this._removeGlobalListener();
+                              }
+                          );
+                      })
+                    : v();
+            }
+            ngOnDestroy() {
+                this._removeGlobalListener(),
+                    this.scrollContainers.forEach((e, i) => this.deregister(i)),
+                    this._scrolled.complete();
+            }
+            ancestorScrolled(e, i) {
+                let r = this.getAncestorScrollContainers(e);
+                return this.scrolled(i).pipe(
+                    dt((s) => !s || r.indexOf(s) > -1)
+                );
+            }
+            getAncestorScrollContainers(e) {
+                let i = [];
+                return (
+                    this.scrollContainers.forEach((r, s) => {
+                        this._scrollableContainsElement(s, e) && i.push(s);
+                    }),
+                    i
+                );
+            }
+            _getWindow() {
+                return this._document.defaultView || window;
+            }
+            _scrollableContainsElement(e, i) {
+                let r = ie(i),
+                    s = e.getElementRef().nativeElement;
+                do if (r == s) return !0;
+                while ((r = r.parentElement));
+                return !1;
+            }
+            _addGlobalListener() {
+                this._globalSubscription = this._ngZone.runOutsideAngular(
+                    () => {
+                        let e = this._getWindow();
+                        return ka(e.document, "scroll").subscribe(() =>
+                            this._scrolled.next()
+                        );
+                    }
+                );
+            }
+            _removeGlobalListener() {
+                this._globalSubscription &&
+                    (this._globalSubscription.unsubscribe(),
+                    (this._globalSubscription = null));
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(I), m(J), m(T, 8));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+var sp = 20,
+    bn = (() => {
+        let t = class t {
+            constructor(e, i, r) {
+                (this._platform = e),
+                    (this._change = new N()),
+                    (this._changeListener = (s) => {
+                        this._change.next(s);
+                    }),
+                    (this._document = r),
+                    i.runOutsideAngular(() => {
+                        if (e.isBrowser) {
+                            let s = this._getWindow();
+                            s.addEventListener("resize", this._changeListener),
+                                s.addEventListener(
+                                    "orientationchange",
+                                    this._changeListener
+                                );
+                        }
+                        this.change().subscribe(
+                            () => (this._viewportSize = null)
+                        );
+                    });
+            }
+            ngOnDestroy() {
+                if (this._platform.isBrowser) {
+                    let e = this._getWindow();
+                    e.removeEventListener("resize", this._changeListener),
+                        e.removeEventListener(
+                            "orientationchange",
+                            this._changeListener
+                        );
+                }
+                this._change.complete();
+            }
+            getViewportSize() {
+                this._viewportSize || this._updateViewportSize();
+                let e = {
+                    width: this._viewportSize.width,
+                    height: this._viewportSize.height,
+                };
+                return (
+                    this._platform.isBrowser || (this._viewportSize = null), e
+                );
+            }
+            getViewportRect() {
+                let e = this.getViewportScrollPosition(),
+                    { width: i, height: r } = this.getViewportSize();
+                return {
+                    top: e.top,
+                    left: e.left,
+                    bottom: e.top + r,
+                    right: e.left + i,
+                    height: r,
+                    width: i,
+                };
+            }
+            getViewportScrollPosition() {
+                if (!this._platform.isBrowser) return { top: 0, left: 0 };
+                let e = this._document,
+                    i = this._getWindow(),
+                    r = e.documentElement,
+                    s = r.getBoundingClientRect(),
+                    a =
+                        -s.top ||
+                        e.body.scrollTop ||
+                        i.scrollY ||
+                        r.scrollTop ||
+                        0,
+                    l =
+                        -s.left ||
+                        e.body.scrollLeft ||
+                        i.scrollX ||
+                        r.scrollLeft ||
+                        0;
+                return { top: a, left: l };
+            }
+            change(e = sp) {
+                return e > 0 ? this._change.pipe(cr(e)) : this._change;
+            }
+            _getWindow() {
+                return this._document.defaultView || window;
+            }
+            _updateViewportSize() {
+                let e = this._getWindow();
+                this._viewportSize = this._platform.isBrowser
+                    ? { width: e.innerWidth, height: e.innerHeight }
+                    : { width: 0, height: 0 };
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(J), m(I), m(T, 8));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+var No = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({}));
+        let n = t;
+        return n;
+    })(),
+    vn = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [_e, No, _e, No] }));
+        let n = t;
+        return n;
+    })();
+var lp = [[["caption"]], [["colgroup"], ["col"]], "*"],
+    cp = ["caption", "colgroup, col", "*"];
+function dp(n, t) {
+    n & 1 && K(0, 2);
+}
+function up(n, t) {
+    n & 1 &&
+        (x(0, "thead", 0),
+        It(1, 1),
+        _(),
+        x(2, "tbody", 0),
+        It(3, 2)(4, 3),
+        _(),
+        x(5, "tfoot", 0),
+        It(6, 4),
+        _());
+}
+function hp(n, t) {
+    n & 1 && It(0, 1)(1, 2)(2, 3)(3, 4);
+}
+var jt = new C("CDK_TABLE");
+var Bo = (() => {
+        let t = class t {
+            constructor(e) {
+                this.template = e;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkCellDef", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Uo = (() => {
+        let t = class t {
+            constructor(e) {
+                this.template = e;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkHeaderCellDef", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    dd = (() => {
+        let t = class t {
+            constructor(e) {
+                this.template = e;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkFooterCellDef", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    yi = (() => {
+        let t = class t {
+            get name() {
+                return this._name;
+            }
+            set name(e) {
+                this._setNameInput(e);
+            }
+            get sticky() {
+                return this._sticky;
+            }
+            set sticky(e) {
+                e !== this._sticky &&
+                    ((this._sticky = e), (this._hasStickyChanged = !0));
+            }
+            get stickyEnd() {
+                return this._stickyEnd;
+            }
+            set stickyEnd(e) {
+                e !== this._stickyEnd &&
+                    ((this._stickyEnd = e), (this._hasStickyChanged = !0));
+            }
+            constructor(e) {
+                (this._table = e),
+                    (this._hasStickyChanged = !1),
+                    (this._sticky = !1),
+                    (this._stickyEnd = !1);
+            }
+            hasStickyChanged() {
+                let e = this._hasStickyChanged;
+                return this.resetStickyChanged(), e;
+            }
+            resetStickyChanged() {
+                this._hasStickyChanged = !1;
+            }
+            _updateColumnCssClassName() {
+                this._columnCssClassName = [
+                    `cdk-column-${this.cssClassFriendlyName}`,
+                ];
+            }
+            _setNameInput(e) {
+                e &&
+                    ((this._name = e),
+                    (this.cssClassFriendlyName = e.replace(
+                        /[^a-z0-9_-]/gi,
+                        "-"
+                    )),
+                    this._updateColumnCssClassName());
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(jt, 8));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkColumnDef", ""]],
+                contentQueries: function (i, r, s) {
+                    if (
+                        (i & 1 && (gt(s, Bo, 5), gt(s, Uo, 5), gt(s, dd, 5)),
+                        i & 2)
+                    ) {
+                        let a;
+                        at((a = lt())) && (r.cell = a.first),
+                            at((a = lt())) && (r.headerCell = a.first),
+                            at((a = lt())) && (r.footerCell = a.first);
+                    }
+                },
+                inputs: {
+                    name: [y.None, "cdkColumnDef", "name"],
+                    sticky: [
+                        y.HasDecoratorInputTransform,
+                        "sticky",
+                        "sticky",
+                        W,
+                    ],
+                    stickyEnd: [
+                        y.HasDecoratorInputTransform,
+                        "stickyEnd",
+                        "stickyEnd",
+                        W,
+                    ],
+                },
+                standalone: !0,
+                features: [
+                    Q([
+                        {
+                            provide: "MAT_SORT_HEADER_COLUMN_DEF",
+                            useExisting: t,
+                        },
+                    ]),
+                    nt,
+                ],
+            }));
+        let n = t;
+        return n;
+    })(),
+    Lo = class {
+        constructor(t, o) {
+            o.nativeElement.classList.add(...t._columnCssClassName);
+        }
+    },
+    ud = (() => {
+        let t = class t extends Lo {
+            constructor(e, i) {
+                super(e, i);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(yi), u(A));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["cdk-header-cell"], ["th", "cdk-header-cell", ""]],
+                hostAttrs: ["role", "columnheader", 1, "cdk-header-cell"],
+                standalone: !0,
+                features: [U],
+            }));
+        let n = t;
+        return n;
+    })();
+var hd = (() => {
+        let t = class t extends Lo {
+            constructor(e, i) {
+                super(e, i);
+                let r = e._table?._getCellRole();
+                r && i.nativeElement.setAttribute("role", r);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(yi), u(A));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["cdk-cell"], ["td", "cdk-cell", ""]],
+                hostAttrs: [1, "cdk-cell"],
+                standalone: !0,
+                features: [U],
+            }));
+        let n = t;
+        return n;
+    })(),
+    jo = class {
+        constructor() {
+            (this.tasks = []), (this.endTasks = []);
+        }
+    },
+    Vo = new C("_COALESCED_STYLE_SCHEDULER"),
+    Gs = (() => {
+        let t = class t {
+            constructor(e) {
+                (this._ngZone = e),
+                    (this._currentSchedule = null),
+                    (this._destroyed = new N());
+            }
+            schedule(e) {
+                this._createScheduleIfNeeded(),
+                    this._currentSchedule.tasks.push(e);
+            }
+            scheduleEnd(e) {
+                this._createScheduleIfNeeded(),
+                    this._currentSchedule.endTasks.push(e);
+            }
+            ngOnDestroy() {
+                this._destroyed.next(), this._destroyed.complete();
+            }
+            _createScheduleIfNeeded() {
+                this._currentSchedule ||
+                    ((this._currentSchedule = new jo()),
+                    this._getScheduleObservable()
+                        .pipe(mt(this._destroyed))
+                        .subscribe(() => {
+                            for (
+                                ;
+                                this._currentSchedule.tasks.length ||
+                                this._currentSchedule.endTasks.length;
+
+                            ) {
+                                let e = this._currentSchedule;
+                                this._currentSchedule = new jo();
+                                for (let i of e.tasks) i();
+                                for (let i of e.endTasks) i();
+                            }
+                            this._currentSchedule = null;
+                        }));
+            }
+            _getScheduleObservable() {
+                return this._ngZone.isStable
+                    ? ht(Promise.resolve(void 0))
+                    : this._ngZone.onStable.pipe(ut(1));
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(I));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })();
+var Ys = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this.template = e), (this._differs = i);
+            }
+            ngOnChanges(e) {
+                if (!this._columnsDiffer) {
+                    let i = (e.columns && e.columns.currentValue) || [];
+                    (this._columnsDiffer = this._differs.find(i).create()),
+                        this._columnsDiffer.diff(i);
+                }
+            }
+            getColumnsDiff() {
+                return this._columnsDiffer.diff(this.columns);
+            }
+            extractCellTemplate(e) {
+                return this instanceof _n
+                    ? e.headerCell.template
+                    : this instanceof qs
+                      ? e.footerCell.template
+                      : e.cell.template;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct), u(Me));
+        }),
+            (t.ɵdir = D({ type: t, features: [yt] }));
+        let n = t;
+        return n;
+    })(),
+    _n = (() => {
+        let t = class t extends Ys {
+            get sticky() {
+                return this._sticky;
+            }
+            set sticky(e) {
+                e !== this._sticky &&
+                    ((this._sticky = e), (this._hasStickyChanged = !0));
+            }
+            constructor(e, i, r) {
+                super(e, i),
+                    (this._table = r),
+                    (this._hasStickyChanged = !1),
+                    (this._sticky = !1);
+            }
+            ngOnChanges(e) {
+                super.ngOnChanges(e);
+            }
+            hasStickyChanged() {
+                let e = this._hasStickyChanged;
+                return this.resetStickyChanged(), e;
+            }
+            resetStickyChanged() {
+                this._hasStickyChanged = !1;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct), u(Me), u(jt, 8));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkHeaderRowDef", ""]],
+                inputs: {
+                    columns: [y.None, "cdkHeaderRowDef", "columns"],
+                    sticky: [
+                        y.HasDecoratorInputTransform,
+                        "cdkHeaderRowDefSticky",
+                        "sticky",
+                        W,
+                    ],
+                },
+                standalone: !0,
+                features: [nt, U, yt],
+            }));
+        let n = t;
+        return n;
+    })(),
+    qs = (() => {
+        let t = class t extends Ys {
+            get sticky() {
+                return this._sticky;
+            }
+            set sticky(e) {
+                e !== this._sticky &&
+                    ((this._sticky = e), (this._hasStickyChanged = !0));
+            }
+            constructor(e, i, r) {
+                super(e, i),
+                    (this._table = r),
+                    (this._hasStickyChanged = !1),
+                    (this._sticky = !1);
+            }
+            ngOnChanges(e) {
+                super.ngOnChanges(e);
+            }
+            hasStickyChanged() {
+                let e = this._hasStickyChanged;
+                return this.resetStickyChanged(), e;
+            }
+            resetStickyChanged() {
+                this._hasStickyChanged = !1;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct), u(Me), u(jt, 8));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkFooterRowDef", ""]],
+                inputs: {
+                    columns: [y.None, "cdkFooterRowDef", "columns"],
+                    sticky: [
+                        y.HasDecoratorInputTransform,
+                        "cdkFooterRowDefSticky",
+                        "sticky",
+                        W,
+                    ],
+                },
+                standalone: !0,
+                features: [nt, U, yt],
+            }));
+        let n = t;
+        return n;
+    })(),
+    Ho = (() => {
+        let t = class t extends Ys {
+            constructor(e, i, r) {
+                super(e, i), (this._table = r);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct), u(Me), u(jt, 8));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkRowDef", ""]],
+                inputs: {
+                    columns: [y.None, "cdkRowDefColumns", "columns"],
+                    when: [y.None, "cdkRowDefWhen", "when"],
+                },
+                standalone: !0,
+                features: [U],
+            }));
+        let n = t;
+        return n;
+    })(),
+    ze = (() => {
+        let t = class t {
+            constructor(e) {
+                (this._viewContainer = e), (t.mostRecentCellOutlet = this);
+            }
+            ngOnDestroy() {
+                t.mostRecentCellOutlet === this &&
+                    (t.mostRecentCellOutlet = null);
+            }
+        };
+        (t.mostRecentCellOutlet = null),
+            (t.ɵfac = function (i) {
+                return new (i || t)(u(kt));
+            }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "cdkCellOutlet", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Zs = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["cdk-header-row"], ["tr", "cdk-header-row", ""]],
+                hostAttrs: ["role", "row", 1, "cdk-header-row"],
+                standalone: !0,
+                features: [tt],
+                decls: 1,
+                vars: 0,
+                consts: [["cdkCellOutlet", ""]],
+                template: function (i, r) {
+                    i & 1 && It(0, 0);
+                },
+                dependencies: [ze],
+                encapsulation: 2,
+            }));
+        let n = t;
+        return n;
+    })();
+var Xs = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["cdk-row"], ["tr", "cdk-row", ""]],
+                hostAttrs: ["role", "row", 1, "cdk-row"],
+                standalone: !0,
+                features: [tt],
+                decls: 1,
+                vars: 0,
+                consts: [["cdkCellOutlet", ""]],
+                template: function (i, r) {
+                    i & 1 && It(0, 0);
+                },
+                dependencies: [ze],
+                encapsulation: 2,
+            }));
+        let n = t;
+        return n;
+    })(),
+    md = (() => {
+        let t = class t {
+            constructor(e) {
+                (this.templateRef = e),
+                    (this._contentClassName = "cdk-no-data-row");
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(Ct));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["ng-template", "cdkNoDataRow", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    ld = ["top", "bottom", "left", "right"],
+    Ws = class {
+        constructor(t, o, e, i, r = !0, s = !0, a) {
+            (this._isNativeHtmlTable = t),
+                (this._stickCellCss = o),
+                (this.direction = e),
+                (this._coalescedStyleScheduler = i),
+                (this._isBrowser = r),
+                (this._needsPositionStickyOnElement = s),
+                (this._positionListener = a),
+                (this._cachedCellWidths = []),
+                (this._borderCellCss = {
+                    top: `${o}-border-elem-top`,
+                    bottom: `${o}-border-elem-bottom`,
+                    left: `${o}-border-elem-left`,
+                    right: `${o}-border-elem-right`,
+                });
+        }
+        clearStickyPositioning(t, o) {
+            let e = [];
+            for (let i of t)
+                if (i.nodeType === i.ELEMENT_NODE) {
+                    e.push(i);
+                    for (let r = 0; r < i.children.length; r++)
+                        e.push(i.children[r]);
+                }
+            this._coalescedStyleScheduler.schedule(() => {
+                for (let i of e) this._removeStickyStyle(i, o);
+            });
+        }
+        updateStickyColumns(t, o, e, i = !0) {
+            if (
+                !t.length ||
+                !this._isBrowser ||
+                !(o.some((r) => r) || e.some((r) => r))
+            ) {
+                this._positionListener &&
+                    (this._positionListener.stickyColumnsUpdated({ sizes: [] }),
+                    this._positionListener.stickyEndColumnsUpdated({
+                        sizes: [],
+                    }));
+                return;
+            }
+            this._coalescedStyleScheduler.schedule(() => {
+                let r = t[0],
+                    s = r.children.length,
+                    a = this._getCellWidths(r, i),
+                    l = this._getStickyStartColumnPositions(a, o),
+                    c = this._getStickyEndColumnPositions(a, e),
+                    d = o.lastIndexOf(!0),
+                    h = e.indexOf(!0),
+                    f = this.direction === "rtl",
+                    w = f ? "right" : "left",
+                    j = f ? "left" : "right";
+                for (let z of t)
+                    for (let k = 0; k < s; k++) {
+                        let V = z.children[k];
+                        o[k] && this._addStickyStyle(V, w, l[k], k === d),
+                            e[k] && this._addStickyStyle(V, j, c[k], k === h);
+                    }
+                this._positionListener &&
+                    (this._positionListener.stickyColumnsUpdated({
+                        sizes:
+                            d === -1
+                                ? []
+                                : a
+                                      .slice(0, d + 1)
+                                      .map((z, k) => (o[k] ? z : null)),
+                    }),
+                    this._positionListener.stickyEndColumnsUpdated({
+                        sizes:
+                            h === -1
+                                ? []
+                                : a
+                                      .slice(h)
+                                      .map((z, k) => (e[k + h] ? z : null))
+                                      .reverse(),
+                    }));
+            });
+        }
+        stickRows(t, o, e) {
+            this._isBrowser &&
+                this._coalescedStyleScheduler.schedule(() => {
+                    let i = e === "bottom" ? t.slice().reverse() : t,
+                        r = e === "bottom" ? o.slice().reverse() : o,
+                        s = [],
+                        a = [],
+                        l = [];
+                    for (let d = 0, h = 0; d < i.length; d++) {
+                        if (!r[d]) continue;
+                        s[d] = h;
+                        let f = i[d];
+                        l[d] = this._isNativeHtmlTable
+                            ? Array.from(f.children)
+                            : [f];
+                        let w = f.getBoundingClientRect().height;
+                        (h += w), (a[d] = w);
+                    }
+                    let c = r.lastIndexOf(!0);
+                    for (let d = 0; d < i.length; d++) {
+                        if (!r[d]) continue;
+                        let h = s[d],
+                            f = d === c;
+                        for (let w of l[d]) this._addStickyStyle(w, e, h, f);
+                    }
+                    e === "top"
+                        ? this._positionListener?.stickyHeaderRowsUpdated({
+                              sizes: a,
+                              offsets: s,
+                              elements: l,
+                          })
+                        : this._positionListener?.stickyFooterRowsUpdated({
+                              sizes: a,
+                              offsets: s,
+                              elements: l,
+                          });
+                });
+        }
+        updateStickyFooterContainer(t, o) {
+            this._isNativeHtmlTable &&
+                this._coalescedStyleScheduler.schedule(() => {
+                    let e = t.querySelector("tfoot");
+                    e &&
+                        (o.some((i) => !i)
+                            ? this._removeStickyStyle(e, ["bottom"])
+                            : this._addStickyStyle(e, "bottom", 0, !1));
+                });
+        }
+        _removeStickyStyle(t, o) {
+            for (let i of o)
+                (t.style[i] = ""), t.classList.remove(this._borderCellCss[i]);
+            ld.some((i) => o.indexOf(i) === -1 && t.style[i])
+                ? (t.style.zIndex = this._getCalculatedZIndex(t))
+                : ((t.style.zIndex = ""),
+                  this._needsPositionStickyOnElement && (t.style.position = ""),
+                  t.classList.remove(this._stickCellCss));
+        }
+        _addStickyStyle(t, o, e, i) {
+            t.classList.add(this._stickCellCss),
+                i && t.classList.add(this._borderCellCss[o]),
+                (t.style[o] = `${e}px`),
+                (t.style.zIndex = this._getCalculatedZIndex(t)),
+                this._needsPositionStickyOnElement &&
+                    (t.style.cssText +=
+                        "position: -webkit-sticky; position: sticky; ");
+        }
+        _getCalculatedZIndex(t) {
+            let o = { top: 100, bottom: 10, left: 1, right: 1 },
+                e = 0;
+            for (let i of ld) t.style[i] && (e += o[i]);
+            return e ? `${e}` : "";
+        }
+        _getCellWidths(t, o = !0) {
+            if (!o && this._cachedCellWidths.length)
+                return this._cachedCellWidths;
+            let e = [],
+                i = t.children;
+            for (let r = 0; r < i.length; r++) {
+                let s = i[r];
+                e.push(s.getBoundingClientRect().width);
+            }
+            return (this._cachedCellWidths = e), e;
+        }
+        _getStickyStartColumnPositions(t, o) {
+            let e = [],
+                i = 0;
+            for (let r = 0; r < t.length; r++)
+                o[r] && ((e[r] = i), (i += t[r]));
+            return e;
+        }
+        _getStickyEndColumnPositions(t, o) {
+            let e = [],
+                i = 0;
+            for (let r = t.length; r > 0; r--)
+                o[r] && ((e[r] = i), (i += t[r]));
+            return e;
+        }
+    };
+var zo = new C("CDK_SPL");
+var Ks = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this.viewContainer = e), (this.elementRef = i);
+                let r = g(jt);
+                (r._rowOutlet = this), r._outletAssigned();
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(kt), u(A));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "rowOutlet", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Qs = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this.viewContainer = e), (this.elementRef = i);
+                let r = g(jt);
+                (r._headerRowOutlet = this), r._outletAssigned();
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(kt), u(A));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "headerRowOutlet", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Js = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this.viewContainer = e), (this.elementRef = i);
+                let r = g(jt);
+                (r._footerRowOutlet = this), r._outletAssigned();
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(kt), u(A));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "footerRowOutlet", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    ta = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this.viewContainer = e), (this.elementRef = i);
+                let r = g(jt);
+                (r._noDataRowOutlet = this), r._outletAssigned();
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(kt), u(A));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "noDataRowOutlet", ""]],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })();
+var ea = (() => {
+    let t = class t {
+        _getCellRole() {
+            if (this._cellRoleInternal === void 0) {
+                let e = this._elementRef.nativeElement.getAttribute("role"),
+                    i = e === "grid" || e === "treegrid" ? "gridcell" : "cell";
+                this._cellRoleInternal =
+                    this._isNativeHtmlTable && i === "cell" ? null : i;
+            }
+            return this._cellRoleInternal;
+        }
+        get trackBy() {
+            return this._trackByFn;
+        }
+        set trackBy(e) {
+            this._trackByFn = e;
+        }
+        get dataSource() {
+            return this._dataSource;
+        }
+        set dataSource(e) {
+            this._dataSource !== e && this._switchDataSource(e);
+        }
+        get multiTemplateDataRows() {
+            return this._multiTemplateDataRows;
+        }
+        set multiTemplateDataRows(e) {
+            (this._multiTemplateDataRows = e),
+                this._rowOutlet &&
+                    this._rowOutlet.viewContainer.length &&
+                    (this._forceRenderDataRows(),
+                    this.updateStickyColumnStyles());
+        }
+        get fixedLayout() {
+            return this._fixedLayout;
+        }
+        set fixedLayout(e) {
+            (this._fixedLayout = e),
+                (this._forceRecalculateCellWidths = !0),
+                (this._stickyColumnStylesNeedReset = !0);
+        }
+        constructor(e, i, r, s, a, l, c, d, h, f, w, j) {
+            (this._differs = e),
+                (this._changeDetectorRef = i),
+                (this._elementRef = r),
+                (this._dir = a),
+                (this._platform = c),
+                (this._viewRepeater = d),
+                (this._coalescedStyleScheduler = h),
+                (this._viewportRuler = f),
+                (this._stickyPositioningListener = w),
+                (this._ngZone = j),
+                (this._onDestroy = new N()),
+                (this._columnDefsByName = new Map()),
+                (this._customColumnDefs = new Set()),
+                (this._customRowDefs = new Set()),
+                (this._customHeaderRowDefs = new Set()),
+                (this._customFooterRowDefs = new Set()),
+                (this._headerRowDefChanged = !0),
+                (this._footerRowDefChanged = !0),
+                (this._stickyColumnStylesNeedReset = !0),
+                (this._forceRecalculateCellWidths = !0),
+                (this._cachedRenderRowsMap = new Map()),
+                (this.stickyCssClass = "cdk-table-sticky"),
+                (this.needsPositionStickyOnElement = !0),
+                (this._isShowingNoDataRow = !1),
+                (this._hasAllOutlets = !1),
+                (this._hasInitialized = !1),
+                (this._cellRoleInternal = void 0),
+                (this._multiTemplateDataRows = !1),
+                (this._fixedLayout = !1),
+                (this.contentChanged = new it()),
+                (this.viewChange = new rt({ start: 0, end: Number.MAX_VALUE })),
+                s || r.nativeElement.setAttribute("role", "table"),
+                (this._document = l),
+                (this._isServer = !c.isBrowser),
+                (this._isNativeHtmlTable =
+                    r.nativeElement.nodeName === "TABLE");
+        }
+        ngOnInit() {
+            this._setupStickyStyler(),
+                (this._dataDiffer = this._differs
+                    .find([])
+                    .create((e, i) =>
+                        this.trackBy ? this.trackBy(i.dataIndex, i.data) : i
+                    )),
+                this._viewportRuler
+                    .change()
+                    .pipe(mt(this._onDestroy))
+                    .subscribe(() => {
+                        this._forceRecalculateCellWidths = !0;
+                    });
+        }
+        ngAfterContentInit() {
+            this._hasInitialized = !0;
+        }
+        ngAfterContentChecked() {
+            this._canRender() && this._render();
+        }
+        ngOnDestroy() {
+            [
+                this._rowOutlet?.viewContainer,
+                this._headerRowOutlet?.viewContainer,
+                this._footerRowOutlet?.viewContainer,
+                this._cachedRenderRowsMap,
+                this._customColumnDefs,
+                this._customRowDefs,
+                this._customHeaderRowDefs,
+                this._customFooterRowDefs,
+                this._columnDefsByName,
+            ].forEach((e) => {
+                e?.clear();
+            }),
+                (this._headerRowDefs = []),
+                (this._footerRowDefs = []),
+                (this._defaultRowDef = null),
+                this._onDestroy.next(),
+                this._onDestroy.complete(),
+                Oo(this.dataSource) && this.dataSource.disconnect(this);
+        }
+        renderRows() {
+            this._renderRows = this._getAllRenderRows();
+            let e = this._dataDiffer.diff(this._renderRows);
+            if (!e) {
+                this._updateNoDataRow(), this.contentChanged.next();
+                return;
+            }
+            let i = this._rowOutlet.viewContainer;
+            this._viewRepeater.applyChanges(
+                e,
+                i,
+                (r, s, a) => this._getEmbeddedViewArgs(r.item, a),
+                (r) => r.item.data,
+                (r) => {
+                    r.operation === bi.INSERTED &&
+                        r.context &&
+                        this._renderCellTemplateForItem(
+                            r.record.item.rowDef,
+                            r.context
+                        );
+                }
+            ),
+                this._updateRowIndexContext(),
+                e.forEachIdentityChange((r) => {
+                    let s = i.get(r.currentIndex);
+                    s.context.$implicit = r.item.data;
+                }),
+                this._updateNoDataRow(),
+                this._ngZone && I.isInAngularZone()
+                    ? this._ngZone.onStable
+                          .pipe(ut(1), mt(this._onDestroy))
+                          .subscribe(() => {
+                              this.updateStickyColumnStyles();
+                          })
+                    : this.updateStickyColumnStyles(),
+                this.contentChanged.next();
+        }
+        addColumnDef(e) {
+            this._customColumnDefs.add(e);
+        }
+        removeColumnDef(e) {
+            this._customColumnDefs.delete(e);
+        }
+        addRowDef(e) {
+            this._customRowDefs.add(e);
+        }
+        removeRowDef(e) {
+            this._customRowDefs.delete(e);
+        }
+        addHeaderRowDef(e) {
+            this._customHeaderRowDefs.add(e), (this._headerRowDefChanged = !0);
+        }
+        removeHeaderRowDef(e) {
+            this._customHeaderRowDefs.delete(e),
+                (this._headerRowDefChanged = !0);
+        }
+        addFooterRowDef(e) {
+            this._customFooterRowDefs.add(e), (this._footerRowDefChanged = !0);
+        }
+        removeFooterRowDef(e) {
+            this._customFooterRowDefs.delete(e),
+                (this._footerRowDefChanged = !0);
+        }
+        setNoDataRow(e) {
+            this._customNoDataRow = e;
+        }
+        updateStickyHeaderRowStyles() {
+            let e = this._getRenderedRows(this._headerRowOutlet);
+            if (this._isNativeHtmlTable) {
+                let r = cd(this._headerRowOutlet, "thead");
+                r && (r.style.display = e.length ? "" : "none");
+            }
+            let i = this._headerRowDefs.map((r) => r.sticky);
+            this._stickyStyler.clearStickyPositioning(e, ["top"]),
+                this._stickyStyler.stickRows(e, i, "top"),
+                this._headerRowDefs.forEach((r) => r.resetStickyChanged());
+        }
+        updateStickyFooterRowStyles() {
+            let e = this._getRenderedRows(this._footerRowOutlet);
+            if (this._isNativeHtmlTable) {
+                let r = cd(this._footerRowOutlet, "tfoot");
+                r && (r.style.display = e.length ? "" : "none");
+            }
+            let i = this._footerRowDefs.map((r) => r.sticky);
+            this._stickyStyler.clearStickyPositioning(e, ["bottom"]),
+                this._stickyStyler.stickRows(e, i, "bottom"),
+                this._stickyStyler.updateStickyFooterContainer(
+                    this._elementRef.nativeElement,
+                    i
+                ),
+                this._footerRowDefs.forEach((r) => r.resetStickyChanged());
+        }
+        updateStickyColumnStyles() {
+            let e = this._getRenderedRows(this._headerRowOutlet),
+                i = this._getRenderedRows(this._rowOutlet),
+                r = this._getRenderedRows(this._footerRowOutlet);
+            ((this._isNativeHtmlTable && !this._fixedLayout) ||
+                this._stickyColumnStylesNeedReset) &&
+                (this._stickyStyler.clearStickyPositioning(
+                    [...e, ...i, ...r],
+                    ["left", "right"]
+                ),
+                (this._stickyColumnStylesNeedReset = !1)),
+                e.forEach((s, a) => {
+                    this._addStickyColumnStyles([s], this._headerRowDefs[a]);
+                }),
+                this._rowDefs.forEach((s) => {
+                    let a = [];
+                    for (let l = 0; l < i.length; l++)
+                        this._renderRows[l].rowDef === s && a.push(i[l]);
+                    this._addStickyColumnStyles(a, s);
+                }),
+                r.forEach((s, a) => {
+                    this._addStickyColumnStyles([s], this._footerRowDefs[a]);
+                }),
+                Array.from(this._columnDefsByName.values()).forEach((s) =>
+                    s.resetStickyChanged()
+                );
+        }
+        _outletAssigned() {
+            !this._hasAllOutlets &&
+                this._rowOutlet &&
+                this._headerRowOutlet &&
+                this._footerRowOutlet &&
+                this._noDataRowOutlet &&
+                ((this._hasAllOutlets = !0),
+                this._canRender() && this._render());
+        }
+        _canRender() {
+            return this._hasAllOutlets && this._hasInitialized;
+        }
+        _render() {
+            this._cacheRowDefs(),
+                this._cacheColumnDefs(),
+                !this._headerRowDefs.length &&
+                    !this._footerRowDefs.length &&
+                    this._rowDefs.length;
+            let i =
+                this._renderUpdatedColumns() ||
+                this._headerRowDefChanged ||
+                this._footerRowDefChanged;
+            (this._stickyColumnStylesNeedReset =
+                this._stickyColumnStylesNeedReset || i),
+                (this._forceRecalculateCellWidths = i),
+                this._headerRowDefChanged &&
+                    (this._forceRenderHeaderRows(),
+                    (this._headerRowDefChanged = !1)),
+                this._footerRowDefChanged &&
+                    (this._forceRenderFooterRows(),
+                    (this._footerRowDefChanged = !1)),
+                this.dataSource &&
+                this._rowDefs.length > 0 &&
+                !this._renderChangeSubscription
+                    ? this._observeRenderChanges()
+                    : this._stickyColumnStylesNeedReset &&
+                      this.updateStickyColumnStyles(),
+                this._checkStickyStates();
+        }
+        _getAllRenderRows() {
+            let e = [],
+                i = this._cachedRenderRowsMap;
+            this._cachedRenderRowsMap = new Map();
+            for (let r = 0; r < this._data.length; r++) {
+                let s = this._data[r],
+                    a = this._getRenderRowsForData(s, r, i.get(s));
+                this._cachedRenderRowsMap.has(s) ||
+                    this._cachedRenderRowsMap.set(s, new WeakMap());
+                for (let l = 0; l < a.length; l++) {
+                    let c = a[l],
+                        d = this._cachedRenderRowsMap.get(c.data);
+                    d.has(c.rowDef)
+                        ? d.get(c.rowDef).push(c)
+                        : d.set(c.rowDef, [c]),
+                        e.push(c);
+                }
+            }
+            return e;
+        }
+        _getRenderRowsForData(e, i, r) {
+            return this._getRowDefs(e, i).map((a) => {
+                let l = r && r.has(a) ? r.get(a) : [];
+                if (l.length) {
+                    let c = l.shift();
+                    return (c.dataIndex = i), c;
+                } else return { data: e, rowDef: a, dataIndex: i };
+            });
+        }
+        _cacheColumnDefs() {
+            this._columnDefsByName.clear(),
+                Po(
+                    this._getOwnDefs(this._contentColumnDefs),
+                    this._customColumnDefs
+                ).forEach((i) => {
+                    this._columnDefsByName.has(i.name),
+                        this._columnDefsByName.set(i.name, i);
+                });
+        }
+        _cacheRowDefs() {
+            (this._headerRowDefs = Po(
+                this._getOwnDefs(this._contentHeaderRowDefs),
+                this._customHeaderRowDefs
+            )),
+                (this._footerRowDefs = Po(
+                    this._getOwnDefs(this._contentFooterRowDefs),
+                    this._customFooterRowDefs
+                )),
+                (this._rowDefs = Po(
+                    this._getOwnDefs(this._contentRowDefs),
+                    this._customRowDefs
+                ));
+            let e = this._rowDefs.filter((i) => !i.when);
+            !this.multiTemplateDataRows && e.length > 1,
+                (this._defaultRowDef = e[0]);
+        }
+        _renderUpdatedColumns() {
+            let e = (a, l) => a || !!l.getColumnsDiff(),
+                i = this._rowDefs.reduce(e, !1);
+            i && this._forceRenderDataRows();
+            let r = this._headerRowDefs.reduce(e, !1);
+            r && this._forceRenderHeaderRows();
+            let s = this._footerRowDefs.reduce(e, !1);
+            return s && this._forceRenderFooterRows(), i || r || s;
+        }
+        _switchDataSource(e) {
+            (this._data = []),
+                Oo(this.dataSource) && this.dataSource.disconnect(this),
+                this._renderChangeSubscription &&
+                    (this._renderChangeSubscription.unsubscribe(),
+                    (this._renderChangeSubscription = null)),
+                e ||
+                    (this._dataDiffer && this._dataDiffer.diff([]),
+                    this._rowOutlet && this._rowOutlet.viewContainer.clear()),
+                (this._dataSource = e);
+        }
+        _observeRenderChanges() {
+            if (!this.dataSource) return;
+            let e;
+            Oo(this.dataSource)
+                ? (e = this.dataSource.connect(this))
+                : We(this.dataSource)
+                  ? (e = this.dataSource)
+                  : Array.isArray(this.dataSource) && (e = v(this.dataSource)),
+                (this._renderChangeSubscription = e
+                    .pipe(mt(this._onDestroy))
+                    .subscribe((i) => {
+                        (this._data = i || []), this.renderRows();
+                    }));
+        }
+        _forceRenderHeaderRows() {
+            this._headerRowOutlet.viewContainer.length > 0 &&
+                this._headerRowOutlet.viewContainer.clear(),
+                this._headerRowDefs.forEach((e, i) =>
+                    this._renderRow(this._headerRowOutlet, e, i)
+                ),
+                this.updateStickyHeaderRowStyles();
+        }
+        _forceRenderFooterRows() {
+            this._footerRowOutlet.viewContainer.length > 0 &&
+                this._footerRowOutlet.viewContainer.clear(),
+                this._footerRowDefs.forEach((e, i) =>
+                    this._renderRow(this._footerRowOutlet, e, i)
+                ),
+                this.updateStickyFooterRowStyles();
+        }
+        _addStickyColumnStyles(e, i) {
+            let r = Array.from(i.columns || []).map((l) => {
+                    let c = this._columnDefsByName.get(l);
+                    return c;
+                }),
+                s = r.map((l) => l.sticky),
+                a = r.map((l) => l.stickyEnd);
+            this._stickyStyler.updateStickyColumns(
+                e,
+                s,
+                a,
+                !this._fixedLayout || this._forceRecalculateCellWidths
+            );
+        }
+        _getRenderedRows(e) {
+            let i = [];
+            for (let r = 0; r < e.viewContainer.length; r++) {
+                let s = e.viewContainer.get(r);
+                i.push(s.rootNodes[0]);
+            }
+            return i;
+        }
+        _getRowDefs(e, i) {
+            if (this._rowDefs.length == 1) return [this._rowDefs[0]];
+            let r = [];
+            if (this.multiTemplateDataRows)
+                r = this._rowDefs.filter((s) => !s.when || s.when(i, e));
+            else {
+                let s =
+                    this._rowDefs.find((a) => a.when && a.when(i, e)) ||
+                    this._defaultRowDef;
+                s && r.push(s);
+            }
+            return r.length, r;
+        }
+        _getEmbeddedViewArgs(e, i) {
+            let r = e.rowDef,
+                s = { $implicit: e.data };
+            return { templateRef: r.template, context: s, index: i };
+        }
+        _renderRow(e, i, r, s = {}) {
+            let a = e.viewContainer.createEmbeddedView(i.template, s, r);
+            return this._renderCellTemplateForItem(i, s), a;
+        }
+        _renderCellTemplateForItem(e, i) {
+            for (let r of this._getCellTemplates(e))
+                ze.mostRecentCellOutlet &&
+                    ze.mostRecentCellOutlet._viewContainer.createEmbeddedView(
+                        r,
+                        i
+                    );
+            this._changeDetectorRef.markForCheck();
+        }
+        _updateRowIndexContext() {
+            let e = this._rowOutlet.viewContainer;
+            for (let i = 0, r = e.length; i < r; i++) {
+                let a = e.get(i).context;
+                (a.count = r),
+                    (a.first = i === 0),
+                    (a.last = i === r - 1),
+                    (a.even = i % 2 === 0),
+                    (a.odd = !a.even),
+                    this.multiTemplateDataRows
+                        ? ((a.dataIndex = this._renderRows[i].dataIndex),
+                          (a.renderIndex = i))
+                        : (a.index = this._renderRows[i].dataIndex);
+            }
+        }
+        _getCellTemplates(e) {
+            return !e || !e.columns
+                ? []
+                : Array.from(e.columns, (i) => {
+                      let r = this._columnDefsByName.get(i);
+                      return e.extractCellTemplate(r);
+                  });
+        }
+        _forceRenderDataRows() {
+            this._dataDiffer.diff([]),
+                this._rowOutlet.viewContainer.clear(),
+                this.renderRows();
+        }
+        _checkStickyStates() {
+            let e = (i, r) => i || r.hasStickyChanged();
+            this._headerRowDefs.reduce(e, !1) &&
+                this.updateStickyHeaderRowStyles(),
+                this._footerRowDefs.reduce(e, !1) &&
+                    this.updateStickyFooterRowStyles(),
+                Array.from(this._columnDefsByName.values()).reduce(e, !1) &&
+                    ((this._stickyColumnStylesNeedReset = !0),
+                    this.updateStickyColumnStyles());
+        }
+        _setupStickyStyler() {
+            let e = this._dir ? this._dir.value : "ltr";
+            (this._stickyStyler = new Ws(
+                this._isNativeHtmlTable,
+                this.stickyCssClass,
+                e,
+                this._coalescedStyleScheduler,
+                this._platform.isBrowser,
+                this.needsPositionStickyOnElement,
+                this._stickyPositioningListener
+            )),
+                (this._dir ? this._dir.change : v())
+                    .pipe(mt(this._onDestroy))
+                    .subscribe((i) => {
+                        (this._stickyStyler.direction = i),
+                            this.updateStickyColumnStyles();
+                    });
+        }
+        _getOwnDefs(e) {
+            return e.filter((i) => !i._table || i._table === this);
+        }
+        _updateNoDataRow() {
+            let e = this._customNoDataRow || this._noDataRow;
+            if (!e) return;
+            let i = this._rowOutlet.viewContainer.length === 0;
+            if (i === this._isShowingNoDataRow) return;
+            let r = this._noDataRowOutlet.viewContainer;
+            if (i) {
+                let s = r.createEmbeddedView(e.templateRef),
+                    a = s.rootNodes[0];
+                s.rootNodes.length === 1 &&
+                    a?.nodeType === this._document.ELEMENT_NODE &&
+                    (a.setAttribute("role", "row"),
+                    a.classList.add(e._contentClassName));
+            } else r.clear();
+            (this._isShowingNoDataRow = i),
+                this._changeDetectorRef.markForCheck();
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(
+            u(Me),
+            u(Dt),
+            u(A),
+            De("role"),
+            u(gi, 8),
+            u(T),
+            u(J),
+            u(fn),
+            u(Vo),
+            u(bn),
+            u(zo, 12),
+            u(I, 8)
+        );
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["cdk-table"], ["table", "cdk-table", ""]],
+            contentQueries: function (i, r, s) {
+                if (
+                    (i & 1 &&
+                        (gt(s, md, 5),
+                        gt(s, yi, 5),
+                        gt(s, Ho, 5),
+                        gt(s, _n, 5),
+                        gt(s, qs, 5)),
+                    i & 2)
+                ) {
+                    let a;
+                    at((a = lt())) && (r._noDataRow = a.first),
+                        at((a = lt())) && (r._contentColumnDefs = a),
+                        at((a = lt())) && (r._contentRowDefs = a),
+                        at((a = lt())) && (r._contentHeaderRowDefs = a),
+                        at((a = lt())) && (r._contentFooterRowDefs = a);
+                }
+            },
+            hostAttrs: [1, "cdk-table"],
+            hostVars: 2,
+            hostBindings: function (i, r) {
+                i & 2 && st("cdk-table-fixed-layout", r.fixedLayout);
+            },
+            inputs: {
+                trackBy: "trackBy",
+                dataSource: "dataSource",
+                multiTemplateDataRows: [
+                    y.HasDecoratorInputTransform,
+                    "multiTemplateDataRows",
+                    "multiTemplateDataRows",
+                    W,
+                ],
+                fixedLayout: [
+                    y.HasDecoratorInputTransform,
+                    "fixedLayout",
+                    "fixedLayout",
+                    W,
+                ],
+            },
+            outputs: { contentChanged: "contentChanged" },
+            exportAs: ["cdkTable"],
+            standalone: !0,
+            features: [
+                Q([
+                    { provide: jt, useExisting: t },
+                    { provide: fn, useClass: vi },
+                    { provide: Vo, useClass: Gs },
+                    { provide: zo, useValue: null },
+                ]),
+                nt,
+                tt,
+            ],
+            ngContentSelectors: cp,
+            decls: 5,
+            vars: 2,
+            consts: [
+                ["role", "rowgroup"],
+                ["headerRowOutlet", ""],
+                ["rowOutlet", ""],
+                ["noDataRowOutlet", ""],
+                ["footerRowOutlet", ""],
+            ],
+            template: function (i, r) {
+                i & 1 &&
+                    (pt(lp),
+                    K(0),
+                    K(1, 1),
+                    ot(2, dp, 1, 0)(3, up, 7, 0)(4, hp, 4, 0)),
+                    i & 2 &&
+                        (R(2),
+                        Ut(2, r._isServer ? 2 : -1),
+                        R(),
+                        Ut(3, r._isNativeHtmlTable ? 3 : 4));
+            },
+            dependencies: [Qs, Ks, ta, Js],
+            styles: [".cdk-table-fixed-layout{table-layout:fixed}"],
+            encapsulation: 2,
+        }));
+    let n = t;
+    return n;
+})();
+function Po(n, t) {
+    return n.concat(Array.from(t));
+}
+function cd(n, t) {
+    let o = t.toUpperCase(),
+        e = n.viewContainer.element.nativeElement;
+    for (; e; ) {
+        let i = e.nodeType === 1 ? e.nodeName : null;
+        if (i === o) return e;
+        if (i === "TABLE") break;
+        e = e.parentNode;
+    }
+    return null;
+}
+var fd = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({ imports: [vn] }));
+    let n = t;
+    return n;
+})();
+function $o(n, ...t) {
+    return t.length
+        ? t.some((o) => n[o])
+        : n.altKey || n.shiftKey || n.ctrlKey || n.metaKey;
+}
+var mp = (() => {
+    let t = class t {
+        create(e) {
+            return typeof MutationObserver > "u"
+                ? null
+                : new MutationObserver(e);
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+var pd = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({ providers: [mp] }));
+    let n = t;
+    return n;
+})();
+var gd = new Set(),
+    Be,
+    fp = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this._platform = e),
+                    (this._nonce = i),
+                    (this._matchMedia =
+                        this._platform.isBrowser && window.matchMedia
+                            ? window.matchMedia.bind(window)
+                            : gp);
+            }
+            matchMedia(e) {
+                return (
+                    (this._platform.WEBKIT || this._platform.BLINK) &&
+                        pp(e, this._nonce),
+                    this._matchMedia(e)
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(J), m(ki, 8));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+function pp(n, t) {
+    if (!gd.has(n))
+        try {
+            Be ||
+                ((Be = document.createElement("style")),
+                t && Be.setAttribute("nonce", t),
+                Be.setAttribute("type", "text/css"),
+                document.head.appendChild(Be)),
+                Be.sheet &&
+                    (Be.sheet.insertRule(`@media ${n} {body{ }}`, 0),
+                    gd.add(n));
+        } catch (o) {
+            console.error(o);
+        }
+}
+function gp(n) {
+    return {
+        matches: n === "all" || n === "",
+        media: n,
+        addListener: () => {},
+        removeListener: () => {},
+    };
+}
+var vd = (() => {
+    let t = class t {
+        constructor(e, i) {
+            (this._mediaMatcher = e),
+                (this._zone = i),
+                (this._queries = new Map()),
+                (this._destroySubject = new N());
+        }
+        ngOnDestroy() {
+            this._destroySubject.next(), this._destroySubject.complete();
+        }
+        isMatched(e) {
+            return bd(_i(e)).some((r) => this._registerQuery(r).mql.matches);
+        }
+        observe(e) {
+            let r = bd(_i(e)).map((a) => this._registerQuery(a).observable),
+                s = Vt(r);
+            return (
+                (s = kn(s.pipe(ut(1)), s.pipe(Fn(1), An(0)))),
+                s.pipe(
+                    M((a) => {
+                        let l = { matches: !1, breakpoints: {} };
+                        return (
+                            a.forEach(({ matches: c, query: d }) => {
+                                (l.matches = l.matches || c),
+                                    (l.breakpoints[d] = c);
+                            }),
+                            l
+                        );
+                    })
+                )
+            );
+        }
+        _registerQuery(e) {
+            if (this._queries.has(e)) return this._queries.get(e);
+            let i = this._mediaMatcher.matchMedia(e),
+                s = {
+                    observable: new $e((a) => {
+                        let l = (c) => this._zone.run(() => a.next(c));
+                        return (
+                            i.addListener(l),
+                            () => {
+                                i.removeListener(l);
+                            }
+                        );
+                    }).pipe(
+                        Xt(i),
+                        M(({ matches: a }) => ({ query: e, matches: a })),
+                        mt(this._destroySubject)
+                    ),
+                    mql: i,
+                };
+            return this._queries.set(e, s), s;
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(fp), m(I));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+function bd(n) {
+    return n
+        .map((t) => t.split(","))
+        .reduce((t, o) => t.concat(o))
+        .map((t) => t.trim());
+}
+var na = class {
+    constructor(t, o) {
+        (this._items = t),
+            (this._activeItemIndex = -1),
+            (this._activeItem = null),
+            (this._wrap = !1),
+            (this._letterKeyStream = new N()),
+            (this._typeaheadSubscription = St.EMPTY),
+            (this._vertical = !0),
+            (this._allowedModifierKeys = []),
+            (this._homeAndEnd = !1),
+            (this._pageUpAndDown = { enabled: !1, delta: 10 }),
+            (this._skipPredicateFn = (e) => e.disabled),
+            (this._pressedLetters = []),
+            (this.tabOut = new N()),
+            (this.change = new N()),
+            t instanceof Ri
+                ? (this._itemChangesSubscription = t.changes.subscribe((e) =>
+                      this._itemsChanged(e.toArray())
+                  ))
+                : vr(t) &&
+                  (this._effectRef = ol(() => this._itemsChanged(t()), {
+                      injector: o,
+                  }));
+    }
+    skipPredicate(t) {
+        return (this._skipPredicateFn = t), this;
+    }
+    withWrap(t = !0) {
+        return (this._wrap = t), this;
+    }
+    withVerticalOrientation(t = !0) {
+        return (this._vertical = t), this;
+    }
+    withHorizontalOrientation(t) {
+        return (this._horizontal = t), this;
+    }
+    withAllowedModifierKeys(t) {
+        return (this._allowedModifierKeys = t), this;
+    }
+    withTypeAhead(t = 200) {
+        return (
+            this._typeaheadSubscription.unsubscribe(),
+            (this._typeaheadSubscription = this._letterKeyStream
+                .pipe(
+                    et((o) => this._pressedLetters.push(o)),
+                    An(t),
+                    dt(() => this._pressedLetters.length > 0),
+                    M(() => this._pressedLetters.join(""))
+                )
+                .subscribe((o) => {
+                    let e = this._getItemsArray();
+                    for (let i = 1; i < e.length + 1; i++) {
+                        let r = (this._activeItemIndex + i) % e.length,
+                            s = e[r];
+                        if (
+                            !this._skipPredicateFn(s) &&
+                            s.getLabel().toUpperCase().trim().indexOf(o) === 0
+                        ) {
+                            this.setActiveItem(r);
+                            break;
+                        }
+                    }
+                    this._pressedLetters = [];
+                })),
+            this
+        );
+    }
+    cancelTypeahead() {
+        return (this._pressedLetters = []), this;
+    }
+    withHomeAndEnd(t = !0) {
+        return (this._homeAndEnd = t), this;
+    }
+    withPageUpDown(t = !0, o = 10) {
+        return (this._pageUpAndDown = { enabled: t, delta: o }), this;
+    }
+    setActiveItem(t) {
+        let o = this._activeItem;
+        this.updateActiveItem(t),
+            this._activeItem !== o && this.change.next(this._activeItemIndex);
+    }
+    onKeydown(t) {
+        let o = t.keyCode,
+            i = ["altKey", "ctrlKey", "metaKey", "shiftKey"].every(
+                (r) => !t[r] || this._allowedModifierKeys.indexOf(r) > -1
+            );
+        switch (o) {
+            case 9:
+                this.tabOut.next();
+                return;
+            case 40:
+                if (this._vertical && i) {
+                    this.setNextItemActive();
+                    break;
+                } else return;
+            case 38:
+                if (this._vertical && i) {
+                    this.setPreviousItemActive();
+                    break;
+                } else return;
+            case 39:
+                if (this._horizontal && i) {
+                    this._horizontal === "rtl"
+                        ? this.setPreviousItemActive()
+                        : this.setNextItemActive();
+                    break;
+                } else return;
+            case 37:
+                if (this._horizontal && i) {
+                    this._horizontal === "rtl"
+                        ? this.setNextItemActive()
+                        : this.setPreviousItemActive();
+                    break;
+                } else return;
+            case 36:
+                if (this._homeAndEnd && i) {
+                    this.setFirstItemActive();
+                    break;
+                } else return;
+            case 35:
+                if (this._homeAndEnd && i) {
+                    this.setLastItemActive();
+                    break;
+                } else return;
+            case 33:
+                if (this._pageUpAndDown.enabled && i) {
+                    let r = this._activeItemIndex - this._pageUpAndDown.delta;
+                    this._setActiveItemByIndex(r > 0 ? r : 0, 1);
+                    break;
+                } else return;
+            case 34:
+                if (this._pageUpAndDown.enabled && i) {
+                    let r = this._activeItemIndex + this._pageUpAndDown.delta,
+                        s = this._getItemsArray().length;
+                    this._setActiveItemByIndex(r < s ? r : s - 1, -1);
+                    break;
+                } else return;
+            default:
+                (i || $o(t, "shiftKey")) &&
+                    (t.key && t.key.length === 1
+                        ? this._letterKeyStream.next(t.key.toLocaleUpperCase())
+                        : ((o >= 65 && o <= 90) || (o >= 48 && o <= 57)) &&
+                          this._letterKeyStream.next(String.fromCharCode(o)));
+                return;
+        }
+        (this._pressedLetters = []), t.preventDefault();
+    }
+    get activeItemIndex() {
+        return this._activeItemIndex;
+    }
+    get activeItem() {
+        return this._activeItem;
+    }
+    isTyping() {
+        return this._pressedLetters.length > 0;
+    }
+    setFirstItemActive() {
+        this._setActiveItemByIndex(0, 1);
+    }
+    setLastItemActive() {
+        this._setActiveItemByIndex(this._getItemsArray().length - 1, -1);
+    }
+    setNextItemActive() {
+        this._activeItemIndex < 0
+            ? this.setFirstItemActive()
+            : this._setActiveItemByDelta(1);
+    }
+    setPreviousItemActive() {
+        this._activeItemIndex < 0 && this._wrap
+            ? this.setLastItemActive()
+            : this._setActiveItemByDelta(-1);
+    }
+    updateActiveItem(t) {
+        let o = this._getItemsArray(),
+            e = typeof t == "number" ? t : o.indexOf(t),
+            i = o[e];
+        (this._activeItem = i ?? null), (this._activeItemIndex = e);
+    }
+    destroy() {
+        this._typeaheadSubscription.unsubscribe(),
+            this._itemChangesSubscription?.unsubscribe(),
+            this._effectRef?.destroy(),
+            this._letterKeyStream.complete(),
+            this.tabOut.complete(),
+            this.change.complete(),
+            (this._pressedLetters = []);
+    }
+    _setActiveItemByDelta(t) {
+        this._wrap
+            ? this._setActiveInWrapMode(t)
+            : this._setActiveInDefaultMode(t);
+    }
+    _setActiveInWrapMode(t) {
+        let o = this._getItemsArray();
+        for (let e = 1; e <= o.length; e++) {
+            let i = (this._activeItemIndex + t * e + o.length) % o.length,
+                r = o[i];
+            if (!this._skipPredicateFn(r)) {
+                this.setActiveItem(i);
+                return;
+            }
+        }
+    }
+    _setActiveInDefaultMode(t) {
+        this._setActiveItemByIndex(this._activeItemIndex + t, t);
+    }
+    _setActiveItemByIndex(t, o) {
+        let e = this._getItemsArray();
+        if (e[t]) {
+            for (; this._skipPredicateFn(e[t]); ) if (((t += o), !e[t])) return;
+            this.setActiveItem(t);
+        }
+    }
+    _getItemsArray() {
+        return vr(this._items)
+            ? this._items()
+            : this._items instanceof Ri
+              ? this._items.toArray()
+              : this._items;
+    }
+    _itemsChanged(t) {
+        if (this._activeItem) {
+            let o = t.indexOf(this._activeItem);
+            o > -1 &&
+                o !== this._activeItemIndex &&
+                (this._activeItemIndex = o);
+        }
+    }
+};
+var Yo = class extends na {
+    constructor() {
+        super(...arguments), (this._origin = "program");
+    }
+    setFocusOrigin(t) {
+        return (this._origin = t), this;
+    }
+    setActiveItem(t) {
+        super.setActiveItem(t),
+            this.activeItem && this.activeItem.focus(this._origin);
+    }
+};
+function yn(n) {
+    return n.buttons === 0 || n.detail === 0;
+}
+function xn(n) {
+    let t =
+        (n.touches && n.touches[0]) ||
+        (n.changedTouches && n.changedTouches[0]);
+    return (
+        !!t &&
+        t.identifier === -1 &&
+        (t.radiusX == null || t.radiusX === 1) &&
+        (t.radiusY == null || t.radiusY === 1)
+    );
+}
+var Tp = new C("cdk-input-modality-detector-options"),
+    Ap = { ignoreKeys: [18, 17, 224, 91, 16] },
+    xd = 650,
+    xi = ye({ passive: !0, capture: !0 }),
+    Fp = (() => {
+        let t = class t {
+            get mostRecentModality() {
+                return this._modality.value;
+            }
+            constructor(e, i, r, s) {
+                (this._platform = e),
+                    (this._mostRecentTarget = null),
+                    (this._modality = new rt(null)),
+                    (this._lastTouchMs = 0),
+                    (this._onKeydown = (a) => {
+                        this._options?.ignoreKeys?.some(
+                            (l) => l === a.keyCode
+                        ) ||
+                            (this._modality.next("keyboard"),
+                            (this._mostRecentTarget = Lt(a)));
+                    }),
+                    (this._onMousedown = (a) => {
+                        Date.now() - this._lastTouchMs < xd ||
+                            (this._modality.next(yn(a) ? "keyboard" : "mouse"),
+                            (this._mostRecentTarget = Lt(a)));
+                    }),
+                    (this._onTouchstart = (a) => {
+                        if (xn(a)) {
+                            this._modality.next("keyboard");
+                            return;
+                        }
+                        (this._lastTouchMs = Date.now()),
+                            this._modality.next("touch"),
+                            (this._mostRecentTarget = Lt(a));
+                    }),
+                    (this._options = p(p({}, Ap), s)),
+                    (this.modalityDetected = this._modality.pipe(Fn(1))),
+                    (this.modalityChanged = this.modalityDetected.pipe(hr())),
+                    e.isBrowser &&
+                        i.runOutsideAngular(() => {
+                            r.addEventListener("keydown", this._onKeydown, xi),
+                                r.addEventListener(
+                                    "mousedown",
+                                    this._onMousedown,
+                                    xi
+                                ),
+                                r.addEventListener(
+                                    "touchstart",
+                                    this._onTouchstart,
+                                    xi
+                                );
+                        });
+            }
+            ngOnDestroy() {
+                this._modality.complete(),
+                    this._platform.isBrowser &&
+                        (document.removeEventListener(
+                            "keydown",
+                            this._onKeydown,
+                            xi
+                        ),
+                        document.removeEventListener(
+                            "mousedown",
+                            this._onMousedown,
+                            xi
+                        ),
+                        document.removeEventListener(
+                            "touchstart",
+                            this._onTouchstart,
+                            xi
+                        ));
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(J), m(I), m(T), m(Tp, 8));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+var Go = (function (n) {
+        return (
+            (n[(n.IMMEDIATE = 0)] = "IMMEDIATE"),
+            (n[(n.EVENTUAL = 1)] = "EVENTUAL"),
+            n
+        );
+    })(Go || {}),
+    Op = new C("cdk-focus-monitor-default-options"),
+    Wo = ye({ passive: !0, capture: !0 }),
+    wn = (() => {
+        let t = class t {
+            constructor(e, i, r, s, a) {
+                (this._ngZone = e),
+                    (this._platform = i),
+                    (this._inputModalityDetector = r),
+                    (this._origin = null),
+                    (this._windowFocused = !1),
+                    (this._originFromTouchInteraction = !1),
+                    (this._elementInfo = new Map()),
+                    (this._monitoredElementCount = 0),
+                    (this._rootNodeFocusListenerCount = new Map()),
+                    (this._windowFocusListener = () => {
+                        (this._windowFocused = !0),
+                            (this._windowFocusTimeoutId = window.setTimeout(
+                                () => (this._windowFocused = !1)
+                            ));
+                    }),
+                    (this._stopInputModalityDetector = new N()),
+                    (this._rootNodeFocusAndBlurListener = (l) => {
+                        let c = Lt(l);
+                        for (let d = c; d; d = d.parentElement)
+                            l.type === "focus"
+                                ? this._onFocus(l, d)
+                                : this._onBlur(l, d);
+                    }),
+                    (this._document = s),
+                    (this._detectionMode = a?.detectionMode || Go.IMMEDIATE);
+            }
+            monitor(e, i = !1) {
+                let r = ie(e);
+                if (!this._platform.isBrowser || r.nodeType !== 1) return v();
+                let s = nd(r) || this._getDocument(),
+                    a = this._elementInfo.get(r);
+                if (a) return i && (a.checkChildren = !0), a.subject;
+                let l = { checkChildren: i, subject: new N(), rootNode: s };
+                return (
+                    this._elementInfo.set(r, l),
+                    this._registerGlobalListeners(l),
+                    l.subject
+                );
+            }
+            stopMonitoring(e) {
+                let i = ie(e),
+                    r = this._elementInfo.get(i);
+                r &&
+                    (r.subject.complete(),
+                    this._setClasses(i),
+                    this._elementInfo.delete(i),
+                    this._removeGlobalListeners(r));
+            }
+            focusVia(e, i, r) {
+                let s = ie(e),
+                    a = this._getDocument().activeElement;
+                s === a
+                    ? this._getClosestElementsInfo(s).forEach(([l, c]) =>
+                          this._originChanged(l, i, c)
+                      )
+                    : (this._setOrigin(i),
+                      typeof s.focus == "function" && s.focus(r));
+            }
+            ngOnDestroy() {
+                this._elementInfo.forEach((e, i) => this.stopMonitoring(i));
+            }
+            _getDocument() {
+                return this._document || document;
+            }
+            _getWindow() {
+                return this._getDocument().defaultView || window;
+            }
+            _getFocusOrigin(e) {
+                return this._origin
+                    ? this._originFromTouchInteraction
+                        ? this._shouldBeAttributedToTouch(e)
+                            ? "touch"
+                            : "program"
+                        : this._origin
+                    : this._windowFocused && this._lastFocusOrigin
+                      ? this._lastFocusOrigin
+                      : e && this._isLastInteractionFromInputLabel(e)
+                        ? "mouse"
+                        : "program";
+            }
+            _shouldBeAttributedToTouch(e) {
+                return (
+                    this._detectionMode === Go.EVENTUAL ||
+                    !!e?.contains(this._inputModalityDetector._mostRecentTarget)
+                );
+            }
+            _setClasses(e, i) {
+                e.classList.toggle("cdk-focused", !!i),
+                    e.classList.toggle("cdk-touch-focused", i === "touch"),
+                    e.classList.toggle(
+                        "cdk-keyboard-focused",
+                        i === "keyboard"
+                    ),
+                    e.classList.toggle("cdk-mouse-focused", i === "mouse"),
+                    e.classList.toggle("cdk-program-focused", i === "program");
+            }
+            _setOrigin(e, i = !1) {
+                this._ngZone.runOutsideAngular(() => {
+                    if (
+                        ((this._origin = e),
+                        (this._originFromTouchInteraction = e === "touch" && i),
+                        this._detectionMode === Go.IMMEDIATE)
+                    ) {
+                        clearTimeout(this._originTimeoutId);
+                        let r = this._originFromTouchInteraction ? xd : 1;
+                        this._originTimeoutId = setTimeout(
+                            () => (this._origin = null),
+                            r
+                        );
+                    }
+                });
+            }
+            _onFocus(e, i) {
+                let r = this._elementInfo.get(i),
+                    s = Lt(e);
+                !r ||
+                    (!r.checkChildren && i !== s) ||
+                    this._originChanged(i, this._getFocusOrigin(s), r);
+            }
+            _onBlur(e, i) {
+                let r = this._elementInfo.get(i);
+                !r ||
+                    (r.checkChildren &&
+                        e.relatedTarget instanceof Node &&
+                        i.contains(e.relatedTarget)) ||
+                    (this._setClasses(i), this._emitOrigin(r, null));
+            }
+            _emitOrigin(e, i) {
+                e.subject.observers.length &&
+                    this._ngZone.run(() => e.subject.next(i));
+            }
+            _registerGlobalListeners(e) {
+                if (!this._platform.isBrowser) return;
+                let i = e.rootNode,
+                    r = this._rootNodeFocusListenerCount.get(i) || 0;
+                r ||
+                    this._ngZone.runOutsideAngular(() => {
+                        i.addEventListener(
+                            "focus",
+                            this._rootNodeFocusAndBlurListener,
+                            Wo
+                        ),
+                            i.addEventListener(
+                                "blur",
+                                this._rootNodeFocusAndBlurListener,
+                                Wo
+                            );
+                    }),
+                    this._rootNodeFocusListenerCount.set(i, r + 1),
+                    ++this._monitoredElementCount === 1 &&
+                        (this._ngZone.runOutsideAngular(() => {
+                            this._getWindow().addEventListener(
+                                "focus",
+                                this._windowFocusListener
+                            );
+                        }),
+                        this._inputModalityDetector.modalityDetected
+                            .pipe(mt(this._stopInputModalityDetector))
+                            .subscribe((s) => {
+                                this._setOrigin(s, !0);
+                            }));
+            }
+            _removeGlobalListeners(e) {
+                let i = e.rootNode;
+                if (this._rootNodeFocusListenerCount.has(i)) {
+                    let r = this._rootNodeFocusListenerCount.get(i);
+                    r > 1
+                        ? this._rootNodeFocusListenerCount.set(i, r - 1)
+                        : (i.removeEventListener(
+                              "focus",
+                              this._rootNodeFocusAndBlurListener,
+                              Wo
+                          ),
+                          i.removeEventListener(
+                              "blur",
+                              this._rootNodeFocusAndBlurListener,
+                              Wo
+                          ),
+                          this._rootNodeFocusListenerCount.delete(i));
+                }
+                --this._monitoredElementCount ||
+                    (this._getWindow().removeEventListener(
+                        "focus",
+                        this._windowFocusListener
+                    ),
+                    this._stopInputModalityDetector.next(),
+                    clearTimeout(this._windowFocusTimeoutId),
+                    clearTimeout(this._originTimeoutId));
+            }
+            _originChanged(e, i, r) {
+                this._setClasses(e, i),
+                    this._emitOrigin(r, i),
+                    (this._lastFocusOrigin = i);
+            }
+            _getClosestElementsInfo(e) {
+                let i = [];
+                return (
+                    this._elementInfo.forEach((r, s) => {
+                        (s === e || (r.checkChildren && s.contains(e))) &&
+                            i.push([s, r]);
+                    }),
+                    i
+                );
+            }
+            _isLastInteractionFromInputLabel(e) {
+                let { _mostRecentTarget: i, mostRecentModality: r } =
+                    this._inputModalityDetector;
+                if (
+                    r !== "mouse" ||
+                    !i ||
+                    i === e ||
+                    (e.nodeName !== "INPUT" && e.nodeName !== "TEXTAREA") ||
+                    e.disabled
+                )
+                    return !1;
+                let s = e.labels;
+                if (s) {
+                    for (let a = 0; a < s.length; a++)
+                        if (s[a].contains(i)) return !0;
+                }
+                return !1;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(I), m(J), m(Fp), m(T, 8), m(Op, 8));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+var Ue = (function (n) {
+        return (
+            (n[(n.NONE = 0)] = "NONE"),
+            (n[(n.BLACK_ON_WHITE = 1)] = "BLACK_ON_WHITE"),
+            (n[(n.WHITE_ON_BLACK = 2)] = "WHITE_ON_BLACK"),
+            n
+        );
+    })(Ue || {}),
+    _d = "cdk-high-contrast-black-on-white",
+    yd = "cdk-high-contrast-white-on-black",
+    ia = "cdk-high-contrast-active",
+    wd = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this._platform = e),
+                    (this._document = i),
+                    (this._breakpointSubscription = g(vd)
+                        .observe("(forced-colors: active)")
+                        .subscribe(() => {
+                            this._hasCheckedHighContrastMode &&
+                                ((this._hasCheckedHighContrastMode = !1),
+                                this._applyBodyHighContrastModeCssClasses());
+                        }));
+            }
+            getHighContrastMode() {
+                if (!this._platform.isBrowser) return Ue.NONE;
+                let e = this._document.createElement("div");
+                (e.style.backgroundColor = "rgb(1,2,3)"),
+                    (e.style.position = "absolute"),
+                    this._document.body.appendChild(e);
+                let i = this._document.defaultView || window,
+                    r = i && i.getComputedStyle ? i.getComputedStyle(e) : null,
+                    s = ((r && r.backgroundColor) || "").replace(/ /g, "");
+                switch ((e.remove(), s)) {
+                    case "rgb(0,0,0)":
+                    case "rgb(45,50,54)":
+                    case "rgb(32,32,32)":
+                        return Ue.WHITE_ON_BLACK;
+                    case "rgb(255,255,255)":
+                    case "rgb(255,250,239)":
+                        return Ue.BLACK_ON_WHITE;
+                }
+                return Ue.NONE;
+            }
+            ngOnDestroy() {
+                this._breakpointSubscription.unsubscribe();
+            }
+            _applyBodyHighContrastModeCssClasses() {
+                if (
+                    !this._hasCheckedHighContrastMode &&
+                    this._platform.isBrowser &&
+                    this._document.body
+                ) {
+                    let e = this._document.body.classList;
+                    e.remove(ia, _d, yd),
+                        (this._hasCheckedHighContrastMode = !0);
+                    let i = this.getHighContrastMode();
+                    i === Ue.BLACK_ON_WHITE
+                        ? e.add(ia, _d)
+                        : i === Ue.WHITE_ON_BLACK && e.add(ia, yd);
+                }
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(J), m(T));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+function Np() {
+    return !0;
+}
+var Pp = new C("mat-sanity-checks", { providedIn: "root", factory: Np }),
+    Y = (() => {
+        let t = class t {
+            constructor(e, i, r) {
+                (this._sanityChecks = i),
+                    (this._document = r),
+                    (this._hasDoneGlobalChecks = !1),
+                    e._applyBodyHighContrastModeCssClasses(),
+                    this._hasDoneGlobalChecks ||
+                        (this._hasDoneGlobalChecks = !0);
+            }
+            _checkIsEnabled(e) {
+                return gn()
+                    ? !1
+                    : typeof this._sanityChecks == "boolean"
+                      ? this._sanityChecks
+                      : !!this._sanityChecks[e];
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(wd), m(Pp, 8), m(T));
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [_e, _e] }));
+        let n = t;
+        return n;
+    })();
+var ua = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Y, Y] }));
+        let n = t;
+        return n;
+    })(),
+    Nt = (function (n) {
+        return (
+            (n[(n.FADING_IN = 0)] = "FADING_IN"),
+            (n[(n.VISIBLE = 1)] = "VISIBLE"),
+            (n[(n.FADING_OUT = 2)] = "FADING_OUT"),
+            (n[(n.HIDDEN = 3)] = "HIDDEN"),
+            n
+        );
+    })(Nt || {}),
+    la = class {
+        constructor(t, o, e, i = !1) {
+            (this._renderer = t),
+                (this.element = o),
+                (this.config = e),
+                (this._animationForciblyDisabledThroughCss = i),
+                (this.state = Nt.HIDDEN);
+        }
+        fadeOut() {
+            this._renderer.fadeOutRipple(this);
+        }
+    },
+    Dd = ye({ passive: !0, capture: !0 }),
+    ca = class {
+        constructor() {
+            (this._events = new Map()),
+                (this._delegateEventHandler = (t) => {
+                    let o = Lt(t);
+                    o &&
+                        this._events.get(t.type)?.forEach((e, i) => {
+                            (i === o || i.contains(o)) &&
+                                e.forEach((r) => r.handleEvent(t));
+                        });
+                });
+        }
+        addHandler(t, o, e, i) {
+            let r = this._events.get(o);
+            if (r) {
+                let s = r.get(e);
+                s ? s.add(i) : r.set(e, new Set([i]));
+            } else
+                this._events.set(o, new Map([[e, new Set([i])]])),
+                    t.runOutsideAngular(() => {
+                        document.addEventListener(
+                            o,
+                            this._delegateEventHandler,
+                            Dd
+                        );
+                    });
+        }
+        removeHandler(t, o, e) {
+            let i = this._events.get(t);
+            if (!i) return;
+            let r = i.get(o);
+            r &&
+                (r.delete(e),
+                r.size === 0 && i.delete(o),
+                i.size === 0 &&
+                    (this._events.delete(t),
+                    document.removeEventListener(
+                        t,
+                        this._delegateEventHandler,
+                        Dd
+                    )));
+        }
+    },
+    Ed = { enterDuration: 225, exitDuration: 150 },
+    Lp = 800,
+    Sd = ye({ passive: !0, capture: !0 }),
+    Id = ["mousedown", "touchstart"],
+    Rd = ["mouseup", "mouseleave", "touchend", "touchcancel"],
+    Cn = class Cn {
+        constructor(t, o, e, i) {
+            (this._target = t),
+                (this._ngZone = o),
+                (this._platform = i),
+                (this._isPointerDown = !1),
+                (this._activeRipples = new Map()),
+                (this._pointerUpEventsRegistered = !1),
+                i.isBrowser && (this._containerElement = ie(e));
+        }
+        fadeInRipple(t, o, e = {}) {
+            let i = (this._containerRect =
+                    this._containerRect ||
+                    this._containerElement.getBoundingClientRect()),
+                r = p(p({}, Ed), e.animation);
+            e.centered &&
+                ((t = i.left + i.width / 2), (o = i.top + i.height / 2));
+            let s = e.radius || jp(t, o, i),
+                a = t - i.left,
+                l = o - i.top,
+                c = r.enterDuration,
+                d = document.createElement("div");
+            d.classList.add("mat-ripple-element"),
+                (d.style.left = `${a - s}px`),
+                (d.style.top = `${l - s}px`),
+                (d.style.height = `${s * 2}px`),
+                (d.style.width = `${s * 2}px`),
+                e.color != null && (d.style.backgroundColor = e.color),
+                (d.style.transitionDuration = `${c}ms`),
+                this._containerElement.appendChild(d);
+            let h = window.getComputedStyle(d),
+                f = h.transitionProperty,
+                w = h.transitionDuration,
+                j =
+                    f === "none" ||
+                    w === "0s" ||
+                    w === "0s, 0s" ||
+                    (i.width === 0 && i.height === 0),
+                z = new la(this, d, e, j);
+            (d.style.transform = "scale3d(1, 1, 1)"),
+                (z.state = Nt.FADING_IN),
+                e.persistent || (this._mostRecentTransientRipple = z);
+            let k = null;
+            return (
+                !j &&
+                    (c || r.exitDuration) &&
+                    this._ngZone.runOutsideAngular(() => {
+                        let V = () => this._finishRippleTransition(z),
+                            Pt = () => this._destroyRipple(z);
+                        d.addEventListener("transitionend", V),
+                            d.addEventListener("transitioncancel", Pt),
+                            (k = {
+                                onTransitionEnd: V,
+                                onTransitionCancel: Pt,
+                            });
+                    }),
+                this._activeRipples.set(z, k),
+                (j || !c) && this._finishRippleTransition(z),
+                z
+            );
+        }
+        fadeOutRipple(t) {
+            if (t.state === Nt.FADING_OUT || t.state === Nt.HIDDEN) return;
+            let o = t.element,
+                e = p(p({}, Ed), t.config.animation);
+            (o.style.transitionDuration = `${e.exitDuration}ms`),
+                (o.style.opacity = "0"),
+                (t.state = Nt.FADING_OUT),
+                (t._animationForciblyDisabledThroughCss || !e.exitDuration) &&
+                    this._finishRippleTransition(t);
+        }
+        fadeOutAll() {
+            this._getActiveRipples().forEach((t) => t.fadeOut());
+        }
+        fadeOutAllNonPersistent() {
+            this._getActiveRipples().forEach((t) => {
+                t.config.persistent || t.fadeOut();
+            });
+        }
+        setupTriggerEvents(t) {
+            let o = ie(t);
+            !this._platform.isBrowser ||
+                !o ||
+                o === this._triggerElement ||
+                (this._removeTriggerEvents(),
+                (this._triggerElement = o),
+                Id.forEach((e) => {
+                    Cn._eventManager.addHandler(this._ngZone, e, o, this);
+                }));
+        }
+        handleEvent(t) {
+            t.type === "mousedown"
+                ? this._onMousedown(t)
+                : t.type === "touchstart"
+                  ? this._onTouchStart(t)
+                  : this._onPointerUp(),
+                this._pointerUpEventsRegistered ||
+                    (this._ngZone.runOutsideAngular(() => {
+                        Rd.forEach((o) => {
+                            this._triggerElement.addEventListener(o, this, Sd);
+                        });
+                    }),
+                    (this._pointerUpEventsRegistered = !0));
+        }
+        _finishRippleTransition(t) {
+            t.state === Nt.FADING_IN
+                ? this._startFadeOutTransition(t)
+                : t.state === Nt.FADING_OUT && this._destroyRipple(t);
+        }
+        _startFadeOutTransition(t) {
+            let o = t === this._mostRecentTransientRipple,
+                { persistent: e } = t.config;
+            (t.state = Nt.VISIBLE),
+                !e && (!o || !this._isPointerDown) && t.fadeOut();
+        }
+        _destroyRipple(t) {
+            let o = this._activeRipples.get(t) ?? null;
+            this._activeRipples.delete(t),
+                this._activeRipples.size || (this._containerRect = null),
+                t === this._mostRecentTransientRipple &&
+                    (this._mostRecentTransientRipple = null),
+                (t.state = Nt.HIDDEN),
+                o !== null &&
+                    (t.element.removeEventListener(
+                        "transitionend",
+                        o.onTransitionEnd
+                    ),
+                    t.element.removeEventListener(
+                        "transitioncancel",
+                        o.onTransitionCancel
+                    )),
+                t.element.remove();
+        }
+        _onMousedown(t) {
+            let o = yn(t),
+                e =
+                    this._lastTouchStartEvent &&
+                    Date.now() < this._lastTouchStartEvent + Lp;
+            !this._target.rippleDisabled &&
+                !o &&
+                !e &&
+                ((this._isPointerDown = !0),
+                this.fadeInRipple(
+                    t.clientX,
+                    t.clientY,
+                    this._target.rippleConfig
+                ));
+        }
+        _onTouchStart(t) {
+            if (!this._target.rippleDisabled && !xn(t)) {
+                (this._lastTouchStartEvent = Date.now()),
+                    (this._isPointerDown = !0);
+                let o = t.changedTouches;
+                if (o)
+                    for (let e = 0; e < o.length; e++)
+                        this.fadeInRipple(
+                            o[e].clientX,
+                            o[e].clientY,
+                            this._target.rippleConfig
+                        );
+            }
+        }
+        _onPointerUp() {
+            this._isPointerDown &&
+                ((this._isPointerDown = !1),
+                this._getActiveRipples().forEach((t) => {
+                    let o =
+                        t.state === Nt.VISIBLE ||
+                        (t.config.terminateOnPointerUp &&
+                            t.state === Nt.FADING_IN);
+                    !t.config.persistent && o && t.fadeOut();
+                }));
+        }
+        _getActiveRipples() {
+            return Array.from(this._activeRipples.keys());
+        }
+        _removeTriggerEvents() {
+            let t = this._triggerElement;
+            t &&
+                (Id.forEach((o) => Cn._eventManager.removeHandler(o, t, this)),
+                this._pointerUpEventsRegistered &&
+                    (Rd.forEach((o) => t.removeEventListener(o, this, Sd)),
+                    (this._pointerUpEventsRegistered = !1)));
+        }
+    };
+Cn._eventManager = new ca();
+var da = Cn;
+function jp(n, t, o) {
+    let e = Math.max(Math.abs(n - o.left), Math.abs(n - o.right)),
+        i = Math.max(Math.abs(t - o.top), Math.abs(t - o.bottom));
+    return Math.sqrt(e * e + i * i);
+}
+var Fd = new C("mat-ripple-global-options"),
+    ha = (() => {
+        let t = class t {
+            get disabled() {
+                return this._disabled;
+            }
+            set disabled(e) {
+                e && this.fadeOutAllNonPersistent(),
+                    (this._disabled = e),
+                    this._setupTriggerEventsIfEnabled();
+            }
+            get trigger() {
+                return this._trigger || this._elementRef.nativeElement;
+            }
+            set trigger(e) {
+                (this._trigger = e), this._setupTriggerEventsIfEnabled();
+            }
+            constructor(e, i, r, s, a) {
+                (this._elementRef = e),
+                    (this._animationMode = a),
+                    (this.radius = 0),
+                    (this._disabled = !1),
+                    (this._isInitialized = !1),
+                    (this._globalOptions = s || {}),
+                    (this._rippleRenderer = new da(this, i, e, r));
+            }
+            ngOnInit() {
+                (this._isInitialized = !0), this._setupTriggerEventsIfEnabled();
+            }
+            ngOnDestroy() {
+                this._rippleRenderer._removeTriggerEvents();
+            }
+            fadeOutAll() {
+                this._rippleRenderer.fadeOutAll();
+            }
+            fadeOutAllNonPersistent() {
+                this._rippleRenderer.fadeOutAllNonPersistent();
+            }
+            get rippleConfig() {
+                return {
+                    centered: this.centered,
+                    radius: this.radius,
+                    color: this.color,
+                    animation: p(
+                        p(
+                            p({}, this._globalOptions.animation),
+                            this._animationMode === "NoopAnimations"
+                                ? { enterDuration: 0, exitDuration: 0 }
+                                : {}
+                        ),
+                        this.animation
+                    ),
+                    terminateOnPointerUp:
+                        this._globalOptions.terminateOnPointerUp,
+                };
+            }
+            get rippleDisabled() {
+                return this.disabled || !!this._globalOptions.disabled;
+            }
+            _setupTriggerEventsIfEnabled() {
+                !this.disabled &&
+                    this._isInitialized &&
+                    this._rippleRenderer.setupTriggerEvents(this.trigger);
+            }
+            launch(e, i = 0, r) {
+                return typeof e == "number"
+                    ? this._rippleRenderer.fadeInRipple(
+                          e,
+                          i,
+                          p(p({}, this.rippleConfig), r)
+                      )
+                    : this._rippleRenderer.fadeInRipple(
+                          0,
+                          0,
+                          p(p({}, this.rippleConfig), e)
+                      );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(A), u(I), u(J), u(Fd, 8), u(Bt, 8));
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [
+                    ["", "mat-ripple", ""],
+                    ["", "matRipple", ""],
+                ],
+                hostAttrs: [1, "mat-ripple"],
+                hostVars: 2,
+                hostBindings: function (i, r) {
+                    i & 2 && st("mat-ripple-unbounded", r.unbounded);
+                },
+                inputs: {
+                    color: [y.None, "matRippleColor", "color"],
+                    unbounded: [y.None, "matRippleUnbounded", "unbounded"],
+                    centered: [y.None, "matRippleCentered", "centered"],
+                    radius: [y.None, "matRippleRadius", "radius"],
+                    animation: [y.None, "matRippleAnimation", "animation"],
+                    disabled: [y.None, "matRippleDisabled", "disabled"],
+                    trigger: [y.None, "matRippleTrigger", "trigger"],
+                },
+                exportAs: ["matRipple"],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Ko = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Y, Y] }));
+        let n = t;
+        return n;
+    })();
+var Md = { capture: !0 },
+    kd = ["focus", "click", "mouseenter", "touchstart"],
+    sa = "mat-ripple-loader-uninitialized",
+    aa = "mat-ripple-loader-class-name",
+    Td = "mat-ripple-loader-centered",
+    Xo = "mat-ripple-loader-disabled",
+    Od = (() => {
+        let t = class t {
+            constructor() {
+                (this._document = g(T, { optional: !0 })),
+                    (this._animationMode = g(Bt, { optional: !0 })),
+                    (this._globalRippleOptions = g(Fd, { optional: !0 })),
+                    (this._platform = g(J)),
+                    (this._ngZone = g(I)),
+                    (this._hosts = new Map()),
+                    (this._onInteraction = (e) => {
+                        if (!(e.target instanceof HTMLElement)) return;
+                        let r = e.target.closest(`[${sa}]`);
+                        r && this._createRipple(r);
+                    }),
+                    this._ngZone.runOutsideAngular(() => {
+                        for (let e of kd)
+                            this._document?.addEventListener(
+                                e,
+                                this._onInteraction,
+                                Md
+                            );
+                    });
+            }
+            ngOnDestroy() {
+                let e = this._hosts.keys();
+                for (let i of e) this.destroyRipple(i);
+                for (let i of kd)
+                    this._document?.removeEventListener(
+                        i,
+                        this._onInteraction,
+                        Md
+                    );
+            }
+            configureRipple(e, i) {
+                e.setAttribute(sa, ""),
+                    (i.className || !e.hasAttribute(aa)) &&
+                        e.setAttribute(aa, i.className || ""),
+                    i.centered && e.setAttribute(Td, ""),
+                    i.disabled && e.setAttribute(Xo, "");
+            }
+            getRipple(e) {
+                return this._hosts.get(e) || this._createRipple(e);
+            }
+            setDisabled(e, i) {
+                let r = this._hosts.get(e);
+                if (r) {
+                    r.disabled = i;
+                    return;
+                }
+                i ? e.setAttribute(Xo, "") : e.removeAttribute(Xo);
+            }
+            _createRipple(e) {
+                if (!this._document) return;
+                let i = this._hosts.get(e);
+                if (i) return i;
+                e.querySelector(".mat-ripple")?.remove();
+                let r = this._document.createElement("span");
+                r.classList.add("mat-ripple", e.getAttribute(aa)), e.append(r);
+                let s = new ha(
+                    new A(r),
+                    this._ngZone,
+                    this._platform,
+                    this._globalRippleOptions
+                        ? this._globalRippleOptions
+                        : void 0,
+                    this._animationMode ? this._animationMode : void 0
+                );
+                return (
+                    (s._isInitialized = !0),
+                    (s.trigger = e),
+                    (s.centered = e.hasAttribute(Td)),
+                    (s.disabled = e.hasAttribute(Xo)),
+                    this.attachRipple(e, s),
+                    s
+                );
+            }
+            attachRipple(e, i) {
+                e.removeAttribute(sa), this._hosts.set(e, i);
+            }
+            destroyRipple(e) {
+                let i = this._hosts.get(e);
+                i && (i.ngOnDestroy(), this._hosts.delete(e));
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+var Vp = [[["caption"]], [["colgroup"], ["col"]], "*"],
+    zp = ["caption", "colgroup, col", "*"];
+function Bp(n, t) {
+    n & 1 && K(0, 2);
+}
+function Up(n, t) {
+    n & 1 &&
+        (x(0, "thead", 0),
+        It(1, 1),
+        _(),
+        x(2, "tbody", 2),
+        It(3, 3)(4, 4),
+        _(),
+        x(5, "tfoot", 0),
+        It(6, 5),
+        _());
+}
+function Hp(n, t) {
+    n & 1 && It(0, 1)(1, 3)(2, 4)(3, 5);
+}
+var Nd = (() => {
+        let t = class t extends ea {
+            constructor() {
+                super(...arguments),
+                    (this.stickyCssClass = "mat-mdc-table-sticky"),
+                    (this.needsPositionStickyOnElement = !1);
+            }
+        };
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["mat-table"], ["table", "mat-table", ""]],
+                hostAttrs: [1, "mat-mdc-table", "mdc-data-table__table"],
+                hostVars: 2,
+                hostBindings: function (i, r) {
+                    i & 2 && st("mdc-table-fixed-layout", r.fixedLayout);
+                },
+                exportAs: ["matTable"],
+                standalone: !0,
+                features: [
+                    Q([
+                        { provide: ea, useExisting: t },
+                        { provide: jt, useExisting: t },
+                        { provide: Vo, useClass: Gs },
+                        { provide: fn, useClass: vi },
+                        { provide: zo, useValue: null },
+                    ]),
+                    U,
+                    tt,
+                ],
+                ngContentSelectors: zp,
+                decls: 5,
+                vars: 2,
+                consts: [
+                    ["role", "rowgroup"],
+                    ["headerRowOutlet", ""],
+                    ["role", "rowgroup", 1, "mdc-data-table__content"],
+                    ["rowOutlet", ""],
+                    ["noDataRowOutlet", ""],
+                    ["footerRowOutlet", ""],
+                ],
+                template: function (i, r) {
+                    i & 1 &&
+                        (pt(Vp),
+                        K(0),
+                        K(1, 1),
+                        ot(2, Bp, 1, 0)(3, Up, 7, 0)(4, Hp, 4, 0)),
+                        i & 2 &&
+                            (R(2),
+                            Ut(2, r._isServer ? 2 : -1),
+                            R(),
+                            Ut(3, r._isNativeHtmlTable ? 3 : 4));
+                },
+                dependencies: [Qs, Ks, ta, Js],
+                styles: [
+                    ".mat-mdc-table-sticky{position:sticky !important}.mdc-data-table{-webkit-overflow-scrolling:touch;display:inline-flex;flex-direction:column;box-sizing:border-box;position:relative}.mdc-data-table__table-container{-webkit-overflow-scrolling:touch;overflow-x:auto;width:100%}.mdc-data-table__table{min-width:100%;border:0;white-space:nowrap;border-spacing:0;table-layout:fixed}.mdc-data-table__cell{box-sizing:border-box;overflow:hidden;text-align:left;text-overflow:ellipsis}[dir=rtl] .mdc-data-table__cell,.mdc-data-table__cell[dir=rtl]{text-align:right}.mdc-data-table__cell--numeric{text-align:right}[dir=rtl] .mdc-data-table__cell--numeric,.mdc-data-table__cell--numeric[dir=rtl]{text-align:left}.mdc-data-table__header-cell{box-sizing:border-box;text-overflow:ellipsis;overflow:hidden;outline:none;text-align:left}[dir=rtl] .mdc-data-table__header-cell,.mdc-data-table__header-cell[dir=rtl]{text-align:right}.mdc-data-table__header-cell--numeric{text-align:right}[dir=rtl] .mdc-data-table__header-cell--numeric,.mdc-data-table__header-cell--numeric[dir=rtl]{text-align:left}.mdc-data-table__header-cell-wrapper{align-items:center;display:inline-flex;vertical-align:middle}.mdc-data-table__cell,.mdc-data-table__header-cell{padding:0 16px 0 16px}.mdc-data-table__header-cell--checkbox,.mdc-data-table__cell--checkbox{padding-left:4px;padding-right:0}[dir=rtl] .mdc-data-table__header-cell--checkbox,[dir=rtl] .mdc-data-table__cell--checkbox,.mdc-data-table__header-cell--checkbox[dir=rtl],.mdc-data-table__cell--checkbox[dir=rtl]{padding-left:0;padding-right:4px}mat-table{display:block}mat-header-row{min-height:56px}mat-row,mat-footer-row{min-height:48px}mat-row,mat-header-row,mat-footer-row{display:flex;border-width:0;border-bottom-width:1px;border-style:solid;align-items:center;box-sizing:border-box}mat-cell:first-of-type,mat-header-cell:first-of-type,mat-footer-cell:first-of-type{padding-left:24px}[dir=rtl] mat-cell:first-of-type:not(:only-of-type),[dir=rtl] mat-header-cell:first-of-type:not(:only-of-type),[dir=rtl] mat-footer-cell:first-of-type:not(:only-of-type){padding-left:0;padding-right:24px}mat-cell:last-of-type,mat-header-cell:last-of-type,mat-footer-cell:last-of-type{padding-right:24px}[dir=rtl] mat-cell:last-of-type:not(:only-of-type),[dir=rtl] mat-header-cell:last-of-type:not(:only-of-type),[dir=rtl] mat-footer-cell:last-of-type:not(:only-of-type){padding-right:0;padding-left:24px}mat-cell,mat-header-cell,mat-footer-cell{flex:1;display:flex;align-items:center;overflow:hidden;word-wrap:break-word;min-height:inherit}.mat-mdc-table{table-layout:auto;white-space:normal;background-color:var(--mat-table-background-color)}.mat-mdc-header-row{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;height:var(--mat-table-header-container-height, 56px);color:var(--mat-table-header-headline-color, rgba(0, 0, 0, 0.87));font-family:var(--mat-table-header-headline-font, Roboto, sans-serif);line-height:var(--mat-table-header-headline-line-height);font-size:var(--mat-table-header-headline-size, 14px);font-weight:var(--mat-table-header-headline-weight, 500)}.mat-mdc-row{height:var(--mat-table-row-item-container-height, 52px);color:var(--mat-table-row-item-label-text-color, rgba(0, 0, 0, 0.87))}.mat-mdc-row,.mdc-data-table__content{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;font-family:var(--mat-table-row-item-label-text-font, Roboto, sans-serif);line-height:var(--mat-table-row-item-label-text-line-height);font-size:var(--mat-table-row-item-label-text-size, 14px);font-weight:var(--mat-table-row-item-label-text-weight)}.mat-mdc-footer-row{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;height:var(--mat-table-footer-container-height, 52px);color:var(--mat-table-row-item-label-text-color, rgba(0, 0, 0, 0.87));font-family:var(--mat-table-footer-supporting-text-font, Roboto, sans-serif);line-height:var(--mat-table-footer-supporting-text-line-height);font-size:var(--mat-table-footer-supporting-text-size, 14px);font-weight:var(--mat-table-footer-supporting-text-weight);letter-spacing:var(--mat-table-footer-supporting-text-tracking)}.mat-mdc-header-cell{border-bottom-color:var(--mat-table-row-item-outline-color, rgba(0, 0, 0, 0.12));border-bottom-width:var(--mat-table-row-item-outline-width, 1px);border-bottom-style:solid;letter-spacing:var(--mat-table-header-headline-tracking);font-weight:inherit;line-height:inherit}.mat-mdc-cell{border-bottom-color:var(--mat-table-row-item-outline-color, rgba(0, 0, 0, 0.12));border-bottom-width:var(--mat-table-row-item-outline-width, 1px);border-bottom-style:solid;letter-spacing:var(--mat-table-row-item-label-text-tracking);line-height:inherit}.mdc-data-table__row:last-child .mat-mdc-cell{border-bottom:none}.mat-mdc-footer-cell{letter-spacing:var(--mat-table-row-item-label-text-tracking)}mat-row.mat-mdc-row,mat-header-row.mat-mdc-header-row,mat-footer-row.mat-mdc-footer-row{border-bottom:none}.mat-mdc-table tbody,.mat-mdc-table tfoot,.mat-mdc-table thead,.mat-mdc-cell,.mat-mdc-footer-cell,.mat-mdc-header-row,.mat-mdc-row,.mat-mdc-footer-row,.mat-mdc-table .mat-mdc-header-cell{background:inherit}.mat-mdc-table mat-header-row.mat-mdc-header-row,.mat-mdc-table mat-row.mat-mdc-row,.mat-mdc-table mat-footer-row.mat-mdc-footer-cell{height:unset}mat-header-cell.mat-mdc-header-cell,mat-cell.mat-mdc-cell,mat-footer-cell.mat-mdc-footer-cell{align-self:stretch}",
+                ],
+                encapsulation: 2,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Pd = (() => {
+        let t = class t extends Bo {};
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "matCellDef", ""]],
+                standalone: !0,
+                features: [Q([{ provide: Bo, useExisting: t }]), U],
+            }));
+        let n = t;
+        return n;
+    })(),
+    Ld = (() => {
+        let t = class t extends Uo {};
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "matHeaderCellDef", ""]],
+                standalone: !0,
+                features: [Q([{ provide: Uo, useExisting: t }]), U],
+            }));
+        let n = t;
+        return n;
+    })();
+var jd = (() => {
+        let t = class t extends yi {
+            get name() {
+                return this._name;
+            }
+            set name(e) {
+                this._setNameInput(e);
+            }
+            _updateColumnCssClassName() {
+                super._updateColumnCssClassName(),
+                    this._columnCssClassName.push(
+                        `mat-column-${this.cssClassFriendlyName}`
+                    );
+            }
+        };
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "matColumnDef", ""]],
+                inputs: { name: [y.None, "matColumnDef", "name"] },
+                standalone: !0,
+                features: [
+                    Q([
+                        { provide: yi, useExisting: t },
+                        {
+                            provide: "MAT_SORT_HEADER_COLUMN_DEF",
+                            useExisting: t,
+                        },
+                    ]),
+                    U,
+                ],
+            }));
+        let n = t;
+        return n;
+    })(),
+    Vd = (() => {
+        let t = class t extends ud {};
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["mat-header-cell"], ["th", "mat-header-cell", ""]],
+                hostAttrs: [
+                    "role",
+                    "columnheader",
+                    1,
+                    "mat-mdc-header-cell",
+                    "mdc-data-table__header-cell",
+                ],
+                standalone: !0,
+                features: [U],
+            }));
+        let n = t;
+        return n;
+    })();
+var zd = (() => {
+    let t = class t extends hd {};
+    (t.ɵfac = (() => {
+        let e;
+        return function (r) {
+            return (e || (e = _t(t)))(r || t);
+        };
+    })()),
+        (t.ɵdir = D({
+            type: t,
+            selectors: [["mat-cell"], ["td", "mat-cell", ""]],
+            hostAttrs: [1, "mat-mdc-cell", "mdc-data-table__cell"],
+            standalone: !0,
+            features: [U],
+        }));
+    let n = t;
+    return n;
+})();
+var Bd = (() => {
+    let t = class t extends _n {};
+    (t.ɵfac = (() => {
+        let e;
+        return function (r) {
+            return (e || (e = _t(t)))(r || t);
+        };
+    })()),
+        (t.ɵdir = D({
+            type: t,
+            selectors: [["", "matHeaderRowDef", ""]],
+            inputs: {
+                columns: [y.None, "matHeaderRowDef", "columns"],
+                sticky: [
+                    y.HasDecoratorInputTransform,
+                    "matHeaderRowDefSticky",
+                    "sticky",
+                    W,
+                ],
+            },
+            standalone: !0,
+            features: [Q([{ provide: _n, useExisting: t }]), nt, U],
+        }));
+    let n = t;
+    return n;
+})();
+var Ud = (() => {
+        let t = class t extends Ho {};
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["", "matRowDef", ""]],
+                inputs: {
+                    columns: [y.None, "matRowDefColumns", "columns"],
+                    when: [y.None, "matRowDefWhen", "when"],
+                },
+                standalone: !0,
+                features: [Q([{ provide: Ho, useExisting: t }]), U],
+            }));
+        let n = t;
+        return n;
+    })(),
+    Hd = (() => {
+        let t = class t extends Zs {};
+        (t.ɵfac = (() => {
+            let e;
+            return function (r) {
+                return (e || (e = _t(t)))(r || t);
+            };
+        })()),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["mat-header-row"], ["tr", "mat-header-row", ""]],
+                hostAttrs: [
+                    "role",
+                    "row",
+                    1,
+                    "mat-mdc-header-row",
+                    "mdc-data-table__header-row",
+                ],
+                exportAs: ["matHeaderRow"],
+                standalone: !0,
+                features: [Q([{ provide: Zs, useExisting: t }]), U, tt],
+                decls: 1,
+                vars: 0,
+                consts: [["cdkCellOutlet", ""]],
+                template: function (i, r) {
+                    i & 1 && It(0, 0);
+                },
+                dependencies: [ze],
+                encapsulation: 2,
+            }));
+        let n = t;
+        return n;
+    })();
+var $d = (() => {
+    let t = class t extends Xs {};
+    (t.ɵfac = (() => {
+        let e;
+        return function (r) {
+            return (e || (e = _t(t)))(r || t);
+        };
+    })()),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["mat-row"], ["tr", "mat-row", ""]],
+            hostAttrs: ["role", "row", 1, "mat-mdc-row", "mdc-data-table__row"],
+            exportAs: ["matRow"],
+            standalone: !0,
+            features: [Q([{ provide: Xs, useExisting: t }]), U, tt],
+            decls: 1,
+            vars: 0,
+            consts: [["cdkCellOutlet", ""]],
+            template: function (i, r) {
+                i & 1 && It(0, 0);
+            },
+            dependencies: [ze],
+            encapsulation: 2,
+        }));
+    let n = t;
+    return n;
+})();
+var Wd = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Y, fd, Y] }));
+        let n = t;
+        return n;
+    })(),
+    $p = 9007199254740991,
+    wi = class extends Fo {
+        get data() {
+            return this._data.value;
+        }
+        set data(t) {
+            (t = Array.isArray(t) ? t : []),
+                this._data.next(t),
+                this._renderChangesSubscription || this._filterData(t);
+        }
+        get filter() {
+            return this._filter.value;
+        }
+        set filter(t) {
+            this._filter.next(t),
+                this._renderChangesSubscription || this._filterData(this.data);
+        }
+        get sort() {
+            return this._sort;
+        }
+        set sort(t) {
+            (this._sort = t), this._updateChangeSubscription();
+        }
+        get paginator() {
+            return this._paginator;
+        }
+        set paginator(t) {
+            (this._paginator = t), this._updateChangeSubscription();
+        }
+        constructor(t = []) {
+            super(),
+                (this._renderData = new rt([])),
+                (this._filter = new rt("")),
+                (this._internalPageChanges = new N()),
+                (this._renderChangesSubscription = null),
+                (this.sortingDataAccessor = (o, e) => {
+                    let i = o[e];
+                    if (od(i)) {
+                        let r = Number(i);
+                        return r < $p ? r : i;
+                    }
+                    return i;
+                }),
+                (this.sortData = (o, e) => {
+                    let i = e.active,
+                        r = e.direction;
+                    return !i || r == ""
+                        ? o
+                        : o.sort((s, a) => {
+                              let l = this.sortingDataAccessor(s, i),
+                                  c = this.sortingDataAccessor(a, i),
+                                  d = typeof l,
+                                  h = typeof c;
+                              d !== h &&
+                                  (d === "number" && (l += ""),
+                                  h === "number" && (c += ""));
+                              let f = 0;
+                              return (
+                                  l != null && c != null
+                                      ? l > c
+                                          ? (f = 1)
+                                          : l < c && (f = -1)
+                                      : l != null
+                                        ? (f = 1)
+                                        : c != null && (f = -1),
+                                  f * (r == "asc" ? 1 : -1)
+                              );
+                          });
+                }),
+                (this.filterPredicate = (o, e) => {
+                    let i = Object.keys(o)
+                            .reduce((s, a) => s + o[a] + "\u25EC", "")
+                            .toLowerCase(),
+                        r = e.trim().toLowerCase();
+                    return i.indexOf(r) != -1;
+                }),
+                (this._data = new rt(t)),
+                this._updateChangeSubscription();
+        }
+        _updateChangeSubscription() {
+            let t = this._sort
+                    ? qt(this._sort.sortChange, this._sort.initialized)
+                    : v(null),
+                o = this._paginator
+                    ? qt(
+                          this._paginator.page,
+                          this._internalPageChanges,
+                          this._paginator.initialized
+                      )
+                    : v(null),
+                e = this._data,
+                i = Vt([e, this._filter]).pipe(M(([a]) => this._filterData(a))),
+                r = Vt([i, t]).pipe(M(([a]) => this._orderData(a))),
+                s = Vt([r, o]).pipe(M(([a]) => this._pageData(a)));
+            this._renderChangesSubscription?.unsubscribe(),
+                (this._renderChangesSubscription = s.subscribe((a) =>
+                    this._renderData.next(a)
+                ));
+        }
+        _filterData(t) {
+            return (
+                (this.filteredData =
+                    this.filter == null || this.filter === ""
+                        ? t
+                        : t.filter((o) =>
+                              this.filterPredicate(o, this.filter)
+                          )),
+                this.paginator &&
+                    this._updatePaginator(this.filteredData.length),
+                this.filteredData
+            );
+        }
+        _orderData(t) {
+            return this.sort ? this.sortData(t.slice(), this.sort) : t;
+        }
+        _pageData(t) {
+            if (!this.paginator) return t;
+            let o = this.paginator.pageIndex * this.paginator.pageSize;
+            return t.slice(o, o + this.paginator.pageSize);
+        }
+        _updatePaginator(t) {
+            Promise.resolve().then(() => {
+                let o = this.paginator;
+                if (o && ((o.length = t), o.pageIndex > 0)) {
+                    let e = Math.ceil(o.length / o.pageSize) - 1 || 0,
+                        i = Math.min(o.pageIndex, e);
+                    i !== o.pageIndex &&
+                        ((o.pageIndex = i), this._internalPageChanges.next());
+                }
+            });
+        }
+        connect() {
+            return (
+                this._renderChangesSubscription ||
+                    this._updateChangeSubscription(),
+                this._renderData
+            );
+        }
+        disconnect() {
+            this._renderChangesSubscription?.unsubscribe(),
+                (this._renderChangesSubscription = null);
+        }
+    };
+var Gp = (n) => ["/Product-Stores", n];
+function Yp(n, t) {
+    if (n & 1) {
+        let o = Ft();
+        x(0, "tr")(1, "td"),
+            H(2, "img", 9),
+            _(),
+            x(3, "td")(4, "a", 10),
+            F(5),
+            _()(),
+            x(6, "td")(7, "button", 11),
+            Z("click", function () {
+                let i = xt(o).$implicit,
+                    r = X(2);
+                return wt(r.deleteOneProductFromSFL(i.productID));
+            }),
+            F(8, "Remove"),
+            _()()();
+    }
+    if (n & 2) {
+        let o = t.$implicit;
+        R(2),
+            Ze("alt", o.productName),
+            L("src", o.productImage, Se),
+            R(2),
+            L("routerLink", Ni(4, Gp, o.productID)),
+            R(),
+            te(o.productName);
+    }
+}
+function qp(n, t) {
+    if (n & 1) {
+        let o = Ft();
+        de(0),
+            x(1, "div", 3),
+            H(2, "div"),
+            x(3, "button", 4),
+            Z("click", function () {
+                xt(o);
+                let i = X();
+                return wt(i.deleteAllProductsFromSFL());
+            }),
+            F(4, "Clear All"),
+            _()(),
+            x(5, "table", 5)(6, "thead", 6)(7, "tr")(8, "th", 7),
+            F(9, "Image"),
+            _(),
+            x(10, "th", 7),
+            F(11, "Product Name"),
+            _(),
+            x(12, "th", 7),
+            F(13, "Actions"),
+            _()()(),
+            x(14, "tbody"),
+            ot(15, Yp, 9, 6, "tr", 8),
+            _()(),
+            ue();
+    }
+    if (n & 2) {
+        let o = X();
+        R(15), L("ngForOf", o.tableDataProductNames.data);
+    }
+}
+function Zp(n, t) {
+    n & 1 && (x(0, "div", 12), F(1, "No products saved for later."), _());
+}
+var Gd = (() => {
+    let t = class t {
+        constructor(e) {
+            (this.productService = e),
+                (this.product = null),
+                (this.tableDataProductNames = new wi());
+        }
+        ngOnInit() {
+            this.getFromSavedForLater();
+        }
+        getFromSavedForLater() {
+            this.productService.getSaveForLater().subscribe((e) => {
+                e &&
+                    e.saveForLater &&
+                    ((this.product = e),
+                    (this.tableDataProductNames.data = e.saveForLater));
+            });
+        }
+        deleteOneProductFromSFL(e) {
+            this.product &&
+                this.productService.deleteSflProduct(e).subscribe(() => {
+                    (this.product.saveForLater =
+                        this.product.saveForLater.filter(
+                            (i) => i.productID !== e
+                        )),
+                        (this.tableDataProductNames.data =
+                            this.product.saveForLater);
+                });
+        }
+        deleteAllProductsFromSFL() {
+            this.product &&
+                this.productService.deleteAllSflProducts().subscribe(() => {
+                    (this.product.saveForLater = []),
+                        (this.tableDataProductNames.data = []);
+                });
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(u(fe));
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["app-save-for-later"]],
+            decls: 4,
+            vars: 2,
+            consts: [
+                ["noData", ""],
+                [1, "container", "mt-5"],
+                [4, "ngIf", "ngIfElse"],
+                [1, "d-flex", "justify-content-between", "mb-3"],
+                [1, "btn", "btn-warning", 3, "click"],
+                [1, "table", "table-bordered", "table-hover"],
+                [1, "thead-light"],
+                ["scope", "col"],
+                [4, "ngFor", "ngForOf"],
+                [1, "img-thumbnail", 2, "width", "100px", 3, "src", "alt"],
+                [3, "routerLink"],
+                [1, "btn", "btn-danger", "btn-sm", 3, "click"],
+                ["id", "noDataMessage", 1, "alert", "alert-info"],
+            ],
+            template: function (i, r) {
+                if (
+                    (i & 1 &&
+                        (x(0, "div", 1),
+                        ot(1, qp, 16, 1, "ng-container", 2)(
+                            2,
+                            Zp,
+                            2,
+                            0,
+                            "ng-template",
+                            null,
+                            0,
+                            Ke
+                        ),
+                        _()),
+                    i & 2)
+                ) {
+                    let s = he(3);
+                    R(),
+                        L(
+                            "ngIf",
+                            r.tableDataProductNames.data &&
+                                r.tableDataProductNames.data.length > 0
+                        )("ngIfElse", s);
+                }
+            },
+            dependencies: [Qe, Ht, ui],
+            styles: [
+                ".save-for-later[_ngcontent-%COMP%]{margin-top:20px;padding:20px;border:1px solid #ccc;border-radius:5px;background-color:#f9f9f9}#noDataMessage[_ngcontent-%COMP%]{text-align:center;margin:auto;width:fit-content}",
+            ],
+        }));
+    let n = t;
+    return n;
+})();
+var Qo = (() => {
+    let t = class t {
+        constructor(e, i) {
+            (this.http = e),
+                (this.router = i),
+                (this.authUrl = "https://pricepinion.azurewebsites.net/"),
+                (this.userSubject = new rt(null)),
+                (this.user = this.userSubject.asObservable()),
+                this.fetchUserData();
+        }
+        login() {
+            (window.location.href = `${this.authUrl}auth/google`),
+                console.log("Logged in", this.user);
+        }
+        logout() {
+            localStorage.removeItem("user"),
+                this.http
+                    .get(`${this.authUrl}auth/logout`, { withCredentials: !0 })
+                    .subscribe(() => {
+                        console.log("Logged out"), this.userSubject.next(null);
+                    });
+        }
+        setUser(e) {
+            localStorage.setItem("user", JSON.stringify(e)),
+                this.userSubject.next(e);
+        }
+        getUser() {
+            return this.userSubject.value;
+        }
+        isLoggedIn() {
+            return !!this.userSubject.value;
+        }
+        fetchUserData() {
+            this.http
+                .get(`${this.authUrl}auth/user`, { withCredentials: !0 })
+                .subscribe(
+                    (e) => {
+                        this.setUser(e);
+                    },
+                    (e) => {
+                        console.error("Failed to fetch user data", e),
+                            this.userSubject.next(null);
+                    }
+                );
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(m(Oe), m(Yt));
+    }),
+        (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+    let n = t;
+    return n;
+})();
+function Xp(n, t) {
+    n & 1 &&
+        (x(0, "div")(1, "label", 11),
+        F(2, "Password"),
+        _(),
+        H(3, "input", 12),
+        _());
+}
+var qd = (() => {
+    let t = class t {
+        constructor(e, i) {
+            (this.authService = e),
+                (this.fb = i),
+                (this.isGoogleUser = !1),
+                (this.customerForm = this.fb.group({
+                    name: [{ value: "", disabled: !0 }, []],
+                    email: [{ value: "", disabled: !0 }, []],
+                    password: [""],
+                })),
+                (this.statusText = this.fb.group({ text: [""] }));
+        }
+        ngOnInit() {
+            this.authService.user.subscribe((e) => {
+                (this.user = e),
+                    (this.isGoogleUser = !!e?.googleId),
+                    console.log("user data:", this.user),
+                    e &&
+                        this.customerForm.patchValue({
+                            name: e.displayName,
+                            email: e.customerEmail,
+                        });
+            }),
+                this.authService.fetchUserData();
+        }
+        onSubmit() {
+            this.customerForm.valid && this.isGoogleUser;
+        }
+        logout() {
+            this.authService.logout();
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(u(Qo), u(Xc));
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["app-account"]],
+            decls: 20,
+            vars: 4,
+            consts: [
+                [1, "title"],
+                [1, "customer-form-container", 3, "ngSubmit", "formGroup"],
+                ["for", "name", 1, "labels"],
+                [
+                    "id",
+                    "name",
+                    "type",
+                    "text",
+                    "formControlName",
+                    "name",
+                    1,
+                    "input-fields",
+                ],
+                ["for", "email", 1, "labels"],
+                [
+                    "id",
+                    "email",
+                    "type",
+                    "email",
+                    "formControlName",
+                    "email",
+                    1,
+                    "input-fields",
+                ],
+                [4, "ngIf"],
+                ["type", "submit", 1, "button", 3, "disabled"],
+                [3, "formGroup"],
+                [
+                    "id",
+                    "text",
+                    "type",
+                    "text",
+                    "formControlName",
+                    "text",
+                    1,
+                    "status-text",
+                ],
+                [1, "button", 3, "click"],
+                ["for", "password", 1, "labels"],
+                [
+                    "id",
+                    "password",
+                    "type",
+                    "password",
+                    "formControlName",
+                    "password",
+                    1,
+                    "input-fields",
+                ],
+            ],
+            template: function (i, r) {
+                i & 1 &&
+                    (x(0, "h3", 0),
+                    F(1, "Account Information"),
+                    _(),
+                    x(2, "form", 1),
+                    Z("ngSubmit", function () {
+                        return r.onSubmit();
+                    }),
+                    x(3, "div")(4, "label", 2),
+                    F(5, "Name"),
+                    _(),
+                    H(6, "input", 3),
+                    _(),
+                    x(7, "div")(8, "label", 4),
+                    F(9, "Email"),
+                    _(),
+                    H(10, "input", 5),
+                    _(),
+                    ot(11, Xp, 4, 0, "div", 6),
+                    x(12, "button", 7),
+                    F(13, "Save Changes"),
+                    _()(),
+                    x(14, "form", 8)(15, "div"),
+                    H(16, "input", 9),
+                    _()(),
+                    x(17, "div")(18, "button", 10),
+                    Z("click", function () {
+                        return r.logout();
+                    }),
+                    F(19, "Logout"),
+                    _()()),
+                    i & 2 &&
+                        (R(2),
+                        L("formGroup", r.customerForm),
+                        R(9),
+                        L("ngIf", !r.isGoogleUser),
+                        R(),
+                        L("disabled", r.isGoogleUser),
+                        R(2),
+                        L("formGroup", r.statusText));
+            },
+            dependencies: [Ht, Yc, pi, Mo, zc, zs, Bs],
+            styles: [
+                ".title[_ngcontent-%COMP%]{margin-top:35px;margin-left:30px;font-size:24px;margin-bottom:35px}.customer-form-container[_ngcontent-%COMP%]{margin-left:80px;margin-right:80px;background-color:#f9f9f9;border:3px solid #ddd;padding:30px;border-radius:10px;margin-bottom:20px}.labels[_ngcontent-%COMP%]{display:block;margin-bottom:10px;font-size:18px}.input-fields[_ngcontent-%COMP%]{width:100%;padding:15px;border:1px solid #ccc;border-radius:4px;box-sizing:border-box;font-size:15px;margin-bottom:20px}.button[_ngcontent-%COMP%]{font-weight:100;margin-top:30px;font-size:18px;background-color:#4848e8;color:#fff;padding:15px 25px;border-radius:5px;cursor:pointer}.status-text[_ngcontent-%COMP%]{width:50%;padding:15px;font-size:16px;border:none;color:#15980c;margin-left:80px}",
+            ],
+        }));
+    let n = t;
+    return n;
+})();
+var Kp = ["*"],
+    Jo;
+function Qp() {
+    if (Jo === void 0 && ((Jo = null), typeof window < "u")) {
+        let n = window;
+        n.trustedTypes !== void 0 &&
+            (Jo = n.trustedTypes.createPolicy("angular#components", {
+                createHTML: (t) => t,
+            }));
+    }
+    return Jo;
+}
+function Dn(n) {
+    return Qp()?.createHTML(n) || n;
+}
+function Zd(n) {
+    return Error(`Unable to find icon with the name "${n}"`);
+}
+function Jp() {
+    return Error(
+        "Could not find HttpClient provider for use with Angular Material icons. Please include the HttpClientModule from @angular/common/http in your app imports."
+    );
+}
+function Xd(n) {
+    return Error(
+        `The URL provided to MatIconRegistry was not trusted as a resource URL via Angular's DomSanitizer. Attempted URL was "${n}".`
+    );
+}
+function Kd(n) {
+    return Error(
+        `The literal provided to MatIconRegistry was not trusted as safe HTML by Angular's DomSanitizer. Attempted literal was "${n}".`
+    );
+}
+var ne = class {
+        constructor(t, o, e) {
+            (this.url = t), (this.svgText = o), (this.options = e);
+        }
+    },
+    tg = (() => {
+        let t = class t {
+            constructor(e, i, r, s) {
+                (this._httpClient = e),
+                    (this._sanitizer = i),
+                    (this._errorHandler = s),
+                    (this._svgIconConfigs = new Map()),
+                    (this._iconSetConfigs = new Map()),
+                    (this._cachedIconsByUrl = new Map()),
+                    (this._inProgressUrlFetches = new Map()),
+                    (this._fontCssClassesByAlias = new Map()),
+                    (this._resolvers = []),
+                    (this._defaultFontSetClass = [
+                        "material-icons",
+                        "mat-ligature-font",
+                    ]),
+                    (this._document = r);
+            }
+            addSvgIcon(e, i, r) {
+                return this.addSvgIconInNamespace("", e, i, r);
+            }
+            addSvgIconLiteral(e, i, r) {
+                return this.addSvgIconLiteralInNamespace("", e, i, r);
+            }
+            addSvgIconInNamespace(e, i, r, s) {
+                return this._addSvgIconConfig(e, i, new ne(r, null, s));
+            }
+            addSvgIconResolver(e) {
+                return this._resolvers.push(e), this;
+            }
+            addSvgIconLiteralInNamespace(e, i, r, s) {
+                let a = this._sanitizer.sanitize(Mt.HTML, r);
+                if (!a) throw Kd(r);
+                let l = Dn(a);
+                return this._addSvgIconConfig(e, i, new ne("", l, s));
+            }
+            addSvgIconSet(e, i) {
+                return this.addSvgIconSetInNamespace("", e, i);
+            }
+            addSvgIconSetLiteral(e, i) {
+                return this.addSvgIconSetLiteralInNamespace("", e, i);
+            }
+            addSvgIconSetInNamespace(e, i, r) {
+                return this._addSvgIconSetConfig(e, new ne(i, null, r));
+            }
+            addSvgIconSetLiteralInNamespace(e, i, r) {
+                let s = this._sanitizer.sanitize(Mt.HTML, i);
+                if (!s) throw Kd(i);
+                let a = Dn(s);
+                return this._addSvgIconSetConfig(e, new ne("", a, r));
+            }
+            registerFontClassAlias(e, i = e) {
+                return this._fontCssClassesByAlias.set(e, i), this;
+            }
+            classNameForFontAlias(e) {
+                return this._fontCssClassesByAlias.get(e) || e;
+            }
+            setDefaultFontSetClass(...e) {
+                return (this._defaultFontSetClass = e), this;
+            }
+            getDefaultFontSetClass() {
+                return this._defaultFontSetClass;
+            }
+            getSvgIconFromUrl(e) {
+                let i = this._sanitizer.sanitize(Mt.RESOURCE_URL, e);
+                if (!i) throw Xd(e);
+                let r = this._cachedIconsByUrl.get(i);
+                return r
+                    ? v(tr(r))
+                    : this._loadSvgIconFromConfig(new ne(e, null)).pipe(
+                          et((s) => this._cachedIconsByUrl.set(i, s)),
+                          M((s) => tr(s))
+                      );
+            }
+            getNamedSvgIcon(e, i = "") {
+                let r = Qd(i, e),
+                    s = this._svgIconConfigs.get(r);
+                if (s) return this._getSvgFromConfig(s);
+                if (((s = this._getIconConfigFromResolvers(i, e)), s))
+                    return (
+                        this._svgIconConfigs.set(r, s),
+                        this._getSvgFromConfig(s)
+                    );
+                let a = this._iconSetConfigs.get(i);
+                return a ? this._getSvgFromIconSetConfigs(e, a) : Ce(Zd(r));
+            }
+            ngOnDestroy() {
+                (this._resolvers = []),
+                    this._svgIconConfigs.clear(),
+                    this._iconSetConfigs.clear(),
+                    this._cachedIconsByUrl.clear();
+            }
+            _getSvgFromConfig(e) {
+                return e.svgText
+                    ? v(tr(this._svgElementFromConfig(e)))
+                    : this._loadSvgIconFromConfig(e).pipe(M((i) => tr(i)));
+            }
+            _getSvgFromIconSetConfigs(e, i) {
+                let r = this._extractIconWithNameFromAnySet(e, i);
+                if (r) return v(r);
+                let s = i
+                    .filter((a) => !a.svgText)
+                    .map((a) =>
+                        this._loadSvgIconSetFromConfig(a).pipe(
+                            re((l) => {
+                                let d = `Loading icon set URL: ${this._sanitizer.sanitize(Mt.RESOURCE_URL, a.url)} failed: ${l.message}`;
+                                return (
+                                    this._errorHandler.handleError(
+                                        new Error(d)
+                                    ),
+                                    v(null)
+                                );
+                            })
+                        )
+                    );
+                return Tn(s).pipe(
+                    M(() => {
+                        let a = this._extractIconWithNameFromAnySet(e, i);
+                        if (!a) throw Zd(e);
+                        return a;
+                    })
+                );
+            }
+            _extractIconWithNameFromAnySet(e, i) {
+                for (let r = i.length - 1; r >= 0; r--) {
+                    let s = i[r];
+                    if (s.svgText && s.svgText.toString().indexOf(e) > -1) {
+                        let a = this._svgElementFromConfig(s),
+                            l = this._extractSvgIconFromSet(a, e, s.options);
+                        if (l) return l;
+                    }
+                }
+                return null;
+            }
+            _loadSvgIconFromConfig(e) {
+                return this._fetchIcon(e).pipe(
+                    et((i) => (e.svgText = i)),
+                    M(() => this._svgElementFromConfig(e))
+                );
+            }
+            _loadSvgIconSetFromConfig(e) {
+                return e.svgText
+                    ? v(null)
+                    : this._fetchIcon(e).pipe(et((i) => (e.svgText = i)));
+            }
+            _extractSvgIconFromSet(e, i, r) {
+                let s = e.querySelector(`[id="${i}"]`);
+                if (!s) return null;
+                let a = s.cloneNode(!0);
+                if (
+                    (a.removeAttribute("id"),
+                    a.nodeName.toLowerCase() === "svg")
+                )
+                    return this._setSvgAttributes(a, r);
+                if (a.nodeName.toLowerCase() === "symbol")
+                    return this._setSvgAttributes(this._toSvgElement(a), r);
+                let l = this._svgElementFromString(Dn("<svg></svg>"));
+                return l.appendChild(a), this._setSvgAttributes(l, r);
+            }
+            _svgElementFromString(e) {
+                let i = this._document.createElement("DIV");
+                i.innerHTML = e;
+                let r = i.querySelector("svg");
+                if (!r) throw Error("<svg> tag not found");
+                return r;
+            }
+            _toSvgElement(e) {
+                let i = this._svgElementFromString(Dn("<svg></svg>")),
+                    r = e.attributes;
+                for (let s = 0; s < r.length; s++) {
+                    let { name: a, value: l } = r[s];
+                    a !== "id" && i.setAttribute(a, l);
+                }
+                for (let s = 0; s < e.childNodes.length; s++)
+                    e.childNodes[s].nodeType === this._document.ELEMENT_NODE &&
+                        i.appendChild(e.childNodes[s].cloneNode(!0));
+                return i;
+            }
+            _setSvgAttributes(e, i) {
+                return (
+                    e.setAttribute("fit", ""),
+                    e.setAttribute("height", "100%"),
+                    e.setAttribute("width", "100%"),
+                    e.setAttribute("preserveAspectRatio", "xMidYMid meet"),
+                    e.setAttribute("focusable", "false"),
+                    i && i.viewBox && e.setAttribute("viewBox", i.viewBox),
+                    e
+                );
+            }
+            _fetchIcon(e) {
+                let { url: i, options: r } = e,
+                    s = r?.withCredentials ?? !1;
+                if (!this._httpClient) throw Jp();
+                if (i == null)
+                    throw Error(`Cannot fetch icon from URL "${i}".`);
+                let a = this._sanitizer.sanitize(Mt.RESOURCE_URL, i);
+                if (!a) throw Xd(i);
+                let l = this._inProgressUrlFetches.get(a);
+                if (l) return l;
+                let c = this._httpClient
+                    .get(a, { responseType: "text", withCredentials: s })
+                    .pipe(
+                        M((d) => Dn(d)),
+                        Zt(() => this._inProgressUrlFetches.delete(a)),
+                        Oa()
+                    );
+                return this._inProgressUrlFetches.set(a, c), c;
+            }
+            _addSvgIconConfig(e, i, r) {
+                return this._svgIconConfigs.set(Qd(e, i), r), this;
+            }
+            _addSvgIconSetConfig(e, i) {
+                let r = this._iconSetConfigs.get(e);
+                return r ? r.push(i) : this._iconSetConfigs.set(e, [i]), this;
+            }
+            _svgElementFromConfig(e) {
+                if (!e.svgElement) {
+                    let i = this._svgElementFromString(e.svgText);
+                    this._setSvgAttributes(i, e.options), (e.svgElement = i);
+                }
+                return e.svgElement;
+            }
+            _getIconConfigFromResolvers(e, i) {
+                for (let r = 0; r < this._resolvers.length; r++) {
+                    let s = this._resolvers[r](i, e);
+                    if (s)
+                        return eg(s)
+                            ? new ne(s.url, null, s.options)
+                            : new ne(s, null);
+                }
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(Oe, 8), m(zr), m(T, 8), m(Ee));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+function tr(n) {
+    return n.cloneNode(!0);
+}
+function Qd(n, t) {
+    return n + ":" + t;
+}
+function eg(n) {
+    return !!(n.url && n.options);
+}
+var ig = new C("MAT_ICON_DEFAULT_OPTIONS"),
+    ng = new C("mat-icon-location", { providedIn: "root", factory: og });
+function og() {
+    let n = g(T),
+        t = n ? n.location : null;
+    return { getPathname: () => (t ? t.pathname + t.search : "") };
+}
+var Jd = [
+        "clip-path",
+        "color-profile",
+        "src",
+        "cursor",
+        "fill",
+        "filter",
+        "marker",
+        "marker-start",
+        "marker-mid",
+        "marker-end",
+        "mask",
+        "stroke",
+    ],
+    rg = Jd.map((n) => `[${n}]`).join(", "),
+    sg = /^url\(['"]?#(.*?)['"]?\)$/,
+    er = (() => {
+        let t = class t {
+            get color() {
+                return this._color || this._defaultColor;
+            }
+            set color(e) {
+                this._color = e;
+            }
+            get svgIcon() {
+                return this._svgIcon;
+            }
+            set svgIcon(e) {
+                e !== this._svgIcon &&
+                    (e
+                        ? this._updateSvgIcon(e)
+                        : this._svgIcon && this._clearSvgElement(),
+                    (this._svgIcon = e));
+            }
+            get fontSet() {
+                return this._fontSet;
+            }
+            set fontSet(e) {
+                let i = this._cleanupFontValue(e);
+                i !== this._fontSet &&
+                    ((this._fontSet = i), this._updateFontIconClasses());
+            }
+            get fontIcon() {
+                return this._fontIcon;
+            }
+            set fontIcon(e) {
+                let i = this._cleanupFontValue(e);
+                i !== this._fontIcon &&
+                    ((this._fontIcon = i), this._updateFontIconClasses());
+            }
+            constructor(e, i, r, s, a, l) {
+                (this._elementRef = e),
+                    (this._iconRegistry = i),
+                    (this._location = s),
+                    (this._errorHandler = a),
+                    (this.inline = !1),
+                    (this._previousFontSetClass = []),
+                    (this._currentIconFetch = St.EMPTY),
+                    l &&
+                        (l.color && (this.color = this._defaultColor = l.color),
+                        l.fontSet && (this.fontSet = l.fontSet)),
+                    r || e.nativeElement.setAttribute("aria-hidden", "true");
+            }
+            _splitIconName(e) {
+                if (!e) return ["", ""];
+                let i = e.split(":");
+                switch (i.length) {
+                    case 1:
+                        return ["", i[0]];
+                    case 2:
+                        return i;
+                    default:
+                        throw Error(`Invalid icon name: "${e}"`);
+                }
+            }
+            ngOnInit() {
+                this._updateFontIconClasses();
+            }
+            ngAfterViewChecked() {
+                let e = this._elementsWithExternalReferences;
+                if (e && e.size) {
+                    let i = this._location.getPathname();
+                    i !== this._previousPath &&
+                        ((this._previousPath = i),
+                        this._prependPathToReferences(i));
+                }
+            }
+            ngOnDestroy() {
+                this._currentIconFetch.unsubscribe(),
+                    this._elementsWithExternalReferences &&
+                        this._elementsWithExternalReferences.clear();
+            }
+            _usingFontIcon() {
+                return !this.svgIcon;
+            }
+            _setSvgElement(e) {
+                this._clearSvgElement();
+                let i = this._location.getPathname();
+                (this._previousPath = i),
+                    this._cacheChildrenWithExternalReferences(e),
+                    this._prependPathToReferences(i),
+                    this._elementRef.nativeElement.appendChild(e);
+            }
+            _clearSvgElement() {
+                let e = this._elementRef.nativeElement,
+                    i = e.childNodes.length;
+                for (
+                    this._elementsWithExternalReferences &&
+                    this._elementsWithExternalReferences.clear();
+                    i--;
+
+                ) {
+                    let r = e.childNodes[i];
+                    (r.nodeType !== 1 || r.nodeName.toLowerCase() === "svg") &&
+                        r.remove();
+                }
+            }
+            _updateFontIconClasses() {
+                if (!this._usingFontIcon()) return;
+                let e = this._elementRef.nativeElement,
+                    i = (
+                        this.fontSet
+                            ? this._iconRegistry
+                                  .classNameForFontAlias(this.fontSet)
+                                  .split(/ +/)
+                            : this._iconRegistry.getDefaultFontSetClass()
+                    ).filter((r) => r.length > 0);
+                this._previousFontSetClass.forEach((r) =>
+                    e.classList.remove(r)
+                ),
+                    i.forEach((r) => e.classList.add(r)),
+                    (this._previousFontSetClass = i),
+                    this.fontIcon !== this._previousFontIconClass &&
+                        !i.includes("mat-ligature-font") &&
+                        (this._previousFontIconClass &&
+                            e.classList.remove(this._previousFontIconClass),
+                        this.fontIcon && e.classList.add(this.fontIcon),
+                        (this._previousFontIconClass = this.fontIcon));
+            }
+            _cleanupFontValue(e) {
+                return typeof e == "string" ? e.trim().split(" ")[0] : e;
+            }
+            _prependPathToReferences(e) {
+                let i = this._elementsWithExternalReferences;
+                i &&
+                    i.forEach((r, s) => {
+                        r.forEach((a) => {
+                            s.setAttribute(a.name, `url('${e}#${a.value}')`);
+                        });
+                    });
+            }
+            _cacheChildrenWithExternalReferences(e) {
+                let i = e.querySelectorAll(rg),
+                    r = (this._elementsWithExternalReferences =
+                        this._elementsWithExternalReferences || new Map());
+                for (let s = 0; s < i.length; s++)
+                    Jd.forEach((a) => {
+                        let l = i[s],
+                            c = l.getAttribute(a),
+                            d = c ? c.match(sg) : null;
+                        if (d) {
+                            let h = r.get(l);
+                            h || ((h = []), r.set(l, h)),
+                                h.push({ name: a, value: d[1] });
+                        }
+                    });
+            }
+            _updateSvgIcon(e) {
+                if (
+                    ((this._svgNamespace = null),
+                    (this._svgName = null),
+                    this._currentIconFetch.unsubscribe(),
+                    e)
+                ) {
+                    let [i, r] = this._splitIconName(e);
+                    i && (this._svgNamespace = i),
+                        r && (this._svgName = r),
+                        (this._currentIconFetch = this._iconRegistry
+                            .getNamedSvgIcon(r, i)
+                            .pipe(ut(1))
+                            .subscribe(
+                                (s) => this._setSvgElement(s),
+                                (s) => {
+                                    let a = `Error retrieving icon ${i}:${r}! ${s.message}`;
+                                    this._errorHandler.handleError(
+                                        new Error(a)
+                                    );
+                                }
+                            ));
+                }
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(
+                u(A),
+                u(tg),
+                De("aria-hidden"),
+                u(ng),
+                u(Ee),
+                u(ig, 8)
+            );
+        }),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["mat-icon"]],
+                hostAttrs: ["role", "img", 1, "mat-icon", "notranslate"],
+                hostVars: 10,
+                hostBindings: function (i, r) {
+                    i & 2 &&
+                        (ft(
+                            "data-mat-icon-type",
+                            r._usingFontIcon() ? "font" : "svg"
+                        )("data-mat-icon-name", r._svgName || r.fontIcon)(
+                            "data-mat-icon-namespace",
+                            r._svgNamespace || r.fontSet
+                        )("fontIcon", r._usingFontIcon() ? r.fontIcon : null),
+                        Jt(r.color ? "mat-" + r.color : ""),
+                        st("mat-icon-inline", r.inline)(
+                            "mat-icon-no-color",
+                            r.color !== "primary" &&
+                                r.color !== "accent" &&
+                                r.color !== "warn"
+                        ));
+                },
+                inputs: {
+                    color: "color",
+                    inline: [
+                        y.HasDecoratorInputTransform,
+                        "inline",
+                        "inline",
+                        W,
+                    ],
+                    svgIcon: "svgIcon",
+                    fontSet: "fontSet",
+                    fontIcon: "fontIcon",
+                },
+                exportAs: ["matIcon"],
+                standalone: !0,
+                features: [nt, tt],
+                ngContentSelectors: Kp,
+                decls: 1,
+                vars: 0,
+                template: function (i, r) {
+                    i & 1 && (pt(), K(0));
+                },
+                styles: [
+                    "mat-icon,mat-icon.mat-primary,mat-icon.mat-accent,mat-icon.mat-warn{color:var(--mat-icon-color)}.mat-icon{-webkit-user-select:none;user-select:none;background-repeat:no-repeat;display:inline-block;fill:currentColor;height:24px;width:24px;overflow:hidden}.mat-icon.mat-icon-inline{font-size:inherit;height:inherit;line-height:inherit;width:inherit}.mat-icon.mat-ligature-font[fontIcon]::before{content:attr(fontIcon)}[dir=rtl] .mat-icon-rtl-mirror{transform:scale(-1, 1)}.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-prefix .mat-icon,.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-suffix .mat-icon{display:block}.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-prefix .mat-icon-button .mat-icon,.mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-suffix .mat-icon-button .mat-icon{margin:auto}",
+                ],
+                encapsulation: 2,
+                changeDetection: 0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    tu = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Y, Y] }));
+        let n = t;
+        return n;
+    })();
+function ag(n, t) {
+    if (n & 1) {
+        let o = Ft();
+        de(0),
+            x(1, "button", 12),
+            Z("click", function () {
+                xt(o);
+                let i = X();
+                return wt(i.toggleSaveForLater());
+            }),
+            x(2, "mat-icon", 13),
+            F(3, "delete"),
+            _(),
+            F(4, " Delete From Save For Later "),
+            _(),
+            ue();
+    }
+}
+function lg(n, t) {
+    if (n & 1) {
+        let o = Ft();
+        x(0, "button", 14),
+            Z("click", function () {
+                xt(o);
+                let i = X();
+                return wt(i.toggleSaveForLater());
+            }),
+            x(1, "mat-icon", 13),
+            F(2, "favorite"),
+            _(),
+            F(3, " Save For Later "),
+            _();
+    }
+}
+function cg(n, t) {
+    if ((n & 1 && (x(0, "th", 18), F(1), _()), n & 2)) {
+        let o = X().$implicit;
+        R(), te(o === "ShopNow" ? "Shop Now" : o);
+    }
+}
+function dg(n, t) {
+    if ((n & 1 && (de(0), F(1), ue()), n & 2)) {
+        let o = X().$implicit,
+            e = X().$implicit;
+        R(), Oi(" ", o[e], " ");
+    }
+}
+function ug(n, t) {
+    if ((n & 1 && (x(0, "a", 20), F(1, "Visit Store"), _()), n & 2)) {
+        let o = X().$implicit,
+            e = X().$implicit;
+        L("href", o[e], Se);
+    }
+}
+function hg(n, t) {
+    if (
+        (n & 1 &&
+            (x(0, "td", 19),
+            ot(1, dg, 2, 1, "ng-container", 5)(
+                2,
+                ug,
+                2,
+                1,
+                "ng-template",
+                null,
+                1,
+                Ke
+            ),
+            _()),
+        n & 2)
+    ) {
+        let o = he(3),
+            e = X().$implicit;
+        R(), L("ngIf", e !== "ShopNow")("ngIfElse", o);
+    }
+}
+function mg(n, t) {
+    if (
+        (n & 1 &&
+            (de(0, 15), ot(1, cg, 2, 1, "th", 16)(2, hg, 4, 2, "td", 17), ue()),
+        n & 2)
+    ) {
+        let o = t.$implicit;
+        L("matColumnDef", o);
+    }
+}
+function fg(n, t) {
+    n & 1 && H(0, "tr", 21);
+}
+function pg(n, t) {
+    n & 1 && H(0, "tr", 22);
+}
+var iu = (() => {
+    let t = class t {
+        constructor(e, i) {
+            (this.productService = e),
+                (this.route = i),
+                (this.productID = ""),
+                (this.tableColumns = ["Store", "Price", "ShopNow"]),
+                (this.statusMessage = ""),
+                (this.sflStatus = !1);
+        }
+        ngOnInit() {
+            this.route.paramMap.subscribe((e) => {
+                this.productID = e.get("productID") ?? "";
+            }),
+                this.getOneProduct(),
+                this.checkSFLStatus();
+        }
+        getOneProduct() {
+            this.productService.getOneProduct(this.productID).subscribe({
+                next: (e) => {
+                    (this.productStores = e), this.generateTableData();
+                },
+                error: (e) => {
+                    console.error("Error fetching stores:", e);
+                },
+            });
+        }
+        generateTableData() {
+            let i = [
+                this.productStores,
+                ...this.productStores.productComparison,
+            ].map((r) => ({
+                Store: r.storeName,
+                Price: r.productPrice,
+                ShopNow: r.productLink,
+            }));
+            this.tableData = new wi(i);
+        }
+        checkSFLStatus() {
+            this.productService.getSaveForLater().subscribe({
+                next: (e) => {
+                    e.saveForLater.length > 0 &&
+                        (this.sflStatus = e.saveForLater.some(
+                            (i) => i.productID === this.productID
+                        ));
+                },
+                error: (e) => {
+                    console.error("Error fetching stores:", e);
+                },
+            });
+        }
+        setMsgTimeOut() {
+            setTimeout(() => {
+                this.statusMessage = "";
+            }, 3e3);
+        }
+        toggleSaveForLater() {
+            this.sflStatus ? this.removeSaveForLater() : this.setSaveForLater();
+        }
+        setSaveForLater() {
+            this.productService.setSaveForLater(this.productID).subscribe({
+                next: (e) => {
+                    e &&
+                        ((this.statusMessage = "Data is saved successfully!"),
+                        (this.sflStatus = !0),
+                        this.setMsgTimeOut()),
+                        this.checkSFLStatus();
+                },
+                error: (e) => {
+                    console.error("Error saving data", e);
+                },
+            });
+        }
+        removeSaveForLater() {
+            this.productService.deleteSflProduct(this.productID).subscribe({
+                next: (e) => {
+                    e &&
+                        ((this.statusMessage =
+                            "Product is removed successfully!"),
+                        (this.sflStatus = !1),
+                        this.setMsgTimeOut()),
+                        this.checkSFLStatus();
+                },
+                error: (e) => {
+                    console.error("Error removing data", e);
+                },
+            });
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(u(fe), u(ee));
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["app-product-stores"]],
+            decls: 17,
+            vars: 10,
+            consts: [
+                ["saveForLaterBtn", ""],
+                ["storeLink", ""],
+                [1, "product-details-container"],
+                [1, "left-column"],
+                [1, "image", 3, "src", "alt"],
+                [4, "ngIf", "ngIfElse"],
+                [1, "status-message"],
+                [1, "right-column"],
+                ["mat-table", "", 1, "table", 3, "dataSource"],
+                [
+                    "class",
+                    "description-cell",
+                    3,
+                    "matColumnDef",
+                    4,
+                    "ngFor",
+                    "ngForOf",
+                ],
+                ["mat-header-row", "", 4, "matHeaderRowDef"],
+                ["mat-row", "", 4, "matRowDef", "matRowDefColumns"],
+                ["type", "button", 1, "button", "delete-button", 3, "click"],
+                [1, "icon"],
+                ["type", "submit", 1, "button", 3, "click"],
+                [1, "description-cell", 3, "matColumnDef"],
+                ["mat-header-cell", "", 4, "matHeaderCellDef"],
+                ["mat-cell", "", 4, "matCellDef"],
+                ["mat-header-cell", ""],
+                ["mat-cell", ""],
+                ["target", "_blank", 3, "href"],
+                ["mat-header-row", ""],
+                ["mat-row", ""],
+            ],
+            template: function (i, r) {
+                if (
+                    (i & 1 &&
+                        (x(0, "div", 2)(1, "div", 3)(2, "h1")(3, "strong"),
+                        F(4),
+                        _()(),
+                        H(5, "img", 4),
+                        x(6, "div"),
+                        ot(7, ag, 5, 0, "ng-container", 5)(
+                            8,
+                            lg,
+                            4,
+                            0,
+                            "ng-template",
+                            null,
+                            0,
+                            Ke
+                        ),
+                        _(),
+                        x(10, "div", 6),
+                        F(11),
+                        _()(),
+                        x(12, "div", 7)(13, "table", 8),
+                        ot(14, mg, 3, 1, "ng-container", 9)(
+                            15,
+                            fg,
+                            1,
+                            0,
+                            "tr",
+                            10
+                        )(16, pg, 1, 0, "tr", 11),
+                        _()()()),
+                    i & 2)
+                ) {
+                    let s = he(9);
+                    R(4),
+                        te(
+                            r.productStores == null
+                                ? null
+                                : r.productStores.productName
+                        ),
+                        R(),
+                        Ze(
+                            "alt",
+                            r.productStores == null
+                                ? null
+                                : r.productStores.productName
+                        ),
+                        L(
+                            "src",
+                            r.productStores == null
+                                ? null
+                                : r.productStores.productImage,
+                            Se
+                        ),
+                        R(2),
+                        L("ngIf", r.sflStatus)("ngIfElse", s),
+                        R(4),
+                        te(r.statusMessage),
+                        R(2),
+                        L("dataSource", r.tableData),
+                        R(),
+                        L("ngForOf", r.tableColumns),
+                        R(),
+                        L("matHeaderRowDef", r.tableColumns),
+                        R(),
+                        L("matRowDefColumns", r.tableColumns);
+                }
+            },
+            dependencies: [Qe, Ht, er, Nd, Ld, Bd, jd, Pd, Ud, Vd, zd, Hd, $d],
+            styles: [
+                ".product-details-container[_ngcontent-%COMP%]{display:flex;color:#578413}.left-column[_ngcontent-%COMP%]{flex:1;padding:20px;border-right:1px solid #ccc}.right-column[_ngcontent-%COMP%]{flex:2;padding:20px}.table[_ngcontent-%COMP%]{width:100%;border-spacing:0}.button[_ngcontent-%COMP%]{font-weight:100;font-size:1rem;background-color:#5f7cd1;color:#fff;padding:.75rem 1rem;border-radius:10px;cursor:pointer;display:flex;align-items:center}.delete-button[_ngcontent-%COMP%]{background-color:tomato}.icon[_ngcontent-%COMP%]{margin-right:.5rem}.description-cell[_ngcontent-%COMP%]{overflow:hidden;text-overflow:ellipsis;font-size:1rem}.image[_ngcontent-%COMP%]{margin-top:50px;max-width:100%;height:auto;margin-bottom:70px}.status-message[_ngcontent-%COMP%]{margin-top:20px}.success[_ngcontent-%COMP%]{color:green}.error[_ngcontent-%COMP%]{color:red}",
+            ],
+        }));
+    let n = t;
+    return n;
+})();
+var gg = [
+        { path: "", component: ed },
+        { path: "SFL", component: Gd },
+        { path: "Account", component: qd },
+        { path: "Product-Stores/:productID", component: iu },
+    ],
+    nu = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Rs.forRoot(gg), Rs] }));
+        let n = t;
+        return n;
+    })();
+var bg = "@",
+    vg = (() => {
+        let t = class t {
+            constructor(e, i, r, s, a) {
+                (this.doc = e),
+                    (this.delegate = i),
+                    (this.zone = r),
+                    (this.animationType = s),
+                    (this.moduleImpl = a),
+                    (this._rendererFactoryPromise = null),
+                    (this.scheduler = g(qa, { optional: !0 }));
+            }
+            ngOnDestroy() {
+                this._engine?.flush();
+            }
+            loadImpl() {
+                return (this.moduleImpl ?? import("./chunk-LWJOV7RA.js"))
+                    .catch((i) => {
+                        throw new $(5300, !1);
+                    })
+                    .then(
+                        ({
+                            ɵcreateEngine: i,
+                            ɵAnimationRendererFactory: r,
+                        }) => {
+                            this._engine = i(
+                                this.animationType,
+                                this.doc,
+                                this.scheduler
+                            );
+                            let s = new r(
+                                this.delegate,
+                                this._engine,
+                                this.zone
+                            );
+                            return (this.delegate = s), s;
+                        }
+                    );
+            }
+            createRenderer(e, i) {
+                let r = this.delegate.createRenderer(e, i);
+                if (r.ɵtype === 0) return r;
+                typeof r.throwOnSyntheticProps == "boolean" &&
+                    (r.throwOnSyntheticProps = !1);
+                let s = new ma(r);
+                return (
+                    i?.data?.animation &&
+                        !this._rendererFactoryPromise &&
+                        (this._rendererFactoryPromise = this.loadImpl()),
+                    this._rendererFactoryPromise
+                        ?.then((a) => {
+                            let l = a.createRenderer(e, i);
+                            s.use(l);
+                        })
+                        .catch((a) => {
+                            s.use(r);
+                        }),
+                    s
+                );
+            }
+            begin() {
+                this.delegate.begin?.();
+            }
+            end() {
+                this.delegate.end?.();
+            }
+            whenRenderingDone() {
+                return this.delegate.whenRenderingDone?.() ?? Promise.resolve();
+            }
+        };
+        (t.ɵfac = function (i) {
+            Ie();
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac }));
+        let n = t;
+        return n;
+    })(),
+    ma = class {
+        constructor(t) {
+            (this.delegate = t), (this.replay = []), (this.ɵtype = 1);
+        }
+        use(t) {
+            if (((this.delegate = t), this.replay !== null)) {
+                for (let o of this.replay) o(t);
+                this.replay = null;
+            }
+        }
+        get data() {
+            return this.delegate.data;
+        }
+        destroy() {
+            (this.replay = null), this.delegate.destroy();
+        }
+        createElement(t, o) {
+            return this.delegate.createElement(t, o);
+        }
+        createComment(t) {
+            return this.delegate.createComment(t);
+        }
+        createText(t) {
+            return this.delegate.createText(t);
+        }
+        get destroyNode() {
+            return this.delegate.destroyNode;
+        }
+        appendChild(t, o) {
+            this.delegate.appendChild(t, o);
+        }
+        insertBefore(t, o, e, i) {
+            this.delegate.insertBefore(t, o, e, i);
+        }
+        removeChild(t, o, e) {
+            this.delegate.removeChild(t, o, e);
+        }
+        selectRootElement(t, o) {
+            return this.delegate.selectRootElement(t, o);
+        }
+        parentNode(t) {
+            return this.delegate.parentNode(t);
+        }
+        nextSibling(t) {
+            return this.delegate.nextSibling(t);
+        }
+        setAttribute(t, o, e, i) {
+            this.delegate.setAttribute(t, o, e, i);
+        }
+        removeAttribute(t, o, e) {
+            this.delegate.removeAttribute(t, o, e);
+        }
+        addClass(t, o) {
+            this.delegate.addClass(t, o);
+        }
+        removeClass(t, o) {
+            this.delegate.removeClass(t, o);
+        }
+        setStyle(t, o, e, i) {
+            this.delegate.setStyle(t, o, e, i);
+        }
+        removeStyle(t, o, e) {
+            this.delegate.removeStyle(t, o, e);
+        }
+        setProperty(t, o, e) {
+            this.shouldReplay(o) &&
+                this.replay.push((i) => i.setProperty(t, o, e)),
+                this.delegate.setProperty(t, o, e);
+        }
+        setValue(t, o) {
+            this.delegate.setValue(t, o);
+        }
+        listen(t, o, e) {
+            return (
+                this.shouldReplay(o) &&
+                    this.replay.push((i) => i.listen(t, o, e)),
+                this.delegate.listen(t, o, e)
+            );
+        }
+        shouldReplay(t) {
+            return this.replay !== null && t.startsWith(bg);
+        }
+    };
+function ou(n = "animations") {
+    return (
+        gr("NgAsyncAnimations"),
+        Ge([
+            {
+                provide: Pn,
+                useFactory: (t, o, e) => new vg(t, o, e, n),
+                deps: [T, to, I],
+            },
+            {
+                provide: Bt,
+                useValue: n === "noop" ? "NoopAnimations" : "BrowserAnimations",
+            },
+        ])
+    );
+}
+var _g = ["*", [["mat-toolbar-row"]]],
+    yg = ["*", "mat-toolbar-row"],
+    xg = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [["mat-toolbar-row"]],
+                hostAttrs: [1, "mat-toolbar-row"],
+                exportAs: ["matToolbarRow"],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    ru = (() => {
+        let t = class t {
+            constructor(e, i, r) {
+                (this._elementRef = e),
+                    (this._platform = i),
+                    (this._document = r);
+            }
+            ngAfterViewInit() {
+                this._platform.isBrowser &&
+                    (this._checkToolbarMixedModes(),
+                    this._toolbarRows.changes.subscribe(() =>
+                        this._checkToolbarMixedModes()
+                    ));
+            }
+            _checkToolbarMixedModes() {
+                this._toolbarRows.length;
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(A), u(J), u(T));
+        }),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["mat-toolbar"]],
+                contentQueries: function (i, r, s) {
+                    if ((i & 1 && gt(s, xg, 5), i & 2)) {
+                        let a;
+                        at((a = lt())) && (r._toolbarRows = a);
+                    }
+                },
+                hostAttrs: [1, "mat-toolbar"],
+                hostVars: 6,
+                hostBindings: function (i, r) {
+                    i & 2 &&
+                        (Jt(r.color ? "mat-" + r.color : ""),
+                        st(
+                            "mat-toolbar-multiple-rows",
+                            r._toolbarRows.length > 0
+                        )(
+                            "mat-toolbar-single-row",
+                            r._toolbarRows.length === 0
+                        ));
+                },
+                inputs: { color: "color" },
+                exportAs: ["matToolbar"],
+                standalone: !0,
+                features: [tt],
+                ngContentSelectors: yg,
+                decls: 2,
+                vars: 0,
+                template: function (i, r) {
+                    i & 1 && (pt(_g), K(0), K(1, 1));
+                },
+                styles: [
+                    ".mat-toolbar{background:var(--mat-toolbar-container-background-color);color:var(--mat-toolbar-container-text-color)}.mat-toolbar,.mat-toolbar h1,.mat-toolbar h2,.mat-toolbar h3,.mat-toolbar h4,.mat-toolbar h5,.mat-toolbar h6{font-family:var(--mat-toolbar-title-text-font);font-size:var(--mat-toolbar-title-text-size);line-height:var(--mat-toolbar-title-text-line-height);font-weight:var(--mat-toolbar-title-text-weight);letter-spacing:var(--mat-toolbar-title-text-tracking);margin:0}.cdk-high-contrast-active .mat-toolbar{outline:solid 1px}.mat-toolbar .mat-form-field-underline,.mat-toolbar .mat-form-field-ripple,.mat-toolbar .mat-focused .mat-form-field-ripple{background-color:currentColor}.mat-toolbar .mat-form-field-label,.mat-toolbar .mat-focused .mat-form-field-label,.mat-toolbar .mat-select-value,.mat-toolbar .mat-select-arrow,.mat-toolbar .mat-form-field.mat-focused .mat-select-arrow{color:inherit}.mat-toolbar .mat-input-element{caret-color:currentColor}.mat-toolbar .mat-mdc-button-base.mat-mdc-button-base.mat-unthemed{--mdc-text-button-label-text-color:var(--mat-toolbar-container-text-color);--mdc-outlined-button-label-text-color:var(--mat-toolbar-container-text-color)}.mat-toolbar-row,.mat-toolbar-single-row{display:flex;box-sizing:border-box;padding:0 16px;width:100%;flex-direction:row;align-items:center;white-space:nowrap;height:var(--mat-toolbar-standard-height)}@media(max-width: 599px){.mat-toolbar-row,.mat-toolbar-single-row{height:var(--mat-toolbar-mobile-height)}}.mat-toolbar-multiple-rows{display:flex;box-sizing:border-box;flex-direction:column;width:100%;min-height:var(--mat-toolbar-standard-height)}@media(max-width: 599px){.mat-toolbar-multiple-rows{min-height:var(--mat-toolbar-mobile-height)}}",
+                ],
+                encapsulation: 2,
+                changeDetection: 0,
+            }));
+        let n = t;
+        return n;
+    })();
+var su = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({ imports: [Y, Y] }));
+    let n = t;
+    return n;
+})();
+var Cg = ["mat-button", ""],
+    Dg = [
+        [
+            ["", 8, "material-icons", 3, "iconPositionEnd", ""],
+            ["mat-icon", 3, "iconPositionEnd", ""],
+            ["", "matButtonIcon", "", 3, "iconPositionEnd", ""],
+        ],
+        "*",
+        [
+            ["", "iconPositionEnd", "", 8, "material-icons"],
+            ["mat-icon", "iconPositionEnd", ""],
+            ["", "matButtonIcon", "", "iconPositionEnd", ""],
+        ],
+    ],
+    Eg = [
+        ".material-icons:not([iconPositionEnd]), mat-icon:not([iconPositionEnd]), [matButtonIcon]:not([iconPositionEnd])",
+        "*",
+        ".material-icons[iconPositionEnd], mat-icon[iconPositionEnd], [matButtonIcon][iconPositionEnd]",
+    ],
+    Sg =
+        '.mdc-touch-target-wrapper{display:inline}.mdc-elevation-overlay{position:absolute;border-radius:inherit;pointer-events:none;opacity:var(--mdc-elevation-overlay-opacity, 0);transition:opacity 280ms cubic-bezier(0.4, 0, 0.2, 1)}.mdc-button{position:relative;display:inline-flex;align-items:center;justify-content:center;box-sizing:border-box;min-width:64px;border:none;outline:none;line-height:inherit;user-select:none;-webkit-appearance:none;overflow:visible;vertical-align:middle;background:rgba(0,0,0,0)}.mdc-button .mdc-elevation-overlay{width:100%;height:100%;top:0;left:0}.mdc-button::-moz-focus-inner{padding:0;border:0}.mdc-button:active{outline:none}.mdc-button:hover{cursor:pointer}.mdc-button:disabled{cursor:default;pointer-events:none}.mdc-button[hidden]{display:none}.mdc-button .mdc-button__icon{margin-left:0;margin-right:8px;display:inline-block;position:relative;vertical-align:top}[dir=rtl] .mdc-button .mdc-button__icon,.mdc-button .mdc-button__icon[dir=rtl]{margin-left:8px;margin-right:0}.mdc-button .mdc-button__progress-indicator{font-size:0;position:absolute;transform:translate(-50%, -50%);top:50%;left:50%;line-height:initial}.mdc-button .mdc-button__label{position:relative}.mdc-button .mdc-button__focus-ring{pointer-events:none;border:2px solid rgba(0,0,0,0);border-radius:6px;box-sizing:content-box;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:calc(100% + 4px);width:calc(100% + 4px);display:none}@media screen and (forced-colors: active){.mdc-button .mdc-button__focus-ring{border-color:CanvasText}}.mdc-button .mdc-button__focus-ring::after{content:"";border:2px solid rgba(0,0,0,0);border-radius:8px;display:block;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:calc(100% + 4px);width:calc(100% + 4px)}@media screen and (forced-colors: active){.mdc-button .mdc-button__focus-ring::after{border-color:CanvasText}}@media screen and (forced-colors: active){.mdc-button.mdc-ripple-upgraded--background-focused .mdc-button__focus-ring,.mdc-button:not(.mdc-ripple-upgraded):focus .mdc-button__focus-ring{display:block}}.mdc-button .mdc-button__touch{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%)}.mdc-button__label+.mdc-button__icon{margin-left:8px;margin-right:0}[dir=rtl] .mdc-button__label+.mdc-button__icon,.mdc-button__label+.mdc-button__icon[dir=rtl]{margin-left:0;margin-right:8px}svg.mdc-button__icon{fill:currentColor}.mdc-button--touch{margin-top:6px;margin-bottom:6px}.mdc-button{padding:0 8px 0 8px}.mdc-button--unelevated{transition:box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1);padding:0 16px 0 16px}.mdc-button--unelevated.mdc-button--icon-trailing{padding:0 12px 0 16px}.mdc-button--unelevated.mdc-button--icon-leading{padding:0 16px 0 12px}.mdc-button--raised{transition:box-shadow 280ms cubic-bezier(0.4, 0, 0.2, 1);padding:0 16px 0 16px}.mdc-button--raised.mdc-button--icon-trailing{padding:0 12px 0 16px}.mdc-button--raised.mdc-button--icon-leading{padding:0 16px 0 12px}.mdc-button--outlined{border-style:solid;transition:border 280ms cubic-bezier(0.4, 0, 0.2, 1)}.mdc-button--outlined .mdc-button__ripple{border-style:solid;border-color:rgba(0,0,0,0)}.mat-mdc-button{font-family:var(--mdc-text-button-label-text-font);font-size:var(--mdc-text-button-label-text-size);letter-spacing:var(--mdc-text-button-label-text-tracking);font-weight:var(--mdc-text-button-label-text-weight);text-transform:var(--mdc-text-button-label-text-transform);height:var(--mdc-text-button-container-height);border-radius:var(--mdc-text-button-container-shape);padding:0 var(--mat-text-button-horizontal-padding, 8px)}.mat-mdc-button:not(:disabled){color:var(--mdc-text-button-label-text-color)}.mat-mdc-button:disabled{color:var(--mdc-text-button-disabled-label-text-color)}.mat-mdc-button .mdc-button__ripple{border-radius:var(--mdc-text-button-container-shape)}.mat-mdc-button:has(.material-icons,mat-icon,[matButtonIcon]){padding:0 var(--mat-text-button-with-icon-horizontal-padding, 8px)}.mat-mdc-button>.mat-icon{margin-right:var(--mat-text-button-icon-spacing, 8px);margin-left:var(--mat-text-button-icon-offset, 0)}[dir=rtl] .mat-mdc-button>.mat-icon{margin-right:var(--mat-text-button-icon-offset, 0);margin-left:var(--mat-text-button-icon-spacing, 8px)}.mat-mdc-button .mdc-button__label+.mat-icon{margin-right:var(--mat-text-button-icon-offset, 0);margin-left:var(--mat-text-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-button .mdc-button__label+.mat-icon{margin-right:var(--mat-text-button-icon-spacing, 8px);margin-left:var(--mat-text-button-icon-offset, 0)}.mat-mdc-button .mat-ripple-element{background-color:var(--mat-text-button-ripple-color)}.mat-mdc-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-text-button-state-layer-color)}.mat-mdc-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-text-button-disabled-state-layer-color)}.mat-mdc-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-text-button-hover-state-layer-opacity)}.mat-mdc-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-text-button-focus-state-layer-opacity)}.mat-mdc-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-text-button-pressed-state-layer-opacity)}.mat-mdc-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-text-button-touch-target-display)}.mat-mdc-button[disabled],.mat-mdc-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-text-button-disabled-label-text-color)}.mat-mdc-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-unelevated-button{font-family:var(--mdc-filled-button-label-text-font);font-size:var(--mdc-filled-button-label-text-size);letter-spacing:var(--mdc-filled-button-label-text-tracking);font-weight:var(--mdc-filled-button-label-text-weight);text-transform:var(--mdc-filled-button-label-text-transform);height:var(--mdc-filled-button-container-height);border-radius:var(--mdc-filled-button-container-shape);padding:0 var(--mat-filled-button-horizontal-padding, 16px)}.mat-mdc-unelevated-button:not(:disabled){background-color:var(--mdc-filled-button-container-color)}.mat-mdc-unelevated-button:disabled{background-color:var(--mdc-filled-button-disabled-container-color)}.mat-mdc-unelevated-button:not(:disabled){color:var(--mdc-filled-button-label-text-color)}.mat-mdc-unelevated-button:disabled{color:var(--mdc-filled-button-disabled-label-text-color)}.mat-mdc-unelevated-button .mdc-button__ripple{border-radius:var(--mdc-filled-button-container-shape)}.mat-mdc-unelevated-button>.mat-icon{margin-right:var(--mat-filled-button-icon-spacing, 8px);margin-left:var(--mat-filled-button-icon-offset, -4px)}[dir=rtl] .mat-mdc-unelevated-button>.mat-icon{margin-right:var(--mat-filled-button-icon-offset, -4px);margin-left:var(--mat-filled-button-icon-spacing, 8px)}.mat-mdc-unelevated-button .mdc-button__label+.mat-icon{margin-right:var(--mat-filled-button-icon-offset, -4px);margin-left:var(--mat-filled-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-unelevated-button .mdc-button__label+.mat-icon{margin-right:var(--mat-filled-button-icon-spacing, 8px);margin-left:var(--mat-filled-button-icon-offset, -4px)}.mat-mdc-unelevated-button .mat-ripple-element{background-color:var(--mat-filled-button-ripple-color)}.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-filled-button-state-layer-color)}.mat-mdc-unelevated-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-filled-button-disabled-state-layer-color)}.mat-mdc-unelevated-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-filled-button-hover-state-layer-opacity)}.mat-mdc-unelevated-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-filled-button-focus-state-layer-opacity)}.mat-mdc-unelevated-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-filled-button-pressed-state-layer-opacity)}.mat-mdc-unelevated-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-filled-button-touch-target-display)}.mat-mdc-unelevated-button[disabled],.mat-mdc-unelevated-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-filled-button-disabled-label-text-color);background-color:var(--mdc-filled-button-disabled-container-color)}.mat-mdc-unelevated-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-raised-button{font-family:var(--mdc-protected-button-label-text-font);font-size:var(--mdc-protected-button-label-text-size);letter-spacing:var(--mdc-protected-button-label-text-tracking);font-weight:var(--mdc-protected-button-label-text-weight);text-transform:var(--mdc-protected-button-label-text-transform);height:var(--mdc-protected-button-container-height);border-radius:var(--mdc-protected-button-container-shape);padding:0 var(--mat-protected-button-horizontal-padding, 16px);box-shadow:var(--mdc-protected-button-container-elevation-shadow)}.mat-mdc-raised-button:not(:disabled){background-color:var(--mdc-protected-button-container-color)}.mat-mdc-raised-button:disabled{background-color:var(--mdc-protected-button-disabled-container-color)}.mat-mdc-raised-button:not(:disabled){color:var(--mdc-protected-button-label-text-color)}.mat-mdc-raised-button:disabled{color:var(--mdc-protected-button-disabled-label-text-color)}.mat-mdc-raised-button .mdc-button__ripple{border-radius:var(--mdc-protected-button-container-shape)}.mat-mdc-raised-button>.mat-icon{margin-right:var(--mat-protected-button-icon-spacing, 8px);margin-left:var(--mat-protected-button-icon-offset, -4px)}[dir=rtl] .mat-mdc-raised-button>.mat-icon{margin-right:var(--mat-protected-button-icon-offset, -4px);margin-left:var(--mat-protected-button-icon-spacing, 8px)}.mat-mdc-raised-button .mdc-button__label+.mat-icon{margin-right:var(--mat-protected-button-icon-offset, -4px);margin-left:var(--mat-protected-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-raised-button .mdc-button__label+.mat-icon{margin-right:var(--mat-protected-button-icon-spacing, 8px);margin-left:var(--mat-protected-button-icon-offset, -4px)}.mat-mdc-raised-button .mat-ripple-element{background-color:var(--mat-protected-button-ripple-color)}.mat-mdc-raised-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-protected-button-state-layer-color)}.mat-mdc-raised-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-protected-button-disabled-state-layer-color)}.mat-mdc-raised-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-protected-button-hover-state-layer-opacity)}.mat-mdc-raised-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-protected-button-focus-state-layer-opacity)}.mat-mdc-raised-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-protected-button-pressed-state-layer-opacity)}.mat-mdc-raised-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-protected-button-touch-target-display)}.mat-mdc-raised-button:hover{box-shadow:var(--mdc-protected-button-hover-container-elevation-shadow)}.mat-mdc-raised-button:focus{box-shadow:var(--mdc-protected-button-focus-container-elevation-shadow)}.mat-mdc-raised-button:active,.mat-mdc-raised-button:focus:active{box-shadow:var(--mdc-protected-button-pressed-container-elevation-shadow)}.mat-mdc-raised-button[disabled],.mat-mdc-raised-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-protected-button-disabled-label-text-color);background-color:var(--mdc-protected-button-disabled-container-color)}.mat-mdc-raised-button[disabled].mat-mdc-button-disabled,.mat-mdc-raised-button.mat-mdc-button-disabled.mat-mdc-button-disabled{box-shadow:var(--mdc-protected-button-disabled-container-elevation-shadow)}.mat-mdc-raised-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-outlined-button{font-family:var(--mdc-outlined-button-label-text-font);font-size:var(--mdc-outlined-button-label-text-size);letter-spacing:var(--mdc-outlined-button-label-text-tracking);font-weight:var(--mdc-outlined-button-label-text-weight);text-transform:var(--mdc-outlined-button-label-text-transform);height:var(--mdc-outlined-button-container-height);border-radius:var(--mdc-outlined-button-container-shape);padding:0 15px 0 15px;border-width:var(--mdc-outlined-button-outline-width);padding:0 var(--mat-outlined-button-horizontal-padding, 15px)}.mat-mdc-outlined-button:not(:disabled){color:var(--mdc-outlined-button-label-text-color)}.mat-mdc-outlined-button:disabled{color:var(--mdc-outlined-button-disabled-label-text-color)}.mat-mdc-outlined-button .mdc-button__ripple{border-radius:var(--mdc-outlined-button-container-shape)}.mat-mdc-outlined-button:not(:disabled){border-color:var(--mdc-outlined-button-outline-color)}.mat-mdc-outlined-button:disabled{border-color:var(--mdc-outlined-button-disabled-outline-color)}.mat-mdc-outlined-button.mdc-button--icon-trailing{padding:0 11px 0 15px}.mat-mdc-outlined-button.mdc-button--icon-leading{padding:0 15px 0 11px}.mat-mdc-outlined-button .mdc-button__ripple{top:-1px;left:-1px;bottom:-1px;right:-1px;border-width:var(--mdc-outlined-button-outline-width)}.mat-mdc-outlined-button .mdc-button__touch{left:calc(-1 * var(--mdc-outlined-button-outline-width));width:calc(100% + 2 * var(--mdc-outlined-button-outline-width))}.mat-mdc-outlined-button>.mat-icon{margin-right:var(--mat-outlined-button-icon-spacing, 8px);margin-left:var(--mat-outlined-button-icon-offset, -4px)}[dir=rtl] .mat-mdc-outlined-button>.mat-icon{margin-right:var(--mat-outlined-button-icon-offset, -4px);margin-left:var(--mat-outlined-button-icon-spacing, 8px)}.mat-mdc-outlined-button .mdc-button__label+.mat-icon{margin-right:var(--mat-outlined-button-icon-offset, -4px);margin-left:var(--mat-outlined-button-icon-spacing, 8px)}[dir=rtl] .mat-mdc-outlined-button .mdc-button__label+.mat-icon{margin-right:var(--mat-outlined-button-icon-spacing, 8px);margin-left:var(--mat-outlined-button-icon-offset, -4px)}.mat-mdc-outlined-button .mat-ripple-element{background-color:var(--mat-outlined-button-ripple-color)}.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-outlined-button-state-layer-color)}.mat-mdc-outlined-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-outlined-button-disabled-state-layer-color)}.mat-mdc-outlined-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-outlined-button-hover-state-layer-opacity)}.mat-mdc-outlined-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-outlined-button-focus-state-layer-opacity)}.mat-mdc-outlined-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-outlined-button-pressed-state-layer-opacity)}.mat-mdc-outlined-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:0;right:0;transform:translateY(-50%);display:var(--mat-outlined-button-touch-target-display)}.mat-mdc-outlined-button[disabled],.mat-mdc-outlined-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-outlined-button-disabled-label-text-color);border-color:var(--mdc-outlined-button-disabled-outline-color)}.mat-mdc-outlined-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-button-base{text-decoration:none}.mat-mdc-button,.mat-mdc-unelevated-button,.mat-mdc-raised-button,.mat-mdc-outlined-button{-webkit-tap-highlight-color:rgba(0,0,0,0)}.mat-mdc-button .mat-mdc-button-ripple,.mat-mdc-button .mat-mdc-button-persistent-ripple,.mat-mdc-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button .mat-mdc-button-ripple,.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple,.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button .mat-mdc-button-ripple,.mat-mdc-raised-button .mat-mdc-button-persistent-ripple,.mat-mdc-raised-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button .mat-mdc-button-ripple,.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple,.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple::before{top:0;left:0;right:0;bottom:0;position:absolute;pointer-events:none;border-radius:inherit}.mat-mdc-button .mat-mdc-button-ripple,.mat-mdc-unelevated-button .mat-mdc-button-ripple,.mat-mdc-raised-button .mat-mdc-button-ripple,.mat-mdc-outlined-button .mat-mdc-button-ripple{overflow:hidden}.mat-mdc-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-unelevated-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-raised-button .mat-mdc-button-persistent-ripple::before,.mat-mdc-outlined-button .mat-mdc-button-persistent-ripple::before{content:"";opacity:0}.mat-mdc-button .mdc-button__label,.mat-mdc-unelevated-button .mdc-button__label,.mat-mdc-raised-button .mdc-button__label,.mat-mdc-outlined-button .mdc-button__label{z-index:1}.mat-mdc-button .mat-mdc-focus-indicator,.mat-mdc-unelevated-button .mat-mdc-focus-indicator,.mat-mdc-raised-button .mat-mdc-focus-indicator,.mat-mdc-outlined-button .mat-mdc-focus-indicator{top:0;left:0;right:0;bottom:0;position:absolute}.mat-mdc-button:focus .mat-mdc-focus-indicator::before,.mat-mdc-unelevated-button:focus .mat-mdc-focus-indicator::before,.mat-mdc-raised-button:focus .mat-mdc-focus-indicator::before,.mat-mdc-outlined-button:focus .mat-mdc-focus-indicator::before{content:""}.mat-mdc-button._mat-animation-noopable,.mat-mdc-unelevated-button._mat-animation-noopable,.mat-mdc-raised-button._mat-animation-noopable,.mat-mdc-outlined-button._mat-animation-noopable{transition:none !important;animation:none !important}.mat-mdc-button>.mat-icon,.mat-mdc-unelevated-button>.mat-icon,.mat-mdc-raised-button>.mat-icon,.mat-mdc-outlined-button>.mat-icon{display:inline-block;position:relative;vertical-align:top;font-size:1.125rem;height:1.125rem;width:1.125rem}.mat-mdc-outlined-button .mat-mdc-button-ripple,.mat-mdc-outlined-button .mdc-button__ripple{top:-1px;left:-1px;bottom:-1px;right:-1px;border-width:-1px}.mat-mdc-unelevated-button .mat-mdc-focus-indicator::before,.mat-mdc-raised-button .mat-mdc-focus-indicator::before{margin:calc(calc(var(--mat-mdc-focus-indicator-border-width, 3px) + 2px)*-1)}.mat-mdc-outlined-button .mat-mdc-focus-indicator::before{margin:calc(calc(var(--mat-mdc-focus-indicator-border-width, 3px) + 3px)*-1)}',
+    au =
+        ".cdk-high-contrast-active .mat-mdc-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-unelevated-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-raised-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-outlined-button:not(.mdc-button--outlined),.cdk-high-contrast-active .mat-mdc-icon-button{outline:solid 1px}";
+var Ig = ["mat-icon-button", ""],
+    Rg = ["*"],
+    Mg =
+        '.mdc-icon-button{display:inline-block;position:relative;box-sizing:border-box;border:none;outline:none;background-color:rgba(0,0,0,0);fill:currentColor;color:inherit;text-decoration:none;cursor:pointer;user-select:none;z-index:0;overflow:visible}.mdc-icon-button .mdc-icon-button__touch{position:absolute;top:50%;height:48px;left:50%;width:48px;transform:translate(-50%, -50%)}@media screen and (forced-colors: active){.mdc-icon-button.mdc-ripple-upgraded--background-focused .mdc-icon-button__focus-ring,.mdc-icon-button:not(.mdc-ripple-upgraded):focus .mdc-icon-button__focus-ring{display:block}}.mdc-icon-button:disabled{cursor:default;pointer-events:none}.mdc-icon-button[hidden]{display:none}.mdc-icon-button--display-flex{align-items:center;display:inline-flex;justify-content:center}.mdc-icon-button__focus-ring{pointer-events:none;border:2px solid rgba(0,0,0,0);border-radius:6px;box-sizing:content-box;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:100%;width:100%;display:none}@media screen and (forced-colors: active){.mdc-icon-button__focus-ring{border-color:CanvasText}}.mdc-icon-button__focus-ring::after{content:"";border:2px solid rgba(0,0,0,0);border-radius:8px;display:block;position:absolute;top:50%;left:50%;transform:translate(-50%, -50%);height:calc(100% + 4px);width:calc(100% + 4px)}@media screen and (forced-colors: active){.mdc-icon-button__focus-ring::after{border-color:CanvasText}}.mdc-icon-button__icon{display:inline-block}.mdc-icon-button__icon.mdc-icon-button__icon--on{display:none}.mdc-icon-button--on .mdc-icon-button__icon{display:none}.mdc-icon-button--on .mdc-icon-button__icon.mdc-icon-button__icon--on{display:inline-block}.mdc-icon-button__link{height:100%;left:0;outline:none;position:absolute;top:0;width:100%}.mat-mdc-icon-button{color:var(--mdc-icon-button-icon-color)}.mat-mdc-icon-button .mdc-button__icon{font-size:var(--mdc-icon-button-icon-size)}.mat-mdc-icon-button svg,.mat-mdc-icon-button img{width:var(--mdc-icon-button-icon-size);height:var(--mdc-icon-button-icon-size)}.mat-mdc-icon-button:disabled{color:var(--mdc-icon-button-disabled-icon-color)}.mat-mdc-icon-button{border-radius:50%;flex-shrink:0;text-align:center;width:var(--mdc-icon-button-state-layer-size, 48px);height:var(--mdc-icon-button-state-layer-size, 48px);padding:calc(calc(var(--mdc-icon-button-state-layer-size, 48px) - var(--mdc-icon-button-icon-size, 24px)) / 2);font-size:var(--mdc-icon-button-icon-size);-webkit-tap-highlight-color:rgba(0,0,0,0)}.mat-mdc-icon-button svg{vertical-align:baseline}.mat-mdc-icon-button[disabled],.mat-mdc-icon-button.mat-mdc-button-disabled{cursor:default;pointer-events:none;color:var(--mdc-icon-button-disabled-icon-color)}.mat-mdc-icon-button.mat-mdc-button-disabled-interactive{pointer-events:auto}.mat-mdc-icon-button .mat-mdc-button-ripple,.mat-mdc-icon-button .mat-mdc-button-persistent-ripple,.mat-mdc-icon-button .mat-mdc-button-persistent-ripple::before{top:0;left:0;right:0;bottom:0;position:absolute;pointer-events:none;border-radius:inherit}.mat-mdc-icon-button .mat-mdc-button-ripple{overflow:hidden}.mat-mdc-icon-button .mat-mdc-button-persistent-ripple::before{content:"";opacity:0}.mat-mdc-icon-button .mdc-button__label{z-index:1}.mat-mdc-icon-button .mat-mdc-focus-indicator{top:0;left:0;right:0;bottom:0;position:absolute}.mat-mdc-icon-button:focus .mat-mdc-focus-indicator::before{content:""}.mat-mdc-icon-button .mat-ripple-element{background-color:var(--mat-icon-button-ripple-color)}.mat-mdc-icon-button .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-icon-button-state-layer-color)}.mat-mdc-icon-button.mat-mdc-button-disabled .mat-mdc-button-persistent-ripple::before{background-color:var(--mat-icon-button-disabled-state-layer-color)}.mat-mdc-icon-button:hover .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-icon-button-hover-state-layer-opacity)}.mat-mdc-icon-button.cdk-program-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-icon-button.cdk-keyboard-focused .mat-mdc-button-persistent-ripple::before,.mat-mdc-icon-button.mat-mdc-button-disabled-interactive:focus .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-icon-button-focus-state-layer-opacity)}.mat-mdc-icon-button:active .mat-mdc-button-persistent-ripple::before{opacity:var(--mat-icon-button-pressed-state-layer-opacity)}.mat-mdc-icon-button .mat-mdc-button-touch-target{position:absolute;top:50%;height:48px;left:50%;width:48px;transform:translate(-50%, -50%);display:var(--mat-icon-button-touch-target-display)}.mat-mdc-icon-button._mat-animation-noopable{transition:none !important;animation:none !important}.mat-mdc-icon-button .mat-mdc-button-persistent-ripple{border-radius:50%}.mat-mdc-icon-button.mat-unthemed:not(.mdc-ripple-upgraded):focus::before,.mat-mdc-icon-button.mat-primary:not(.mdc-ripple-upgraded):focus::before,.mat-mdc-icon-button.mat-accent:not(.mdc-ripple-upgraded):focus::before,.mat-mdc-icon-button.mat-warn:not(.mdc-ripple-upgraded):focus::before{background:rgba(0,0,0,0);opacity:1}',
+    kg = new C("MAT_BUTTON_CONFIG");
+var Tg = [
+        {
+            attribute: "mat-button",
+            mdcClasses: ["mdc-button", "mat-mdc-button"],
+        },
+        {
+            attribute: "mat-flat-button",
+            mdcClasses: [
+                "mdc-button",
+                "mdc-button--unelevated",
+                "mat-mdc-unelevated-button",
+            ],
+        },
+        {
+            attribute: "mat-raised-button",
+            mdcClasses: [
+                "mdc-button",
+                "mdc-button--raised",
+                "mat-mdc-raised-button",
+            ],
+        },
+        {
+            attribute: "mat-stroked-button",
+            mdcClasses: [
+                "mdc-button",
+                "mdc-button--outlined",
+                "mat-mdc-outlined-button",
+            ],
+        },
+        { attribute: "mat-fab", mdcClasses: ["mdc-fab", "mat-mdc-fab"] },
+        {
+            attribute: "mat-mini-fab",
+            mdcClasses: ["mdc-fab", "mdc-fab--mini", "mat-mdc-mini-fab"],
+        },
+        {
+            attribute: "mat-icon-button",
+            mdcClasses: ["mdc-icon-button", "mat-mdc-icon-button"],
+        },
+    ],
+    Ag = (() => {
+        let t = class t {
+            get ripple() {
+                return this._rippleLoader?.getRipple(
+                    this._elementRef.nativeElement
+                );
+            }
+            set ripple(e) {
+                this._rippleLoader?.attachRipple(
+                    this._elementRef.nativeElement,
+                    e
+                );
+            }
+            get disableRipple() {
+                return this._disableRipple;
+            }
+            set disableRipple(e) {
+                (this._disableRipple = e), this._updateRippleDisabled();
+            }
+            get disabled() {
+                return this._disabled;
+            }
+            set disabled(e) {
+                (this._disabled = e), this._updateRippleDisabled();
+            }
+            constructor(e, i, r, s) {
+                (this._elementRef = e),
+                    (this._platform = i),
+                    (this._ngZone = r),
+                    (this._animationMode = s),
+                    (this._focusMonitor = g(wn)),
+                    (this._rippleLoader = g(Od)),
+                    (this._isFab = !1),
+                    (this._disableRipple = !1),
+                    (this._disabled = !1);
+                let a = g(kg, { optional: !0 }),
+                    l = e.nativeElement,
+                    c = l.classList;
+                (this.disabledInteractive = a?.disabledInteractive ?? !1),
+                    this._rippleLoader?.configureRipple(l, {
+                        className: "mat-mdc-button-ripple",
+                    });
+                for (let { attribute: d, mdcClasses: h } of Tg)
+                    l.hasAttribute(d) && c.add(...h);
+            }
+            ngAfterViewInit() {
+                this._focusMonitor.monitor(this._elementRef, !0);
+            }
+            ngOnDestroy() {
+                this._focusMonitor.stopMonitoring(this._elementRef),
+                    this._rippleLoader?.destroyRipple(
+                        this._elementRef.nativeElement
+                    );
+            }
+            focus(e = "program", i) {
+                e
+                    ? this._focusMonitor.focusVia(
+                          this._elementRef.nativeElement,
+                          e,
+                          i
+                      )
+                    : this._elementRef.nativeElement.focus(i);
+            }
+            _getAriaDisabled() {
+                return this.ariaDisabled != null
+                    ? this.ariaDisabled
+                    : this.disabled && this.disabledInteractive
+                      ? !0
+                      : null;
+            }
+            _getDisabledAttribute() {
+                return this.disabledInteractive || !this.disabled ? null : !0;
+            }
+            _updateRippleDisabled() {
+                this._rippleLoader?.setDisabled(
+                    this._elementRef.nativeElement,
+                    this.disableRipple || this.disabled
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            Ie();
+        }),
+            (t.ɵdir = D({
+                type: t,
+                inputs: {
+                    color: "color",
+                    disableRipple: [
+                        y.HasDecoratorInputTransform,
+                        "disableRipple",
+                        "disableRipple",
+                        W,
+                    ],
+                    disabled: [
+                        y.HasDecoratorInputTransform,
+                        "disabled",
+                        "disabled",
+                        W,
+                    ],
+                    ariaDisabled: [
+                        y.HasDecoratorInputTransform,
+                        "aria-disabled",
+                        "ariaDisabled",
+                        W,
+                    ],
+                    disabledInteractive: [
+                        y.HasDecoratorInputTransform,
+                        "disabledInteractive",
+                        "disabledInteractive",
+                        W,
+                    ],
+                },
+                features: [nt],
+            }));
+        let n = t;
+        return n;
+    })();
+var lu = (() => {
+    let t = class t extends Ag {
+        constructor(e, i, r, s) {
+            super(e, i, r, s),
+                (this._haltDisabledEvents = (a) => {
+                    this.disabled &&
+                        (a.preventDefault(), a.stopImmediatePropagation());
+                });
+        }
+        ngOnInit() {
+            this._ngZone.runOutsideAngular(() => {
+                this._elementRef.nativeElement.addEventListener(
+                    "click",
+                    this._haltDisabledEvents
+                );
+            });
+        }
+        ngOnDestroy() {
+            super.ngOnDestroy(),
+                this._elementRef.nativeElement.removeEventListener(
+                    "click",
+                    this._haltDisabledEvents
+                );
+        }
+        _getAriaDisabled() {
+            return this.ariaDisabled == null
+                ? this.disabled
+                : this.ariaDisabled;
+        }
+    };
+    (t.ɵfac = function (i) {
+        Ie();
+    }),
+        (t.ɵdir = D({
+            type: t,
+            inputs: {
+                tabIndex: [
+                    y.HasDecoratorInputTransform,
+                    "tabIndex",
+                    "tabIndex",
+                    (e) => (e == null ? void 0 : nl(e)),
+                ],
+            },
+            features: [nt, U],
+        }));
+    let n = t;
+    return n;
+})();
+var cu = (() => {
+    let t = class t extends lu {
+        constructor(e, i, r, s) {
+            super(e, i, r, s);
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(u(A), u(J), u(I), u(Bt, 8));
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [
+                ["a", "mat-button", ""],
+                ["a", "mat-raised-button", ""],
+                ["a", "mat-flat-button", ""],
+                ["a", "mat-stroked-button", ""],
+            ],
+            hostVars: 15,
+            hostBindings: function (i, r) {
+                i & 2 &&
+                    (ft("disabled", r._getDisabledAttribute())(
+                        "tabindex",
+                        r.disabled && !r.disabledInteractive ? -1 : r.tabIndex
+                    )("aria-disabled", r._getDisabledAttribute()),
+                    Jt(r.color ? "mat-" + r.color : ""),
+                    st("mat-mdc-button-disabled", r.disabled)(
+                        "mat-mdc-button-disabled-interactive",
+                        r.disabledInteractive
+                    )(
+                        "_mat-animation-noopable",
+                        r._animationMode === "NoopAnimations"
+                    )("mat-unthemed", !r.color)("mat-mdc-button-base", !0));
+            },
+            exportAs: ["matButton", "matAnchor"],
+            standalone: !0,
+            features: [U, tt],
+            attrs: Cg,
+            ngContentSelectors: Eg,
+            decls: 7,
+            vars: 4,
+            consts: [
+                [1, "mat-mdc-button-persistent-ripple"],
+                [1, "mdc-button__label"],
+                [1, "mat-mdc-focus-indicator"],
+                [1, "mat-mdc-button-touch-target"],
+            ],
+            template: function (i, r) {
+                i & 1 &&
+                    (pt(Dg),
+                    H(0, "span", 0),
+                    K(1),
+                    x(2, "span", 1),
+                    K(3, 1),
+                    _(),
+                    K(4, 2),
+                    H(5, "span", 2)(6, "span", 3)),
+                    i & 2 &&
+                        st("mdc-button__ripple", !r._isFab)(
+                            "mdc-fab__ripple",
+                            r._isFab
+                        );
+            },
+            styles: [Sg, au],
+            encapsulation: 2,
+            changeDetection: 0,
+        }));
+    let n = t;
+    return n;
+})();
+var du = (() => {
+        let t = class t extends lu {
+            constructor(e, i, r, s) {
+                super(e, i, r, s);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(A), u(J), u(I), u(Bt, 8));
+        }),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["a", "mat-icon-button", ""]],
+                hostVars: 15,
+                hostBindings: function (i, r) {
+                    i & 2 &&
+                        (ft("disabled", r._getDisabledAttribute())(
+                            "tabindex",
+                            r.disabled && !r.disabledInteractive
+                                ? -1
+                                : r.tabIndex
+                        )("aria-disabled", r._getDisabledAttribute()),
+                        Jt(r.color ? "mat-" + r.color : ""),
+                        st("mat-mdc-button-disabled", r.disabled)(
+                            "mat-mdc-button-disabled-interactive",
+                            r.disabledInteractive
+                        )(
+                            "_mat-animation-noopable",
+                            r._animationMode === "NoopAnimations"
+                        )("mat-unthemed", !r.color)("mat-mdc-button-base", !0));
+                },
+                exportAs: ["matButton", "matAnchor"],
+                standalone: !0,
+                features: [U, tt],
+                attrs: Ig,
+                ngContentSelectors: Rg,
+                decls: 4,
+                vars: 0,
+                consts: [
+                    [
+                        1,
+                        "mat-mdc-button-persistent-ripple",
+                        "mdc-icon-button__ripple",
+                    ],
+                    [1, "mat-mdc-focus-indicator"],
+                    [1, "mat-mdc-button-touch-target"],
+                ],
+                template: function (i, r) {
+                    i & 1 &&
+                        (pt(),
+                        H(0, "span", 0),
+                        K(1),
+                        H(2, "span", 1)(3, "span", 2));
+                },
+                styles: [Mg, au],
+                encapsulation: 2,
+                changeDetection: 0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    uu = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ imports: [Y, Ko, Y] }));
+        let n = t;
+        return n;
+    })();
+var En = class {
+        attach(t) {
+            return (this._attachedHost = t), t.attach(this);
+        }
+        detach() {
+            let t = this._attachedHost;
+            t != null && ((this._attachedHost = null), t.detach());
+        }
+        get isAttached() {
+            return this._attachedHost != null;
+        }
+        setAttachedHost(t) {
+            this._attachedHost = t;
+        }
+    },
+    fa = class extends En {
+        constructor(t, o, e, i, r) {
+            super(),
+                (this.component = t),
+                (this.viewContainerRef = o),
+                (this.injector = e),
+                (this.componentFactoryResolver = i),
+                (this.projectableNodes = r);
+        }
+    },
+    Ci = class extends En {
+        constructor(t, o, e, i) {
+            super(),
+                (this.templateRef = t),
+                (this.viewContainerRef = o),
+                (this.context = e),
+                (this.injector = i);
+        }
+        get origin() {
+            return this.templateRef.elementRef;
+        }
+        attach(t, o = this.context) {
+            return (this.context = o), super.attach(t);
+        }
+        detach() {
+            return (this.context = void 0), super.detach();
+        }
+    },
+    pa = class extends En {
+        constructor(t) {
+            super(), (this.element = t instanceof A ? t.nativeElement : t);
+        }
+    },
+    ga = class {
+        constructor() {
+            (this._isDisposed = !1), (this.attachDomPortal = null);
+        }
+        hasAttached() {
+            return !!this._attachedPortal;
+        }
+        attach(t) {
+            if (t instanceof fa)
+                return (
+                    (this._attachedPortal = t), this.attachComponentPortal(t)
+                );
+            if (t instanceof Ci)
+                return (this._attachedPortal = t), this.attachTemplatePortal(t);
+            if (this.attachDomPortal && t instanceof pa)
+                return (this._attachedPortal = t), this.attachDomPortal(t);
+        }
+        detach() {
+            this._attachedPortal &&
+                (this._attachedPortal.setAttachedHost(null),
+                (this._attachedPortal = null)),
+                this._invokeDisposeFn();
+        }
+        dispose() {
+            this.hasAttached() && this.detach(),
+                this._invokeDisposeFn(),
+                (this._isDisposed = !0);
+        }
+        setDisposeFn(t) {
+            this._disposeFn = t;
+        }
+        _invokeDisposeFn() {
+            this._disposeFn && (this._disposeFn(), (this._disposeFn = null));
+        }
+    };
+var Sn = class extends ga {
+    constructor(t, o, e, i, r) {
+        super(),
+            (this.outletElement = t),
+            (this._componentFactoryResolver = o),
+            (this._appRef = e),
+            (this._defaultInjector = i),
+            (this.attachDomPortal = (s) => {
+                this._document;
+                let a = s.element;
+                a.parentNode;
+                let l = this._document.createComment("dom-portal");
+                a.parentNode.insertBefore(l, a),
+                    this.outletElement.appendChild(a),
+                    (this._attachedPortal = s),
+                    super.setDisposeFn(() => {
+                        l.parentNode && l.parentNode.replaceChild(a, l);
+                    });
+            }),
+            (this._document = r);
+    }
+    attachComponentPortal(t) {
+        let e = (
+                t.componentFactoryResolver || this._componentFactoryResolver
+            ).resolveComponentFactory(t.component),
+            i;
+        return (
+            t.viewContainerRef
+                ? ((i = t.viewContainerRef.createComponent(
+                      e,
+                      t.viewContainerRef.length,
+                      t.injector || t.viewContainerRef.injector,
+                      t.projectableNodes || void 0
+                  )),
+                  this.setDisposeFn(() => i.destroy()))
+                : ((i = e.create(
+                      t.injector || this._defaultInjector || Kt.NULL
+                  )),
+                  this._appRef.attachView(i.hostView),
+                  this.setDisposeFn(() => {
+                      this._appRef.viewCount > 0 &&
+                          this._appRef.detachView(i.hostView),
+                          i.destroy();
+                  })),
+            this.outletElement.appendChild(this._getComponentRootNode(i)),
+            (this._attachedPortal = t),
+            i
+        );
+    }
+    attachTemplatePortal(t) {
+        let o = t.viewContainerRef,
+            e = o.createEmbeddedView(t.templateRef, t.context, {
+                injector: t.injector,
+            });
+        return (
+            e.rootNodes.forEach((i) => this.outletElement.appendChild(i)),
+            e.detectChanges(),
+            this.setDisposeFn(() => {
+                let i = o.indexOf(e);
+                i !== -1 && o.remove(i);
+            }),
+            (this._attachedPortal = t),
+            e
+        );
+    }
+    dispose() {
+        super.dispose(), this.outletElement.remove();
+    }
+    _getComponentRootNode(t) {
+        return t.hostView.rootNodes[0];
+    }
+};
+var hu = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({}));
+    let n = t;
+    return n;
+})();
+var mu = id(),
+    ba = class {
+        constructor(t, o) {
+            (this._viewportRuler = t),
+                (this._previousHTMLStyles = { top: "", left: "" }),
+                (this._isEnabled = !1),
+                (this._document = o);
+        }
+        attach() {}
+        enable() {
+            if (this._canBeEnabled()) {
+                let t = this._document.documentElement;
+                (this._previousScrollPosition =
+                    this._viewportRuler.getViewportScrollPosition()),
+                    (this._previousHTMLStyles.left = t.style.left || ""),
+                    (this._previousHTMLStyles.top = t.style.top || ""),
+                    (t.style.left = ct(-this._previousScrollPosition.left)),
+                    (t.style.top = ct(-this._previousScrollPosition.top)),
+                    t.classList.add("cdk-global-scrollblock"),
+                    (this._isEnabled = !0);
+            }
+        }
+        disable() {
+            if (this._isEnabled) {
+                let t = this._document.documentElement,
+                    o = this._document.body,
+                    e = t.style,
+                    i = o.style,
+                    r = e.scrollBehavior || "",
+                    s = i.scrollBehavior || "";
+                (this._isEnabled = !1),
+                    (e.left = this._previousHTMLStyles.left),
+                    (e.top = this._previousHTMLStyles.top),
+                    t.classList.remove("cdk-global-scrollblock"),
+                    mu && (e.scrollBehavior = i.scrollBehavior = "auto"),
+                    window.scroll(
+                        this._previousScrollPosition.left,
+                        this._previousScrollPosition.top
+                    ),
+                    mu && ((e.scrollBehavior = r), (i.scrollBehavior = s));
+            }
+        }
+        _canBeEnabled() {
+            if (
+                this._document.documentElement.classList.contains(
+                    "cdk-global-scrollblock"
+                ) ||
+                this._isEnabled
+            )
+                return !1;
+            let o = this._document.body,
+                e = this._viewportRuler.getViewportSize();
+            return o.scrollHeight > e.height || o.scrollWidth > e.width;
+        }
+    };
+var va = class {
+        constructor(t, o, e, i) {
+            (this._scrollDispatcher = t),
+                (this._ngZone = o),
+                (this._viewportRuler = e),
+                (this._config = i),
+                (this._scrollSubscription = null),
+                (this._detach = () => {
+                    this.disable(),
+                        this._overlayRef.hasAttached() &&
+                            this._ngZone.run(() => this._overlayRef.detach());
+                });
+        }
+        attach(t) {
+            this._overlayRef, (this._overlayRef = t);
+        }
+        enable() {
+            if (this._scrollSubscription) return;
+            let t = this._scrollDispatcher
+                .scrolled(0)
+                .pipe(
+                    dt(
+                        (o) =>
+                            !o ||
+                            !this._overlayRef.overlayElement.contains(
+                                o.getElementRef().nativeElement
+                            )
+                    )
+                );
+            this._config && this._config.threshold && this._config.threshold > 1
+                ? ((this._initialScrollPosition =
+                      this._viewportRuler.getViewportScrollPosition().top),
+                  (this._scrollSubscription = t.subscribe(() => {
+                      let o =
+                          this._viewportRuler.getViewportScrollPosition().top;
+                      Math.abs(o - this._initialScrollPosition) >
+                      this._config.threshold
+                          ? this._detach()
+                          : this._overlayRef.updatePosition();
+                  })))
+                : (this._scrollSubscription = t.subscribe(this._detach));
+        }
+        disable() {
+            this._scrollSubscription &&
+                (this._scrollSubscription.unsubscribe(),
+                (this._scrollSubscription = null));
+        }
+        detach() {
+            this.disable(), (this._overlayRef = null);
+        }
+    },
+    ir = class {
+        enable() {}
+        disable() {}
+        attach() {}
+    };
+function _a(n, t) {
+    return t.some((o) => {
+        let e = n.bottom < o.top,
+            i = n.top > o.bottom,
+            r = n.right < o.left,
+            s = n.left > o.right;
+        return e || i || r || s;
+    });
+}
+function fu(n, t) {
+    return t.some((o) => {
+        let e = n.top < o.top,
+            i = n.bottom > o.bottom,
+            r = n.left < o.left,
+            s = n.right > o.right;
+        return e || i || r || s;
+    });
+}
+var ya = class {
+        constructor(t, o, e, i) {
+            (this._scrollDispatcher = t),
+                (this._viewportRuler = o),
+                (this._ngZone = e),
+                (this._config = i),
+                (this._scrollSubscription = null);
+        }
+        attach(t) {
+            this._overlayRef, (this._overlayRef = t);
+        }
+        enable() {
+            if (!this._scrollSubscription) {
+                let t = this._config ? this._config.scrollThrottle : 0;
+                this._scrollSubscription = this._scrollDispatcher
+                    .scrolled(t)
+                    .subscribe(() => {
+                        if (
+                            (this._overlayRef.updatePosition(),
+                            this._config && this._config.autoClose)
+                        ) {
+                            let o =
+                                    this._overlayRef.overlayElement.getBoundingClientRect(),
+                                { width: e, height: i } =
+                                    this._viewportRuler.getViewportSize();
+                            _a(o, [
+                                {
+                                    width: e,
+                                    height: i,
+                                    bottom: i,
+                                    right: e,
+                                    top: 0,
+                                    left: 0,
+                                },
+                            ]) &&
+                                (this.disable(),
+                                this._ngZone.run(() =>
+                                    this._overlayRef.detach()
+                                ));
+                        }
+                    });
+            }
+        }
+        disable() {
+            this._scrollSubscription &&
+                (this._scrollSubscription.unsubscribe(),
+                (this._scrollSubscription = null));
+        }
+        detach() {
+            this.disable(), (this._overlayRef = null);
+        }
+    },
+    Og = (() => {
+        let t = class t {
+            constructor(e, i, r, s) {
+                (this._scrollDispatcher = e),
+                    (this._viewportRuler = i),
+                    (this._ngZone = r),
+                    (this.noop = () => new ir()),
+                    (this.close = (a) =>
+                        new va(
+                            this._scrollDispatcher,
+                            this._ngZone,
+                            this._viewportRuler,
+                            a
+                        )),
+                    (this.block = () =>
+                        new ba(this._viewportRuler, this._document)),
+                    (this.reposition = (a) =>
+                        new ya(
+                            this._scrollDispatcher,
+                            this._viewportRuler,
+                            this._ngZone,
+                            a
+                        )),
+                    (this._document = s);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(sd), m(bn), m(I), m(T));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    In = class {
+        constructor(t) {
+            if (
+                ((this.scrollStrategy = new ir()),
+                (this.panelClass = ""),
+                (this.hasBackdrop = !1),
+                (this.backdropClass = "cdk-overlay-dark-backdrop"),
+                (this.disposeOnNavigation = !1),
+                t)
+            ) {
+                let o = Object.keys(t);
+                for (let e of o) t[e] !== void 0 && (this[e] = t[e]);
+            }
+        }
+    };
+var xa = class {
+    constructor(t, o) {
+        (this.connectionPair = t), (this.scrollableViewProperties = o);
+    }
+};
+var _u = (() => {
+        let t = class t {
+            constructor(e) {
+                (this._attachedOverlays = []), (this._document = e);
+            }
+            ngOnDestroy() {
+                this.detach();
+            }
+            add(e) {
+                this.remove(e), this._attachedOverlays.push(e);
+            }
+            remove(e) {
+                let i = this._attachedOverlays.indexOf(e);
+                i > -1 && this._attachedOverlays.splice(i, 1),
+                    this._attachedOverlays.length === 0 && this.detach();
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    Ng = (() => {
+        let t = class t extends _u {
+            constructor(e, i) {
+                super(e),
+                    (this._ngZone = i),
+                    (this._keydownListener = (r) => {
+                        let s = this._attachedOverlays;
+                        for (let a = s.length - 1; a > -1; a--)
+                            if (s[a]._keydownEvents.observers.length > 0) {
+                                let l = s[a]._keydownEvents;
+                                this._ngZone
+                                    ? this._ngZone.run(() => l.next(r))
+                                    : l.next(r);
+                                break;
+                            }
+                    });
+            }
+            add(e) {
+                super.add(e),
+                    this._isAttached ||
+                        (this._ngZone
+                            ? this._ngZone.runOutsideAngular(() =>
+                                  this._document.body.addEventListener(
+                                      "keydown",
+                                      this._keydownListener
+                                  )
+                              )
+                            : this._document.body.addEventListener(
+                                  "keydown",
+                                  this._keydownListener
+                              ),
+                        (this._isAttached = !0));
+            }
+            detach() {
+                this._isAttached &&
+                    (this._document.body.removeEventListener(
+                        "keydown",
+                        this._keydownListener
+                    ),
+                    (this._isAttached = !1));
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T), m(I, 8));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    Pg = (() => {
+        let t = class t extends _u {
+            constructor(e, i, r) {
+                super(e),
+                    (this._platform = i),
+                    (this._ngZone = r),
+                    (this._cursorStyleIsSet = !1),
+                    (this._pointerDownListener = (s) => {
+                        this._pointerDownEventTarget = Lt(s);
+                    }),
+                    (this._clickListener = (s) => {
+                        let a = Lt(s),
+                            l =
+                                s.type === "click" &&
+                                this._pointerDownEventTarget
+                                    ? this._pointerDownEventTarget
+                                    : a;
+                        this._pointerDownEventTarget = null;
+                        let c = this._attachedOverlays.slice();
+                        for (let d = c.length - 1; d > -1; d--) {
+                            let h = c[d];
+                            if (
+                                h._outsidePointerEvents.observers.length < 1 ||
+                                !h.hasAttached()
+                            )
+                                continue;
+                            if (
+                                h.overlayElement.contains(a) ||
+                                h.overlayElement.contains(l)
+                            )
+                                break;
+                            let f = h._outsidePointerEvents;
+                            this._ngZone
+                                ? this._ngZone.run(() => f.next(s))
+                                : f.next(s);
+                        }
+                    });
+            }
+            add(e) {
+                if ((super.add(e), !this._isAttached)) {
+                    let i = this._document.body;
+                    this._ngZone
+                        ? this._ngZone.runOutsideAngular(() =>
+                              this._addEventListeners(i)
+                          )
+                        : this._addEventListeners(i),
+                        this._platform.IOS &&
+                            !this._cursorStyleIsSet &&
+                            ((this._cursorOriginalValue = i.style.cursor),
+                            (i.style.cursor = "pointer"),
+                            (this._cursorStyleIsSet = !0)),
+                        (this._isAttached = !0);
+                }
+            }
+            detach() {
+                if (this._isAttached) {
+                    let e = this._document.body;
+                    e.removeEventListener(
+                        "pointerdown",
+                        this._pointerDownListener,
+                        !0
+                    ),
+                        e.removeEventListener("click", this._clickListener, !0),
+                        e.removeEventListener(
+                            "auxclick",
+                            this._clickListener,
+                            !0
+                        ),
+                        e.removeEventListener(
+                            "contextmenu",
+                            this._clickListener,
+                            !0
+                        ),
+                        this._platform.IOS &&
+                            this._cursorStyleIsSet &&
+                            ((e.style.cursor = this._cursorOriginalValue),
+                            (this._cursorStyleIsSet = !1)),
+                        (this._isAttached = !1);
+                }
+            }
+            _addEventListeners(e) {
+                e.addEventListener(
+                    "pointerdown",
+                    this._pointerDownListener,
+                    !0
+                ),
+                    e.addEventListener("click", this._clickListener, !0),
+                    e.addEventListener("auxclick", this._clickListener, !0),
+                    e.addEventListener("contextmenu", this._clickListener, !0);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T), m(J), m(I, 8));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    yu = (() => {
+        let t = class t {
+            constructor(e, i) {
+                (this._platform = i), (this._document = e);
+            }
+            ngOnDestroy() {
+                this._containerElement?.remove();
+            }
+            getContainerElement() {
+                return (
+                    this._containerElement || this._createContainer(),
+                    this._containerElement
+                );
+            }
+            _createContainer() {
+                let e = "cdk-overlay-container";
+                if (this._platform.isBrowser || gn()) {
+                    let r = this._document.querySelectorAll(
+                        `.${e}[platform="server"], .${e}[platform="test"]`
+                    );
+                    for (let s = 0; s < r.length; s++) r[s].remove();
+                }
+                let i = this._document.createElement("div");
+                i.classList.add(e),
+                    gn()
+                        ? i.setAttribute("platform", "test")
+                        : this._platform.isBrowser ||
+                          i.setAttribute("platform", "server"),
+                    this._document.body.appendChild(i),
+                    (this._containerElement = i);
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(T), m(J));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    wa = class {
+        constructor(t, o, e, i, r, s, a, l, c, d = !1) {
+            (this._portalOutlet = t),
+                (this._host = o),
+                (this._pane = e),
+                (this._config = i),
+                (this._ngZone = r),
+                (this._keyboardDispatcher = s),
+                (this._document = a),
+                (this._location = l),
+                (this._outsideClickDispatcher = c),
+                (this._animationsDisabled = d),
+                (this._backdropElement = null),
+                (this._backdropClick = new N()),
+                (this._attachments = new N()),
+                (this._detachments = new N()),
+                (this._locationChanges = St.EMPTY),
+                (this._backdropClickHandler = (h) =>
+                    this._backdropClick.next(h)),
+                (this._backdropTransitionendHandler = (h) => {
+                    this._disposeBackdrop(h.target);
+                }),
+                (this._keydownEvents = new N()),
+                (this._outsidePointerEvents = new N()),
+                i.scrollStrategy &&
+                    ((this._scrollStrategy = i.scrollStrategy),
+                    this._scrollStrategy.attach(this)),
+                (this._positionStrategy = i.positionStrategy);
+        }
+        get overlayElement() {
+            return this._pane;
+        }
+        get backdropElement() {
+            return this._backdropElement;
+        }
+        get hostElement() {
+            return this._host;
+        }
+        attach(t) {
+            !this._host.parentElement &&
+                this._previousHostParent &&
+                this._previousHostParent.appendChild(this._host);
+            let o = this._portalOutlet.attach(t);
+            return (
+                this._positionStrategy && this._positionStrategy.attach(this),
+                this._updateStackingOrder(),
+                this._updateElementSize(),
+                this._updateElementDirection(),
+                this._scrollStrategy && this._scrollStrategy.enable(),
+                this._ngZone.onStable.pipe(ut(1)).subscribe(() => {
+                    this.hasAttached() && this.updatePosition();
+                }),
+                this._togglePointerEvents(!0),
+                this._config.hasBackdrop && this._attachBackdrop(),
+                this._config.panelClass &&
+                    this._toggleClasses(
+                        this._pane,
+                        this._config.panelClass,
+                        !0
+                    ),
+                this._attachments.next(),
+                this._keyboardDispatcher.add(this),
+                this._config.disposeOnNavigation &&
+                    (this._locationChanges = this._location.subscribe(() =>
+                        this.dispose()
+                    )),
+                this._outsideClickDispatcher.add(this),
+                typeof o?.onDestroy == "function" &&
+                    o.onDestroy(() => {
+                        this.hasAttached() &&
+                            this._ngZone.runOutsideAngular(() =>
+                                Promise.resolve().then(() => this.detach())
+                            );
+                    }),
+                o
+            );
+        }
+        detach() {
+            if (!this.hasAttached()) return;
+            this.detachBackdrop(),
+                this._togglePointerEvents(!1),
+                this._positionStrategy &&
+                    this._positionStrategy.detach &&
+                    this._positionStrategy.detach(),
+                this._scrollStrategy && this._scrollStrategy.disable();
+            let t = this._portalOutlet.detach();
+            return (
+                this._detachments.next(),
+                this._keyboardDispatcher.remove(this),
+                this._detachContentWhenStable(),
+                this._locationChanges.unsubscribe(),
+                this._outsideClickDispatcher.remove(this),
+                t
+            );
+        }
+        dispose() {
+            let t = this.hasAttached();
+            this._positionStrategy && this._positionStrategy.dispose(),
+                this._disposeScrollStrategy(),
+                this._disposeBackdrop(this._backdropElement),
+                this._locationChanges.unsubscribe(),
+                this._keyboardDispatcher.remove(this),
+                this._portalOutlet.dispose(),
+                this._attachments.complete(),
+                this._backdropClick.complete(),
+                this._keydownEvents.complete(),
+                this._outsidePointerEvents.complete(),
+                this._outsideClickDispatcher.remove(this),
+                this._host?.remove(),
+                (this._previousHostParent = this._pane = this._host = null),
+                t && this._detachments.next(),
+                this._detachments.complete();
+        }
+        hasAttached() {
+            return this._portalOutlet.hasAttached();
+        }
+        backdropClick() {
+            return this._backdropClick;
+        }
+        attachments() {
+            return this._attachments;
+        }
+        detachments() {
+            return this._detachments;
+        }
+        keydownEvents() {
+            return this._keydownEvents;
+        }
+        outsidePointerEvents() {
+            return this._outsidePointerEvents;
+        }
+        getConfig() {
+            return this._config;
+        }
+        updatePosition() {
+            this._positionStrategy && this._positionStrategy.apply();
+        }
+        updatePositionStrategy(t) {
+            t !== this._positionStrategy &&
+                (this._positionStrategy && this._positionStrategy.dispose(),
+                (this._positionStrategy = t),
+                this.hasAttached() && (t.attach(this), this.updatePosition()));
+        }
+        updateSize(t) {
+            (this._config = p(p({}, this._config), t)),
+                this._updateElementSize();
+        }
+        setDirection(t) {
+            (this._config = q(p({}, this._config), { direction: t })),
+                this._updateElementDirection();
+        }
+        addPanelClass(t) {
+            this._pane && this._toggleClasses(this._pane, t, !0);
+        }
+        removePanelClass(t) {
+            this._pane && this._toggleClasses(this._pane, t, !1);
+        }
+        getDirection() {
+            let t = this._config.direction;
+            return t ? (typeof t == "string" ? t : t.value) : "ltr";
+        }
+        updateScrollStrategy(t) {
+            t !== this._scrollStrategy &&
+                (this._disposeScrollStrategy(),
+                (this._scrollStrategy = t),
+                this.hasAttached() && (t.attach(this), t.enable()));
+        }
+        _updateElementDirection() {
+            this._host.setAttribute("dir", this.getDirection());
+        }
+        _updateElementSize() {
+            if (!this._pane) return;
+            let t = this._pane.style;
+            (t.width = ct(this._config.width)),
+                (t.height = ct(this._config.height)),
+                (t.minWidth = ct(this._config.minWidth)),
+                (t.minHeight = ct(this._config.minHeight)),
+                (t.maxWidth = ct(this._config.maxWidth)),
+                (t.maxHeight = ct(this._config.maxHeight));
+        }
+        _togglePointerEvents(t) {
+            this._pane.style.pointerEvents = t ? "" : "none";
+        }
+        _attachBackdrop() {
+            let t = "cdk-overlay-backdrop-showing";
+            (this._backdropElement = this._document.createElement("div")),
+                this._backdropElement.classList.add("cdk-overlay-backdrop"),
+                this._animationsDisabled &&
+                    this._backdropElement.classList.add(
+                        "cdk-overlay-backdrop-noop-animation"
+                    ),
+                this._config.backdropClass &&
+                    this._toggleClasses(
+                        this._backdropElement,
+                        this._config.backdropClass,
+                        !0
+                    ),
+                this._host.parentElement.insertBefore(
+                    this._backdropElement,
+                    this._host
+                ),
+                this._backdropElement.addEventListener(
+                    "click",
+                    this._backdropClickHandler
+                ),
+                !this._animationsDisabled && typeof requestAnimationFrame < "u"
+                    ? this._ngZone.runOutsideAngular(() => {
+                          requestAnimationFrame(() => {
+                              this._backdropElement &&
+                                  this._backdropElement.classList.add(t);
+                          });
+                      })
+                    : this._backdropElement.classList.add(t);
+        }
+        _updateStackingOrder() {
+            this._host.nextSibling &&
+                this._host.parentNode.appendChild(this._host);
+        }
+        detachBackdrop() {
+            let t = this._backdropElement;
+            if (t) {
+                if (this._animationsDisabled) {
+                    this._disposeBackdrop(t);
+                    return;
+                }
+                t.classList.remove("cdk-overlay-backdrop-showing"),
+                    this._ngZone.runOutsideAngular(() => {
+                        t.addEventListener(
+                            "transitionend",
+                            this._backdropTransitionendHandler
+                        );
+                    }),
+                    (t.style.pointerEvents = "none"),
+                    (this._backdropTimeout = this._ngZone.runOutsideAngular(
+                        () =>
+                            setTimeout(() => {
+                                this._disposeBackdrop(t);
+                            }, 500)
+                    ));
+            }
+        }
+        _toggleClasses(t, o, e) {
+            let i = _i(o || []).filter((r) => !!r);
+            i.length && (e ? t.classList.add(...i) : t.classList.remove(...i));
+        }
+        _detachContentWhenStable() {
+            this._ngZone.runOutsideAngular(() => {
+                let t = this._ngZone.onStable
+                    .pipe(mt(qt(this._attachments, this._detachments)))
+                    .subscribe(() => {
+                        (!this._pane ||
+                            !this._host ||
+                            this._pane.children.length === 0) &&
+                            (this._pane &&
+                                this._config.panelClass &&
+                                this._toggleClasses(
+                                    this._pane,
+                                    this._config.panelClass,
+                                    !1
+                                ),
+                            this._host &&
+                                this._host.parentElement &&
+                                ((this._previousHostParent =
+                                    this._host.parentElement),
+                                this._host.remove()),
+                            t.unsubscribe());
+                    });
+            });
+        }
+        _disposeScrollStrategy() {
+            let t = this._scrollStrategy;
+            t && (t.disable(), t.detach && t.detach());
+        }
+        _disposeBackdrop(t) {
+            t &&
+                (t.removeEventListener("click", this._backdropClickHandler),
+                t.removeEventListener(
+                    "transitionend",
+                    this._backdropTransitionendHandler
+                ),
+                t.remove(),
+                this._backdropElement === t && (this._backdropElement = null)),
+                this._backdropTimeout &&
+                    (clearTimeout(this._backdropTimeout),
+                    (this._backdropTimeout = void 0));
+        }
+    },
+    pu = "cdk-overlay-connected-position-bounding-box",
+    Lg = /([A-Za-z%]+)$/,
+    Ca = class {
+        get positions() {
+            return this._preferredPositions;
+        }
+        constructor(t, o, e, i, r) {
+            (this._viewportRuler = o),
+                (this._document = e),
+                (this._platform = i),
+                (this._overlayContainer = r),
+                (this._lastBoundingBoxSize = { width: 0, height: 0 }),
+                (this._isPushed = !1),
+                (this._canPush = !0),
+                (this._growAfterOpen = !1),
+                (this._hasFlexibleDimensions = !0),
+                (this._positionLocked = !1),
+                (this._viewportMargin = 0),
+                (this._scrollables = []),
+                (this._preferredPositions = []),
+                (this._positionChanges = new N()),
+                (this._resizeSubscription = St.EMPTY),
+                (this._offsetX = 0),
+                (this._offsetY = 0),
+                (this._appliedPanelClasses = []),
+                (this.positionChanges = this._positionChanges),
+                this.setOrigin(t);
+        }
+        attach(t) {
+            this._overlayRef && this._overlayRef,
+                this._validatePositions(),
+                t.hostElement.classList.add(pu),
+                (this._overlayRef = t),
+                (this._boundingBox = t.hostElement),
+                (this._pane = t.overlayElement),
+                (this._isDisposed = !1),
+                (this._isInitialRender = !0),
+                (this._lastPosition = null),
+                this._resizeSubscription.unsubscribe(),
+                (this._resizeSubscription = this._viewportRuler
+                    .change()
+                    .subscribe(() => {
+                        (this._isInitialRender = !0), this.apply();
+                    }));
+        }
+        apply() {
+            if (this._isDisposed || !this._platform.isBrowser) return;
+            if (
+                !this._isInitialRender &&
+                this._positionLocked &&
+                this._lastPosition
+            ) {
+                this.reapplyLastPosition();
+                return;
+            }
+            this._clearPanelClasses(),
+                this._resetOverlayElementStyles(),
+                this._resetBoundingBoxStyles(),
+                (this._viewportRect = this._getNarrowedViewportRect()),
+                (this._originRect = this._getOriginRect()),
+                (this._overlayRect = this._pane.getBoundingClientRect()),
+                (this._containerRect = this._overlayContainer
+                    .getContainerElement()
+                    .getBoundingClientRect());
+            let t = this._originRect,
+                o = this._overlayRect,
+                e = this._viewportRect,
+                i = this._containerRect,
+                r = [],
+                s;
+            for (let a of this._preferredPositions) {
+                let l = this._getOriginPoint(t, i, a),
+                    c = this._getOverlayPoint(l, o, a),
+                    d = this._getOverlayFit(c, o, e, a);
+                if (d.isCompletelyWithinViewport) {
+                    (this._isPushed = !1), this._applyPosition(a, l);
+                    return;
+                }
+                if (this._canFitWithFlexibleDimensions(d, c, e)) {
+                    r.push({
+                        position: a,
+                        origin: l,
+                        overlayRect: o,
+                        boundingBoxRect: this._calculateBoundingBoxRect(l, a),
+                    });
+                    continue;
+                }
+                (!s || s.overlayFit.visibleArea < d.visibleArea) &&
+                    (s = {
+                        overlayFit: d,
+                        overlayPoint: c,
+                        originPoint: l,
+                        position: a,
+                        overlayRect: o,
+                    });
+            }
+            if (r.length) {
+                let a = null,
+                    l = -1;
+                for (let c of r) {
+                    let d =
+                        c.boundingBoxRect.width *
+                        c.boundingBoxRect.height *
+                        (c.position.weight || 1);
+                    d > l && ((l = d), (a = c));
+                }
+                (this._isPushed = !1),
+                    this._applyPosition(a.position, a.origin);
+                return;
+            }
+            if (this._canPush) {
+                (this._isPushed = !0),
+                    this._applyPosition(s.position, s.originPoint);
+                return;
+            }
+            this._applyPosition(s.position, s.originPoint);
+        }
+        detach() {
+            this._clearPanelClasses(),
+                (this._lastPosition = null),
+                (this._previousPushAmount = null),
+                this._resizeSubscription.unsubscribe();
+        }
+        dispose() {
+            this._isDisposed ||
+                (this._boundingBox &&
+                    He(this._boundingBox.style, {
+                        top: "",
+                        left: "",
+                        right: "",
+                        bottom: "",
+                        height: "",
+                        width: "",
+                        alignItems: "",
+                        justifyContent: "",
+                    }),
+                this._pane && this._resetOverlayElementStyles(),
+                this._overlayRef &&
+                    this._overlayRef.hostElement.classList.remove(pu),
+                this.detach(),
+                this._positionChanges.complete(),
+                (this._overlayRef = this._boundingBox = null),
+                (this._isDisposed = !0));
+        }
+        reapplyLastPosition() {
+            if (this._isDisposed || !this._platform.isBrowser) return;
+            let t = this._lastPosition;
+            if (t) {
+                (this._originRect = this._getOriginRect()),
+                    (this._overlayRect = this._pane.getBoundingClientRect()),
+                    (this._viewportRect = this._getNarrowedViewportRect()),
+                    (this._containerRect = this._overlayContainer
+                        .getContainerElement()
+                        .getBoundingClientRect());
+                let o = this._getOriginPoint(
+                    this._originRect,
+                    this._containerRect,
+                    t
+                );
+                this._applyPosition(t, o);
+            } else this.apply();
+        }
+        withScrollableContainers(t) {
+            return (this._scrollables = t), this;
+        }
+        withPositions(t) {
+            return (
+                (this._preferredPositions = t),
+                t.indexOf(this._lastPosition) === -1 &&
+                    (this._lastPosition = null),
+                this._validatePositions(),
+                this
+            );
+        }
+        withViewportMargin(t) {
+            return (this._viewportMargin = t), this;
+        }
+        withFlexibleDimensions(t = !0) {
+            return (this._hasFlexibleDimensions = t), this;
+        }
+        withGrowAfterOpen(t = !0) {
+            return (this._growAfterOpen = t), this;
+        }
+        withPush(t = !0) {
+            return (this._canPush = t), this;
+        }
+        withLockedPosition(t = !0) {
+            return (this._positionLocked = t), this;
+        }
+        setOrigin(t) {
+            return (this._origin = t), this;
+        }
+        withDefaultOffsetX(t) {
+            return (this._offsetX = t), this;
+        }
+        withDefaultOffsetY(t) {
+            return (this._offsetY = t), this;
+        }
+        withTransformOriginOn(t) {
+            return (this._transformOriginSelector = t), this;
+        }
+        _getOriginPoint(t, o, e) {
+            let i;
+            if (e.originX == "center") i = t.left + t.width / 2;
+            else {
+                let s = this._isRtl() ? t.right : t.left,
+                    a = this._isRtl() ? t.left : t.right;
+                i = e.originX == "start" ? s : a;
+            }
+            o.left < 0 && (i -= o.left);
+            let r;
+            return (
+                e.originY == "center"
+                    ? (r = t.top + t.height / 2)
+                    : (r = e.originY == "top" ? t.top : t.bottom),
+                o.top < 0 && (r -= o.top),
+                { x: i, y: r }
+            );
+        }
+        _getOverlayPoint(t, o, e) {
+            let i;
+            e.overlayX == "center"
+                ? (i = -o.width / 2)
+                : e.overlayX === "start"
+                  ? (i = this._isRtl() ? -o.width : 0)
+                  : (i = this._isRtl() ? 0 : -o.width);
+            let r;
+            return (
+                e.overlayY == "center"
+                    ? (r = -o.height / 2)
+                    : (r = e.overlayY == "top" ? 0 : -o.height),
+                { x: t.x + i, y: t.y + r }
+            );
+        }
+        _getOverlayFit(t, o, e, i) {
+            let r = bu(o),
+                { x: s, y: a } = t,
+                l = this._getOffset(i, "x"),
+                c = this._getOffset(i, "y");
+            l && (s += l), c && (a += c);
+            let d = 0 - s,
+                h = s + r.width - e.width,
+                f = 0 - a,
+                w = a + r.height - e.height,
+                j = this._subtractOverflows(r.width, d, h),
+                z = this._subtractOverflows(r.height, f, w),
+                k = j * z;
+            return {
+                visibleArea: k,
+                isCompletelyWithinViewport: r.width * r.height === k,
+                fitsInViewportVertically: z === r.height,
+                fitsInViewportHorizontally: j == r.width,
+            };
+        }
+        _canFitWithFlexibleDimensions(t, o, e) {
+            if (this._hasFlexibleDimensions) {
+                let i = e.bottom - o.y,
+                    r = e.right - o.x,
+                    s = gu(this._overlayRef.getConfig().minHeight),
+                    a = gu(this._overlayRef.getConfig().minWidth),
+                    l = t.fitsInViewportVertically || (s != null && s <= i),
+                    c = t.fitsInViewportHorizontally || (a != null && a <= r);
+                return l && c;
+            }
+            return !1;
+        }
+        _pushOverlayOnScreen(t, o, e) {
+            if (this._previousPushAmount && this._positionLocked)
+                return {
+                    x: t.x + this._previousPushAmount.x,
+                    y: t.y + this._previousPushAmount.y,
+                };
+            let i = bu(o),
+                r = this._viewportRect,
+                s = Math.max(t.x + i.width - r.width, 0),
+                a = Math.max(t.y + i.height - r.height, 0),
+                l = Math.max(r.top - e.top - t.y, 0),
+                c = Math.max(r.left - e.left - t.x, 0),
+                d = 0,
+                h = 0;
+            return (
+                i.width <= r.width
+                    ? (d = c || -s)
+                    : (d =
+                          t.x < this._viewportMargin
+                              ? r.left - e.left - t.x
+                              : 0),
+                i.height <= r.height
+                    ? (h = l || -a)
+                    : (h =
+                          t.y < this._viewportMargin ? r.top - e.top - t.y : 0),
+                (this._previousPushAmount = { x: d, y: h }),
+                { x: t.x + d, y: t.y + h }
+            );
+        }
+        _applyPosition(t, o) {
+            if (
+                (this._setTransformOrigin(t),
+                this._setOverlayElementStyles(o, t),
+                this._setBoundingBoxStyles(o, t),
+                t.panelClass && this._addPanelClasses(t.panelClass),
+                this._positionChanges.observers.length)
+            ) {
+                let e = this._getScrollVisibility();
+                if (
+                    t !== this._lastPosition ||
+                    !this._lastScrollVisibility ||
+                    !jg(this._lastScrollVisibility, e)
+                ) {
+                    let i = new xa(t, e);
+                    this._positionChanges.next(i);
+                }
+                this._lastScrollVisibility = e;
+            }
+            (this._lastPosition = t), (this._isInitialRender = !1);
+        }
+        _setTransformOrigin(t) {
+            if (!this._transformOriginSelector) return;
+            let o = this._boundingBox.querySelectorAll(
+                    this._transformOriginSelector
+                ),
+                e,
+                i = t.overlayY;
+            t.overlayX === "center"
+                ? (e = "center")
+                : this._isRtl()
+                  ? (e = t.overlayX === "start" ? "right" : "left")
+                  : (e = t.overlayX === "start" ? "left" : "right");
+            for (let r = 0; r < o.length; r++)
+                o[r].style.transformOrigin = `${e} ${i}`;
+        }
+        _calculateBoundingBoxRect(t, o) {
+            let e = this._viewportRect,
+                i = this._isRtl(),
+                r,
+                s,
+                a;
+            if (o.overlayY === "top")
+                (s = t.y), (r = e.height - s + this._viewportMargin);
+            else if (o.overlayY === "bottom")
+                (a = e.height - t.y + this._viewportMargin * 2),
+                    (r = e.height - a + this._viewportMargin);
+            else {
+                let w = Math.min(e.bottom - t.y + e.top, t.y),
+                    j = this._lastBoundingBoxSize.height;
+                (r = w * 2),
+                    (s = t.y - w),
+                    r > j &&
+                        !this._isInitialRender &&
+                        !this._growAfterOpen &&
+                        (s = t.y - j / 2);
+            }
+            let l =
+                    (o.overlayX === "start" && !i) ||
+                    (o.overlayX === "end" && i),
+                c =
+                    (o.overlayX === "end" && !i) ||
+                    (o.overlayX === "start" && i),
+                d,
+                h,
+                f;
+            if (c)
+                (f = e.width - t.x + this._viewportMargin * 2),
+                    (d = t.x - this._viewportMargin);
+            else if (l) (h = t.x), (d = e.right - t.x);
+            else {
+                let w = Math.min(e.right - t.x + e.left, t.x),
+                    j = this._lastBoundingBoxSize.width;
+                (d = w * 2),
+                    (h = t.x - w),
+                    d > j &&
+                        !this._isInitialRender &&
+                        !this._growAfterOpen &&
+                        (h = t.x - j / 2);
+            }
+            return {
+                top: s,
+                left: h,
+                bottom: a,
+                right: f,
+                width: d,
+                height: r,
+            };
+        }
+        _setBoundingBoxStyles(t, o) {
+            let e = this._calculateBoundingBoxRect(t, o);
+            !this._isInitialRender &&
+                !this._growAfterOpen &&
+                ((e.height = Math.min(
+                    e.height,
+                    this._lastBoundingBoxSize.height
+                )),
+                (e.width = Math.min(e.width, this._lastBoundingBoxSize.width)));
+            let i = {};
+            if (this._hasExactPosition())
+                (i.top = i.left = "0"),
+                    (i.bottom = i.right = i.maxHeight = i.maxWidth = ""),
+                    (i.width = i.height = "100%");
+            else {
+                let r = this._overlayRef.getConfig().maxHeight,
+                    s = this._overlayRef.getConfig().maxWidth;
+                (i.height = ct(e.height)),
+                    (i.top = ct(e.top)),
+                    (i.bottom = ct(e.bottom)),
+                    (i.width = ct(e.width)),
+                    (i.left = ct(e.left)),
+                    (i.right = ct(e.right)),
+                    o.overlayX === "center"
+                        ? (i.alignItems = "center")
+                        : (i.alignItems =
+                              o.overlayX === "end" ? "flex-end" : "flex-start"),
+                    o.overlayY === "center"
+                        ? (i.justifyContent = "center")
+                        : (i.justifyContent =
+                              o.overlayY === "bottom"
+                                  ? "flex-end"
+                                  : "flex-start"),
+                    r && (i.maxHeight = ct(r)),
+                    s && (i.maxWidth = ct(s));
+            }
+            (this._lastBoundingBoxSize = e), He(this._boundingBox.style, i);
+        }
+        _resetBoundingBoxStyles() {
+            He(this._boundingBox.style, {
+                top: "0",
+                left: "0",
+                right: "0",
+                bottom: "0",
+                height: "",
+                width: "",
+                alignItems: "",
+                justifyContent: "",
+            });
+        }
+        _resetOverlayElementStyles() {
+            He(this._pane.style, {
+                top: "",
+                left: "",
+                bottom: "",
+                right: "",
+                position: "",
+                transform: "",
+            });
+        }
+        _setOverlayElementStyles(t, o) {
+            let e = {},
+                i = this._hasExactPosition(),
+                r = this._hasFlexibleDimensions,
+                s = this._overlayRef.getConfig();
+            if (i) {
+                let d = this._viewportRuler.getViewportScrollPosition();
+                He(e, this._getExactOverlayY(o, t, d)),
+                    He(e, this._getExactOverlayX(o, t, d));
+            } else e.position = "static";
+            let a = "",
+                l = this._getOffset(o, "x"),
+                c = this._getOffset(o, "y");
+            l && (a += `translateX(${l}px) `),
+                c && (a += `translateY(${c}px)`),
+                (e.transform = a.trim()),
+                s.maxHeight &&
+                    (i
+                        ? (e.maxHeight = ct(s.maxHeight))
+                        : r && (e.maxHeight = "")),
+                s.maxWidth &&
+                    (i
+                        ? (e.maxWidth = ct(s.maxWidth))
+                        : r && (e.maxWidth = "")),
+                He(this._pane.style, e);
+        }
+        _getExactOverlayY(t, o, e) {
+            let i = { top: "", bottom: "" },
+                r = this._getOverlayPoint(o, this._overlayRect, t);
+            if (
+                (this._isPushed &&
+                    (r = this._pushOverlayOnScreen(r, this._overlayRect, e)),
+                t.overlayY === "bottom")
+            ) {
+                let s = this._document.documentElement.clientHeight;
+                i.bottom = `${s - (r.y + this._overlayRect.height)}px`;
+            } else i.top = ct(r.y);
+            return i;
+        }
+        _getExactOverlayX(t, o, e) {
+            let i = { left: "", right: "" },
+                r = this._getOverlayPoint(o, this._overlayRect, t);
+            this._isPushed &&
+                (r = this._pushOverlayOnScreen(r, this._overlayRect, e));
+            let s;
+            if (
+                (this._isRtl()
+                    ? (s = t.overlayX === "end" ? "left" : "right")
+                    : (s = t.overlayX === "end" ? "right" : "left"),
+                s === "right")
+            ) {
+                let a = this._document.documentElement.clientWidth;
+                i.right = `${a - (r.x + this._overlayRect.width)}px`;
+            } else i.left = ct(r.x);
+            return i;
+        }
+        _getScrollVisibility() {
+            let t = this._getOriginRect(),
+                o = this._pane.getBoundingClientRect(),
+                e = this._scrollables.map((i) =>
+                    i.getElementRef().nativeElement.getBoundingClientRect()
+                );
+            return {
+                isOriginClipped: fu(t, e),
+                isOriginOutsideView: _a(t, e),
+                isOverlayClipped: fu(o, e),
+                isOverlayOutsideView: _a(o, e),
+            };
+        }
+        _subtractOverflows(t, ...o) {
+            return o.reduce((e, i) => e - Math.max(i, 0), t);
+        }
+        _getNarrowedViewportRect() {
+            let t = this._document.documentElement.clientWidth,
+                o = this._document.documentElement.clientHeight,
+                e = this._viewportRuler.getViewportScrollPosition();
+            return {
+                top: e.top + this._viewportMargin,
+                left: e.left + this._viewportMargin,
+                right: e.left + t - this._viewportMargin,
+                bottom: e.top + o - this._viewportMargin,
+                width: t - 2 * this._viewportMargin,
+                height: o - 2 * this._viewportMargin,
+            };
+        }
+        _isRtl() {
+            return this._overlayRef.getDirection() === "rtl";
+        }
+        _hasExactPosition() {
+            return !this._hasFlexibleDimensions || this._isPushed;
+        }
+        _getOffset(t, o) {
+            return o === "x"
+                ? t.offsetX == null
+                    ? this._offsetX
+                    : t.offsetX
+                : t.offsetY == null
+                  ? this._offsetY
+                  : t.offsetY;
+        }
+        _validatePositions() {}
+        _addPanelClasses(t) {
+            this._pane &&
+                _i(t).forEach((o) => {
+                    o !== "" &&
+                        this._appliedPanelClasses.indexOf(o) === -1 &&
+                        (this._appliedPanelClasses.push(o),
+                        this._pane.classList.add(o));
+                });
+        }
+        _clearPanelClasses() {
+            this._pane &&
+                (this._appliedPanelClasses.forEach((t) => {
+                    this._pane.classList.remove(t);
+                }),
+                (this._appliedPanelClasses = []));
+        }
+        _getOriginRect() {
+            let t = this._origin;
+            if (t instanceof A) return t.nativeElement.getBoundingClientRect();
+            if (t instanceof Element) return t.getBoundingClientRect();
+            let o = t.width || 0,
+                e = t.height || 0;
+            return {
+                top: t.y,
+                bottom: t.y + e,
+                left: t.x,
+                right: t.x + o,
+                height: e,
+                width: o,
+            };
+        }
+    };
+function He(n, t) {
+    for (let o in t) t.hasOwnProperty(o) && (n[o] = t[o]);
+    return n;
+}
+function gu(n) {
+    if (typeof n != "number" && n != null) {
+        let [t, o] = n.split(Lg);
+        return !o || o === "px" ? parseFloat(t) : null;
+    }
+    return n || null;
+}
+function bu(n) {
+    return {
+        top: Math.floor(n.top),
+        right: Math.floor(n.right),
+        bottom: Math.floor(n.bottom),
+        left: Math.floor(n.left),
+        width: Math.floor(n.width),
+        height: Math.floor(n.height),
+    };
+}
+function jg(n, t) {
+    return n === t
+        ? !0
+        : n.isOriginClipped === t.isOriginClipped &&
+              n.isOriginOutsideView === t.isOriginOutsideView &&
+              n.isOverlayClipped === t.isOverlayClipped &&
+              n.isOverlayOutsideView === t.isOverlayOutsideView;
+}
+var vu = "cdk-global-overlay-wrapper",
+    Da = class {
+        constructor() {
+            (this._cssPosition = "static"),
+                (this._topOffset = ""),
+                (this._bottomOffset = ""),
+                (this._alignItems = ""),
+                (this._xPosition = ""),
+                (this._xOffset = ""),
+                (this._width = ""),
+                (this._height = ""),
+                (this._isDisposed = !1);
+        }
+        attach(t) {
+            let o = t.getConfig();
+            (this._overlayRef = t),
+                this._width && !o.width && t.updateSize({ width: this._width }),
+                this._height &&
+                    !o.height &&
+                    t.updateSize({ height: this._height }),
+                t.hostElement.classList.add(vu),
+                (this._isDisposed = !1);
+        }
+        top(t = "") {
+            return (
+                (this._bottomOffset = ""),
+                (this._topOffset = t),
+                (this._alignItems = "flex-start"),
+                this
+            );
+        }
+        left(t = "") {
+            return (this._xOffset = t), (this._xPosition = "left"), this;
+        }
+        bottom(t = "") {
+            return (
+                (this._topOffset = ""),
+                (this._bottomOffset = t),
+                (this._alignItems = "flex-end"),
+                this
+            );
+        }
+        right(t = "") {
+            return (this._xOffset = t), (this._xPosition = "right"), this;
+        }
+        start(t = "") {
+            return (this._xOffset = t), (this._xPosition = "start"), this;
+        }
+        end(t = "") {
+            return (this._xOffset = t), (this._xPosition = "end"), this;
+        }
+        width(t = "") {
+            return (
+                this._overlayRef
+                    ? this._overlayRef.updateSize({ width: t })
+                    : (this._width = t),
+                this
+            );
+        }
+        height(t = "") {
+            return (
+                this._overlayRef
+                    ? this._overlayRef.updateSize({ height: t })
+                    : (this._height = t),
+                this
+            );
+        }
+        centerHorizontally(t = "") {
+            return this.left(t), (this._xPosition = "center"), this;
+        }
+        centerVertically(t = "") {
+            return this.top(t), (this._alignItems = "center"), this;
+        }
+        apply() {
+            if (!this._overlayRef || !this._overlayRef.hasAttached()) return;
+            let t = this._overlayRef.overlayElement.style,
+                o = this._overlayRef.hostElement.style,
+                e = this._overlayRef.getConfig(),
+                { width: i, height: r, maxWidth: s, maxHeight: a } = e,
+                l =
+                    (i === "100%" || i === "100vw") &&
+                    (!s || s === "100%" || s === "100vw"),
+                c =
+                    (r === "100%" || r === "100vh") &&
+                    (!a || a === "100%" || a === "100vh"),
+                d = this._xPosition,
+                h = this._xOffset,
+                f = this._overlayRef.getConfig().direction === "rtl",
+                w = "",
+                j = "",
+                z = "";
+            l
+                ? (z = "flex-start")
+                : d === "center"
+                  ? ((z = "center"), f ? (j = h) : (w = h))
+                  : f
+                    ? d === "left" || d === "end"
+                        ? ((z = "flex-end"), (w = h))
+                        : (d === "right" || d === "start") &&
+                          ((z = "flex-start"), (j = h))
+                    : d === "left" || d === "start"
+                      ? ((z = "flex-start"), (w = h))
+                      : (d === "right" || d === "end") &&
+                        ((z = "flex-end"), (j = h)),
+                (t.position = this._cssPosition),
+                (t.marginLeft = l ? "0" : w),
+                (t.marginTop = c ? "0" : this._topOffset),
+                (t.marginBottom = this._bottomOffset),
+                (t.marginRight = l ? "0" : j),
+                (o.justifyContent = z),
+                (o.alignItems = c ? "flex-start" : this._alignItems);
+        }
+        dispose() {
+            if (this._isDisposed || !this._overlayRef) return;
+            let t = this._overlayRef.overlayElement.style,
+                o = this._overlayRef.hostElement,
+                e = o.style;
+            o.classList.remove(vu),
+                (e.justifyContent =
+                    e.alignItems =
+                    t.marginTop =
+                    t.marginBottom =
+                    t.marginLeft =
+                    t.marginRight =
+                    t.position =
+                        ""),
+                (this._overlayRef = null),
+                (this._isDisposed = !0);
+        }
+    },
+    Vg = (() => {
+        let t = class t {
+            constructor(e, i, r, s) {
+                (this._viewportRuler = e),
+                    (this._document = i),
+                    (this._platform = r),
+                    (this._overlayContainer = s);
+            }
+            global() {
+                return new Da();
+            }
+            flexibleConnectedTo(e) {
+                return new Ca(
+                    e,
+                    this._viewportRuler,
+                    this._document,
+                    this._platform,
+                    this._overlayContainer
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(m(bn), m(T), m(J), m(yu));
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })(),
+    zg = 0,
+    we = (() => {
+        let t = class t {
+            constructor(e, i, r, s, a, l, c, d, h, f, w, j) {
+                (this.scrollStrategies = e),
+                    (this._overlayContainer = i),
+                    (this._componentFactoryResolver = r),
+                    (this._positionBuilder = s),
+                    (this._keyboardDispatcher = a),
+                    (this._injector = l),
+                    (this._ngZone = c),
+                    (this._document = d),
+                    (this._directionality = h),
+                    (this._location = f),
+                    (this._outsideClickDispatcher = w),
+                    (this._animationsModuleType = j);
+            }
+            create(e) {
+                let i = this._createHostElement(),
+                    r = this._createPaneElement(i),
+                    s = this._createPortalOutlet(r),
+                    a = new In(e);
+                return (
+                    (a.direction = a.direction || this._directionality.value),
+                    new wa(
+                        s,
+                        i,
+                        r,
+                        a,
+                        this._ngZone,
+                        this._keyboardDispatcher,
+                        this._document,
+                        this._location,
+                        this._outsideClickDispatcher,
+                        this._animationsModuleType === "NoopAnimations"
+                    )
+                );
+            }
+            position() {
+                return this._positionBuilder;
+            }
+            _createPaneElement(e) {
+                let i = this._document.createElement("div");
+                return (
+                    (i.id = `cdk-overlay-${zg++}`),
+                    i.classList.add("cdk-overlay-pane"),
+                    e.appendChild(i),
+                    i
+                );
+            }
+            _createHostElement() {
+                let e = this._document.createElement("div");
+                return (
+                    this._overlayContainer.getContainerElement().appendChild(e),
+                    e
+                );
+            }
+            _createPortalOutlet(e) {
+                return (
+                    this._appRef || (this._appRef = this._injector.get(Re)),
+                    new Sn(
+                        e,
+                        this._componentFactoryResolver,
+                        this._appRef,
+                        this._injector,
+                        this._document
+                    )
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(
+                m(Og),
+                m(yu),
+                m(Nn),
+                m(Vg),
+                m(Ng),
+                m(Kt),
+                m(I),
+                m(T),
+                m(gi),
+                m(Te),
+                m(Pg),
+                m(Bt, 8)
+            );
+        }),
+            (t.ɵprov = b({ token: t, factory: t.ɵfac, providedIn: "root" }));
+        let n = t;
+        return n;
+    })();
+var Bg = new C("cdk-connected-overlay-scroll-strategy", {
+    providedIn: "root",
+    factory: () => {
+        let n = g(we);
+        return () => n.scrollStrategies.reposition();
+    },
+});
+function Ug(n) {
+    return () => n.scrollStrategies.reposition();
+}
+var Hg = { provide: Bg, deps: [we], useFactory: Ug },
+    xu = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ providers: [we, Hg], imports: [_e, hu, vn, vn] }));
+        let n = t;
+        return n;
+    })();
+var qg = ["mat-menu-item", ""],
+    Zg = [[["mat-icon"], ["", "matMenuItemIcon", ""]], "*"],
+    Xg = ["mat-icon, [matMenuItemIcon]", "*"];
+function Kg(n, t) {
+    n & 1 && (La(), x(0, "svg", 2), H(1, "polygon", 3), _());
+}
+var Qg = ["*"];
+function Jg(n, t) {
+    if (n & 1) {
+        let o = Ft();
+        x(0, "div", 0),
+            Z("keydown", function (i) {
+                xt(o);
+                let r = X();
+                return wt(r._handleKeydown(i));
+            })("click", function () {
+                xt(o);
+                let i = X();
+                return wt(i.closed.emit("click"));
+            })("@transformMenu.start", function (i) {
+                xt(o);
+                let r = X();
+                return wt(r._onAnimationStart(i));
+            })("@transformMenu.done", function (i) {
+                xt(o);
+                let r = X();
+                return wt(r._onAnimationDone(i));
+            }),
+            x(1, "div", 1),
+            K(2),
+            _()();
+    }
+    if (n & 2) {
+        let o = X();
+        Jt(o._classList),
+            L("id", o.panelId)("@transformMenu", o._panelAnimationState),
+            ft("aria-label", o.ariaLabel || null)(
+                "aria-labelledby",
+                o.ariaLabelledby || null
+            )("aria-describedby", o.ariaDescribedby || null);
+    }
+}
+var Ea = new C("MAT_MENU_PANEL"),
+    Rn = (() => {
+        let t = class t {
+            constructor(e, i, r, s, a) {
+                (this._elementRef = e),
+                    (this._document = i),
+                    (this._focusMonitor = r),
+                    (this._parentMenu = s),
+                    (this._changeDetectorRef = a),
+                    (this.role = "menuitem"),
+                    (this.disabled = !1),
+                    (this.disableRipple = !1),
+                    (this._hovered = new N()),
+                    (this._focused = new N()),
+                    (this._highlighted = !1),
+                    (this._triggersSubmenu = !1),
+                    s?.addItem?.(this);
+            }
+            focus(e, i) {
+                this._focusMonitor && e
+                    ? this._focusMonitor.focusVia(this._getHostElement(), e, i)
+                    : this._getHostElement().focus(i),
+                    this._focused.next(this);
+            }
+            ngAfterViewInit() {
+                this._focusMonitor &&
+                    this._focusMonitor.monitor(this._elementRef, !1);
+            }
+            ngOnDestroy() {
+                this._focusMonitor &&
+                    this._focusMonitor.stopMonitoring(this._elementRef),
+                    this._parentMenu &&
+                        this._parentMenu.removeItem &&
+                        this._parentMenu.removeItem(this),
+                    this._hovered.complete(),
+                    this._focused.complete();
+            }
+            _getTabIndex() {
+                return this.disabled ? "-1" : "0";
+            }
+            _getHostElement() {
+                return this._elementRef.nativeElement;
+            }
+            _checkDisabled(e) {
+                this.disabled && (e.preventDefault(), e.stopPropagation());
+            }
+            _handleMouseEnter() {
+                this._hovered.next(this);
+            }
+            getLabel() {
+                let e = this._elementRef.nativeElement.cloneNode(!0),
+                    i = e.querySelectorAll("mat-icon, .material-icons");
+                for (let r = 0; r < i.length; r++) i[r].remove();
+                return e.textContent?.trim() || "";
+            }
+            _setHighlighted(e) {
+                (this._highlighted = e),
+                    this._changeDetectorRef?.markForCheck();
+            }
+            _setTriggersSubmenu(e) {
+                (this._triggersSubmenu = e),
+                    this._changeDetectorRef?.markForCheck();
+            }
+            _hasFocus() {
+                return (
+                    this._document &&
+                    this._document.activeElement === this._getHostElement()
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(A), u(T), u(wn), u(Ea, 8), u(Dt));
+        }),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["", "mat-menu-item", ""]],
+                hostAttrs: [1, "mat-mdc-menu-item", "mat-mdc-focus-indicator"],
+                hostVars: 8,
+                hostBindings: function (i, r) {
+                    i & 1 &&
+                        Z("click", function (a) {
+                            return r._checkDisabled(a);
+                        })("mouseenter", function () {
+                            return r._handleMouseEnter();
+                        }),
+                        i & 2 &&
+                            (ft("role", r.role)("tabindex", r._getTabIndex())(
+                                "aria-disabled",
+                                r.disabled
+                            )("disabled", r.disabled || null),
+                            st("mat-mdc-menu-item-highlighted", r._highlighted)(
+                                "mat-mdc-menu-item-submenu-trigger",
+                                r._triggersSubmenu
+                            ));
+                },
+                inputs: {
+                    role: "role",
+                    disabled: [
+                        y.HasDecoratorInputTransform,
+                        "disabled",
+                        "disabled",
+                        W,
+                    ],
+                    disableRipple: [
+                        y.HasDecoratorInputTransform,
+                        "disableRipple",
+                        "disableRipple",
+                        W,
+                    ],
+                },
+                exportAs: ["matMenuItem"],
+                standalone: !0,
+                features: [nt, tt],
+                attrs: qg,
+                ngContentSelectors: Xg,
+                decls: 5,
+                vars: 3,
+                consts: [
+                    [1, "mat-mdc-menu-item-text"],
+                    [
+                        "matRipple",
+                        "",
+                        1,
+                        "mat-mdc-menu-ripple",
+                        3,
+                        "matRippleDisabled",
+                        "matRippleTrigger",
+                    ],
+                    [
+                        "viewBox",
+                        "0 0 5 10",
+                        "focusable",
+                        "false",
+                        "aria-hidden",
+                        "true",
+                        1,
+                        "mat-mdc-menu-submenu-icon",
+                    ],
+                    ["points", "0,0 5,5 0,10"],
+                ],
+                template: function (i, r) {
+                    i & 1 &&
+                        (pt(Zg),
+                        K(0),
+                        x(1, "span", 0),
+                        K(2, 1),
+                        _(),
+                        H(3, "div", 1),
+                        ot(4, Kg, 2, 0, ":svg:svg", 2)),
+                        i & 2 &&
+                            (R(3),
+                            L(
+                                "matRippleDisabled",
+                                r.disableRipple || r.disabled
+                            )("matRippleTrigger", r._getHostElement()),
+                            R(),
+                            Ut(4, r._triggersSubmenu ? 4 : -1));
+                },
+                dependencies: [ha],
+                encapsulation: 2,
+                changeDetection: 0,
+            }));
+        let n = t;
+        return n;
+    })();
+var tb = new C("MatMenuContent");
+var nr = {
+        transformMenu: Cr("transformMenu", [
+            Dr("void", ti({ opacity: 0, transform: "scale(0.8)" })),
+            Gn(
+                "void => enter",
+                Wn(
+                    "120ms cubic-bezier(0, 0, 0.2, 1)",
+                    ti({ opacity: 1, transform: "scale(1)" })
+                )
+            ),
+            Gn("* => void", Wn("100ms 25ms linear", ti({ opacity: 0 }))),
+        ]),
+        fadeInItems: Cr("fadeInItems", [
+            Dr("showing", ti({ opacity: 1 })),
+            Gn("void => *", [
+                ti({ opacity: 0 }),
+                Wn("400ms 100ms cubic-bezier(0.55, 0, 0.55, 0.2)"),
+            ]),
+        ]),
+    },
+    dx = nr.fadeInItems,
+    ux = nr.transformMenu,
+    eb = 0,
+    ib = new C("mat-menu-default-options", { providedIn: "root", factory: nb });
+function nb() {
+    return {
+        overlapTrigger: !1,
+        xPosition: "after",
+        yPosition: "below",
+        backdropClass: "cdk-overlay-transparent-backdrop",
+    };
+}
+var Di = (() => {
+        let t = class t {
+            get xPosition() {
+                return this._xPosition;
+            }
+            set xPosition(e) {
+                (this._xPosition = e), this.setPositionClasses();
+            }
+            get yPosition() {
+                return this._yPosition;
+            }
+            set yPosition(e) {
+                (this._yPosition = e), this.setPositionClasses();
+            }
+            set panelClass(e) {
+                let i = this._previousPanelClass,
+                    r = p({}, this._classList);
+                i &&
+                    i.length &&
+                    i.split(" ").forEach((s) => {
+                        r[s] = !1;
+                    }),
+                    (this._previousPanelClass = e),
+                    e &&
+                        e.length &&
+                        (e.split(" ").forEach((s) => {
+                            r[s] = !0;
+                        }),
+                        (this._elementRef.nativeElement.className = "")),
+                    (this._classList = r);
+            }
+            get classList() {
+                return this.panelClass;
+            }
+            set classList(e) {
+                this.panelClass = e;
+            }
+            constructor(e, i, r, s) {
+                (this._elementRef = e),
+                    (this._ngZone = i),
+                    (this._changeDetectorRef = s),
+                    (this._elevationPrefix = "mat-elevation-z"),
+                    (this._baseElevation = 8),
+                    (this._directDescendantItems = new Ri()),
+                    (this._classList = {}),
+                    (this._panelAnimationState = "void"),
+                    (this._animationDone = new N()),
+                    (this.closed = new it()),
+                    (this.close = this.closed),
+                    (this.panelId = `mat-menu-panel-${eb++}`),
+                    (this.overlayPanelClass = r.overlayPanelClass || ""),
+                    (this._xPosition = r.xPosition),
+                    (this._yPosition = r.yPosition),
+                    (this.backdropClass = r.backdropClass),
+                    (this.overlapTrigger = r.overlapTrigger),
+                    (this.hasBackdrop = r.hasBackdrop);
+            }
+            ngOnInit() {
+                this.setPositionClasses();
+            }
+            ngAfterContentInit() {
+                this._updateDirectDescendants(),
+                    (this._keyManager = new Yo(this._directDescendantItems)
+                        .withWrap()
+                        .withTypeAhead()
+                        .withHomeAndEnd()),
+                    this._keyManager.tabOut.subscribe(() =>
+                        this.closed.emit("tab")
+                    ),
+                    this._directDescendantItems.changes
+                        .pipe(
+                            Xt(this._directDescendantItems),
+                            vt((e) => qt(...e.map((i) => i._focused)))
+                        )
+                        .subscribe((e) => this._keyManager.updateActiveItem(e)),
+                    this._directDescendantItems.changes.subscribe((e) => {
+                        let i = this._keyManager;
+                        if (
+                            this._panelAnimationState === "enter" &&
+                            i.activeItem?._hasFocus()
+                        ) {
+                            let r = e.toArray(),
+                                s = Math.max(
+                                    0,
+                                    Math.min(
+                                        r.length - 1,
+                                        i.activeItemIndex || 0
+                                    )
+                                );
+                            r[s] && !r[s].disabled
+                                ? i.setActiveItem(s)
+                                : i.setNextItemActive();
+                        }
+                    });
+            }
+            ngOnDestroy() {
+                this._keyManager?.destroy(),
+                    this._directDescendantItems.destroy(),
+                    this.closed.complete(),
+                    this._firstItemFocusSubscription?.unsubscribe();
+            }
+            _hovered() {
+                return this._directDescendantItems.changes.pipe(
+                    Xt(this._directDescendantItems),
+                    vt((i) => qt(...i.map((r) => r._hovered)))
+                );
+            }
+            addItem(e) {}
+            removeItem(e) {}
+            _handleKeydown(e) {
+                let i = e.keyCode,
+                    r = this._keyManager;
+                switch (i) {
+                    case 27:
+                        $o(e) ||
+                            (e.preventDefault(), this.closed.emit("keydown"));
+                        break;
+                    case 37:
+                        this.parentMenu &&
+                            this.direction === "ltr" &&
+                            this.closed.emit("keydown");
+                        break;
+                    case 39:
+                        this.parentMenu &&
+                            this.direction === "rtl" &&
+                            this.closed.emit("keydown");
+                        break;
+                    default:
+                        (i === 38 || i === 40) && r.setFocusOrigin("keyboard"),
+                            r.onKeydown(e);
+                        return;
+                }
+                e.stopPropagation();
+            }
+            focusFirstItem(e = "program") {
+                this._firstItemFocusSubscription?.unsubscribe(),
+                    (this._firstItemFocusSubscription = this._ngZone.onStable
+                        .pipe(ut(1))
+                        .subscribe(() => {
+                            let i = null;
+                            if (
+                                (this._directDescendantItems.length &&
+                                    (i = this._directDescendantItems.first
+                                        ._getHostElement()
+                                        .closest('[role="menu"]')),
+                                !i || !i.contains(document.activeElement))
+                            ) {
+                                let r = this._keyManager;
+                                r.setFocusOrigin(e).setFirstItemActive(),
+                                    !r.activeItem && i && i.focus();
+                            }
+                        }));
+            }
+            resetActiveItem() {
+                this._keyManager.setActiveItem(-1);
+            }
+            setElevation(e) {
+                let i = Math.min(this._baseElevation + e, 24),
+                    r = `${this._elevationPrefix}${i}`,
+                    s = Object.keys(this._classList).find((a) =>
+                        a.startsWith(this._elevationPrefix)
+                    );
+                if (!s || s === this._previousElevation) {
+                    let a = p({}, this._classList);
+                    this._previousElevation &&
+                        (a[this._previousElevation] = !1),
+                        (a[r] = !0),
+                        (this._previousElevation = r),
+                        (this._classList = a);
+                }
+            }
+            setPositionClasses(e = this.xPosition, i = this.yPosition) {
+                (this._classList = q(p({}, this._classList), {
+                    "mat-menu-before": e === "before",
+                    "mat-menu-after": e === "after",
+                    "mat-menu-above": i === "above",
+                    "mat-menu-below": i === "below",
+                })),
+                    this._changeDetectorRef?.markForCheck();
+            }
+            _startAnimation() {
+                this._panelAnimationState = "enter";
+            }
+            _resetAnimation() {
+                this._panelAnimationState = "void";
+            }
+            _onAnimationDone(e) {
+                this._animationDone.next(e), (this._isAnimating = !1);
+            }
+            _onAnimationStart(e) {
+                (this._isAnimating = !0),
+                    e.toState === "enter" &&
+                        this._keyManager.activeItemIndex === 0 &&
+                        (e.element.scrollTop = 0);
+            }
+            _updateDirectDescendants() {
+                this._allItems.changes
+                    .pipe(Xt(this._allItems))
+                    .subscribe((e) => {
+                        this._directDescendantItems.reset(
+                            e.filter((i) => i._parentMenu === this)
+                        ),
+                            this._directDescendantItems.notifyOnChanges();
+                    });
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(u(A), u(I), u(ib), u(Dt));
+        }),
+            (t.ɵcmp = P({
+                type: t,
+                selectors: [["mat-menu"]],
+                contentQueries: function (i, r, s) {
+                    if (
+                        (i & 1 && (gt(s, tb, 5), gt(s, Rn, 5), gt(s, Rn, 4)),
+                        i & 2)
+                    ) {
+                        let a;
+                        at((a = lt())) && (r.lazyContent = a.first),
+                            at((a = lt())) && (r._allItems = a),
+                            at((a = lt())) && (r.items = a);
+                    }
+                },
+                viewQuery: function (i, r) {
+                    if ((i & 1 && Xe(Ct, 5), i & 2)) {
+                        let s;
+                        at((s = lt())) && (r.templateRef = s.first);
+                    }
+                },
+                hostVars: 3,
+                hostBindings: function (i, r) {
+                    i & 2 &&
+                        ft("aria-label", null)("aria-labelledby", null)(
+                            "aria-describedby",
+                            null
+                        );
+                },
+                inputs: {
+                    backdropClass: "backdropClass",
+                    ariaLabel: [y.None, "aria-label", "ariaLabel"],
+                    ariaLabelledby: [
+                        y.None,
+                        "aria-labelledby",
+                        "ariaLabelledby",
+                    ],
+                    ariaDescribedby: [
+                        y.None,
+                        "aria-describedby",
+                        "ariaDescribedby",
+                    ],
+                    xPosition: "xPosition",
+                    yPosition: "yPosition",
+                    overlapTrigger: [
+                        y.HasDecoratorInputTransform,
+                        "overlapTrigger",
+                        "overlapTrigger",
+                        W,
+                    ],
+                    hasBackdrop: [
+                        y.HasDecoratorInputTransform,
+                        "hasBackdrop",
+                        "hasBackdrop",
+                        (e) => (e == null ? null : W(e)),
+                    ],
+                    panelClass: [y.None, "class", "panelClass"],
+                    classList: "classList",
+                },
+                outputs: { closed: "closed", close: "close" },
+                exportAs: ["matMenu"],
+                standalone: !0,
+                features: [Q([{ provide: Ea, useExisting: t }]), nt, tt],
+                ngContentSelectors: Qg,
+                decls: 1,
+                vars: 0,
+                consts: [
+                    [
+                        "tabindex",
+                        "-1",
+                        "role",
+                        "menu",
+                        1,
+                        "mat-mdc-menu-panel",
+                        "mat-mdc-elevation-specific",
+                        3,
+                        "keydown",
+                        "click",
+                        "id",
+                    ],
+                    [1, "mat-mdc-menu-content"],
+                ],
+                template: function (i, r) {
+                    i & 1 && (pt(), ot(0, Jg, 3, 7, "ng-template"));
+                },
+                styles: [
+                    'mat-menu{display:none}.mat-mdc-menu-content{margin:0;padding:8px 0;list-style-type:none}.mat-mdc-menu-content:focus{outline:none}.mat-mdc-menu-content,.mat-mdc-menu-content .mat-mdc-menu-item .mat-mdc-menu-item-text{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;flex:1;white-space:normal;font-family:var(--mat-menu-item-label-text-font);line-height:var(--mat-menu-item-label-text-line-height);font-size:var(--mat-menu-item-label-text-size);letter-spacing:var(--mat-menu-item-label-text-tracking);font-weight:var(--mat-menu-item-label-text-weight)}.mat-mdc-menu-panel{min-width:112px;max-width:280px;overflow:auto;-webkit-overflow-scrolling:touch;box-sizing:border-box;outline:0;border-radius:var(--mat-menu-container-shape);background-color:var(--mat-menu-container-color);will-change:transform,opacity}.mat-mdc-menu-panel.ng-animating{pointer-events:none}.cdk-high-contrast-active .mat-mdc-menu-panel{outline:solid 1px}.mat-divider{color:var(--mat-menu-divider-color);margin-bottom:var(--mat-menu-divider-bottom-spacing);margin-top:var(--mat-menu-divider-top-spacing)}.mat-mdc-menu-item{display:flex;position:relative;align-items:center;justify-content:flex-start;overflow:hidden;padding:0;padding-left:var(--mat-menu-item-leading-spacing);padding-right:var(--mat-menu-item-trailing-spacing);-webkit-user-select:none;user-select:none;cursor:pointer;outline:none;border:none;-webkit-tap-highlight-color:rgba(0,0,0,0);cursor:pointer;width:100%;text-align:left;box-sizing:border-box;color:inherit;font-size:inherit;background:none;text-decoration:none;margin:0;align-items:center;min-height:48px}.mat-mdc-menu-item:focus{outline:none}[dir=rtl] .mat-mdc-menu-item,.mat-mdc-menu-item[dir=rtl]{padding-left:var(--mat-menu-item-trailing-spacing);padding-right:var(--mat-menu-item-leading-spacing)}.mat-mdc-menu-item:has(.material-icons,mat-icon,[matButtonIcon]){padding-left:var(--mat-menu-item-with-icon-leading-spacing);padding-right:var(--mat-menu-item-with-icon-trailing-spacing)}[dir=rtl] .mat-mdc-menu-item:has(.material-icons,mat-icon,[matButtonIcon]),.mat-mdc-menu-item:has(.material-icons,mat-icon,[matButtonIcon])[dir=rtl]{padding-left:var(--mat-menu-item-with-icon-trailing-spacing);padding-right:var(--mat-menu-item-with-icon-leading-spacing)}.mat-mdc-menu-item::-moz-focus-inner{border:0}.mat-mdc-menu-item,.mat-mdc-menu-item:visited,.mat-mdc-menu-item:link{color:var(--mat-menu-item-label-text-color)}.mat-mdc-menu-item .mat-icon-no-color,.mat-mdc-menu-item .mat-mdc-menu-submenu-icon{color:var(--mat-menu-item-icon-color)}.mat-mdc-menu-item[disabled]{cursor:default;opacity:.38}.mat-mdc-menu-item[disabled]::after{display:block;position:absolute;content:"";top:0;left:0;bottom:0;right:0}.mat-mdc-menu-item .mat-icon{flex-shrink:0;margin-right:var(--mat-menu-item-spacing);height:var(--mat-menu-item-icon-size);width:var(--mat-menu-item-icon-size)}[dir=rtl] .mat-mdc-menu-item{text-align:right}[dir=rtl] .mat-mdc-menu-item .mat-icon{margin-right:0;margin-left:var(--mat-menu-item-spacing)}.mat-mdc-menu-item:not([disabled]):hover{background-color:var(--mat-menu-item-hover-state-layer-color)}.mat-mdc-menu-item:not([disabled]).cdk-program-focused,.mat-mdc-menu-item:not([disabled]).cdk-keyboard-focused,.mat-mdc-menu-item:not([disabled]).mat-mdc-menu-item-highlighted{background-color:var(--mat-menu-item-focus-state-layer-color)}.cdk-high-contrast-active .mat-mdc-menu-item{margin-top:1px}.mat-mdc-menu-submenu-icon{width:var(--mat-menu-item-icon-size);height:10px;fill:currentColor;padding-left:var(--mat-menu-item-spacing)}[dir=rtl] .mat-mdc-menu-submenu-icon{padding-right:var(--mat-menu-item-spacing);padding-left:0}[dir=rtl] .mat-mdc-menu-submenu-icon polygon{transform:scaleX(-1)}.cdk-high-contrast-active .mat-mdc-menu-submenu-icon{fill:CanvasText}.mat-mdc-menu-item .mat-mdc-menu-ripple{top:0;left:0;right:0;bottom:0;position:absolute;pointer-events:none}',
+                ],
+                encapsulation: 2,
+                data: { animation: [nr.transformMenu, nr.fadeInItems] },
+                changeDetection: 0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Cu = new C("mat-menu-scroll-strategy", {
+        providedIn: "root",
+        factory: () => {
+            let n = g(we);
+            return () => n.scrollStrategies.reposition();
+        },
+    });
+function ob(n) {
+    return () => n.scrollStrategies.reposition();
+}
+var rb = { provide: Cu, deps: [we], useFactory: ob },
+    wu = ye({ passive: !0 });
+var Du = (() => {
+        let t = class t {
+            get _deprecatedMatMenuTriggerFor() {
+                return this.menu;
+            }
+            set _deprecatedMatMenuTriggerFor(e) {
+                this.menu = e;
+            }
+            get menu() {
+                return this._menu;
+            }
+            set menu(e) {
+                e !== this._menu &&
+                    ((this._menu = e),
+                    this._menuCloseSubscription.unsubscribe(),
+                    e &&
+                        (this._parentMaterialMenu,
+                        (this._menuCloseSubscription = e.close.subscribe(
+                            (i) => {
+                                this._destroyMenu(i),
+                                    (i === "click" || i === "tab") &&
+                                        this._parentMaterialMenu &&
+                                        this._parentMaterialMenu.closed.emit(i);
+                            }
+                        ))),
+                    this._menuItemInstance?._setTriggersSubmenu(
+                        this.triggersSubmenu()
+                    ));
+            }
+            constructor(e, i, r, s, a, l, c, d, h) {
+                (this._overlay = e),
+                    (this._element = i),
+                    (this._viewContainerRef = r),
+                    (this._menuItemInstance = l),
+                    (this._dir = c),
+                    (this._focusMonitor = d),
+                    (this._ngZone = h),
+                    (this._overlayRef = null),
+                    (this._menuOpen = !1),
+                    (this._closingActionsSubscription = St.EMPTY),
+                    (this._hoverSubscription = St.EMPTY),
+                    (this._menuCloseSubscription = St.EMPTY),
+                    (this._changeDetectorRef = g(Dt)),
+                    (this._handleTouchStart = (f) => {
+                        xn(f) || (this._openedBy = "touch");
+                    }),
+                    (this._openedBy = void 0),
+                    (this.restoreFocus = !0),
+                    (this.menuOpened = new it()),
+                    (this.onMenuOpen = this.menuOpened),
+                    (this.menuClosed = new it()),
+                    (this.onMenuClose = this.menuClosed),
+                    (this._scrollStrategy = s),
+                    (this._parentMaterialMenu = a instanceof Di ? a : void 0),
+                    i.nativeElement.addEventListener(
+                        "touchstart",
+                        this._handleTouchStart,
+                        wu
+                    );
+            }
+            ngAfterContentInit() {
+                this._handleHover();
+            }
+            ngOnDestroy() {
+                this._overlayRef &&
+                    (this._overlayRef.dispose(), (this._overlayRef = null)),
+                    this._element.nativeElement.removeEventListener(
+                        "touchstart",
+                        this._handleTouchStart,
+                        wu
+                    ),
+                    this._menuCloseSubscription.unsubscribe(),
+                    this._closingActionsSubscription.unsubscribe(),
+                    this._hoverSubscription.unsubscribe();
+            }
+            get menuOpen() {
+                return this._menuOpen;
+            }
+            get dir() {
+                return this._dir && this._dir.value === "rtl" ? "rtl" : "ltr";
+            }
+            triggersSubmenu() {
+                return !!(
+                    this._menuItemInstance &&
+                    this._parentMaterialMenu &&
+                    this.menu
+                );
+            }
+            toggleMenu() {
+                return this._menuOpen ? this.closeMenu() : this.openMenu();
+            }
+            openMenu() {
+                let e = this.menu;
+                if (this._menuOpen || !e) return;
+                let i = this._createOverlay(e),
+                    r = i.getConfig(),
+                    s = r.positionStrategy;
+                this._setPosition(e, s),
+                    (r.hasBackdrop =
+                        e.hasBackdrop == null
+                            ? !this.triggersSubmenu()
+                            : e.hasBackdrop),
+                    i.attach(this._getPortal(e)),
+                    e.lazyContent && e.lazyContent.attach(this.menuData),
+                    (this._closingActionsSubscription =
+                        this._menuClosingActions().subscribe(() =>
+                            this.closeMenu()
+                        )),
+                    this._initMenu(e),
+                    e instanceof Di &&
+                        (e._startAnimation(),
+                        e._directDescendantItems.changes
+                            .pipe(mt(e.close))
+                            .subscribe(() => {
+                                s.withLockedPosition(!1).reapplyLastPosition(),
+                                    s.withLockedPosition(!0);
+                            }));
+            }
+            closeMenu() {
+                this.menu?.close.emit();
+            }
+            focus(e, i) {
+                this._focusMonitor && e
+                    ? this._focusMonitor.focusVia(this._element, e, i)
+                    : this._element.nativeElement.focus(i);
+            }
+            updatePosition() {
+                this._overlayRef?.updatePosition();
+            }
+            _destroyMenu(e) {
+                if (!this._overlayRef || !this.menuOpen) return;
+                let i = this.menu;
+                this._closingActionsSubscription.unsubscribe(),
+                    this._overlayRef.detach(),
+                    this.restoreFocus &&
+                        (e === "keydown" ||
+                            !this._openedBy ||
+                            !this.triggersSubmenu()) &&
+                        this.focus(this._openedBy),
+                    (this._openedBy = void 0),
+                    i instanceof Di
+                        ? (i._resetAnimation(),
+                          i.lazyContent
+                              ? i._animationDone
+                                    .pipe(
+                                        dt((r) => r.toState === "void"),
+                                        ut(1),
+                                        mt(i.lazyContent._attached)
+                                    )
+                                    .subscribe({
+                                        next: () => i.lazyContent.detach(),
+                                        complete: () => this._setIsMenuOpen(!1),
+                                    })
+                              : this._setIsMenuOpen(!1))
+                        : (this._setIsMenuOpen(!1), i?.lazyContent?.detach());
+            }
+            _initMenu(e) {
+                (e.parentMenu = this.triggersSubmenu()
+                    ? this._parentMaterialMenu
+                    : void 0),
+                    (e.direction = this.dir),
+                    this._setMenuElevation(e),
+                    e.focusFirstItem(this._openedBy || "program"),
+                    this._setIsMenuOpen(!0);
+            }
+            _setMenuElevation(e) {
+                if (e.setElevation) {
+                    let i = 0,
+                        r = e.parentMenu;
+                    for (; r; ) i++, (r = r.parentMenu);
+                    e.setElevation(i);
+                }
+            }
+            _setIsMenuOpen(e) {
+                e !== this._menuOpen &&
+                    ((this._menuOpen = e),
+                    this._menuOpen
+                        ? this.menuOpened.emit()
+                        : this.menuClosed.emit(),
+                    this.triggersSubmenu() &&
+                        this._menuItemInstance._setHighlighted(e),
+                    this._changeDetectorRef.markForCheck());
+            }
+            _createOverlay(e) {
+                if (!this._overlayRef) {
+                    let i = this._getOverlayConfig(e);
+                    this._subscribeToPositions(e, i.positionStrategy),
+                        (this._overlayRef = this._overlay.create(i)),
+                        this._overlayRef.keydownEvents().subscribe();
+                }
+                return this._overlayRef;
+            }
+            _getOverlayConfig(e) {
+                return new In({
+                    positionStrategy: this._overlay
+                        .position()
+                        .flexibleConnectedTo(this._element)
+                        .withLockedPosition()
+                        .withGrowAfterOpen()
+                        .withTransformOriginOn(
+                            ".mat-menu-panel, .mat-mdc-menu-panel"
+                        ),
+                    backdropClass:
+                        e.backdropClass || "cdk-overlay-transparent-backdrop",
+                    panelClass: e.overlayPanelClass,
+                    scrollStrategy: this._scrollStrategy(),
+                    direction: this._dir,
+                });
+            }
+            _subscribeToPositions(e, i) {
+                e.setPositionClasses &&
+                    i.positionChanges.subscribe((r) => {
+                        let s =
+                                r.connectionPair.overlayX === "start"
+                                    ? "after"
+                                    : "before",
+                            a =
+                                r.connectionPair.overlayY === "top"
+                                    ? "below"
+                                    : "above";
+                        this._ngZone
+                            ? this._ngZone.run(() => e.setPositionClasses(s, a))
+                            : e.setPositionClasses(s, a);
+                    });
+            }
+            _setPosition(e, i) {
+                let [r, s] =
+                        e.xPosition === "before"
+                            ? ["end", "start"]
+                            : ["start", "end"],
+                    [a, l] =
+                        e.yPosition === "above"
+                            ? ["bottom", "top"]
+                            : ["top", "bottom"],
+                    [c, d] = [a, l],
+                    [h, f] = [r, s],
+                    w = 0;
+                if (this.triggersSubmenu()) {
+                    if (
+                        ((f = r = e.xPosition === "before" ? "start" : "end"),
+                        (s = h = r === "end" ? "start" : "end"),
+                        this._parentMaterialMenu)
+                    ) {
+                        if (this._parentInnerPadding == null) {
+                            let j = this._parentMaterialMenu.items.first;
+                            this._parentInnerPadding = j
+                                ? j._getHostElement().offsetTop
+                                : 0;
+                        }
+                        w =
+                            a === "bottom"
+                                ? this._parentInnerPadding
+                                : -this._parentInnerPadding;
+                    }
+                } else
+                    e.overlapTrigger ||
+                        ((c = a === "top" ? "bottom" : "top"),
+                        (d = l === "top" ? "bottom" : "top"));
+                i.withPositions([
+                    {
+                        originX: r,
+                        originY: c,
+                        overlayX: h,
+                        overlayY: a,
+                        offsetY: w,
+                    },
+                    {
+                        originX: s,
+                        originY: c,
+                        overlayX: f,
+                        overlayY: a,
+                        offsetY: w,
+                    },
+                    {
+                        originX: r,
+                        originY: d,
+                        overlayX: h,
+                        overlayY: l,
+                        offsetY: -w,
+                    },
+                    {
+                        originX: s,
+                        originY: d,
+                        overlayX: f,
+                        overlayY: l,
+                        offsetY: -w,
+                    },
+                ]);
+            }
+            _menuClosingActions() {
+                let e = this._overlayRef.backdropClick(),
+                    i = this._overlayRef.detachments(),
+                    r = this._parentMaterialMenu
+                        ? this._parentMaterialMenu.closed
+                        : v(),
+                    s = this._parentMaterialMenu
+                        ? this._parentMaterialMenu._hovered().pipe(
+                              dt((a) => a !== this._menuItemInstance),
+                              dt(() => this._menuOpen)
+                          )
+                        : v();
+                return qt(e, r, s, i);
+            }
+            _handleMousedown(e) {
+                yn(e) ||
+                    ((this._openedBy = e.button === 0 ? "mouse" : void 0),
+                    this.triggersSubmenu() && e.preventDefault());
+            }
+            _handleKeydown(e) {
+                let i = e.keyCode;
+                (i === 13 || i === 32) && (this._openedBy = "keyboard"),
+                    this.triggersSubmenu() &&
+                        ((i === 39 && this.dir === "ltr") ||
+                            (i === 37 && this.dir === "rtl")) &&
+                        ((this._openedBy = "keyboard"), this.openMenu());
+            }
+            _handleClick(e) {
+                this.triggersSubmenu()
+                    ? (e.stopPropagation(), this.openMenu())
+                    : this.toggleMenu();
+            }
+            _handleHover() {
+                !this.triggersSubmenu() ||
+                    !this._parentMaterialMenu ||
+                    (this._hoverSubscription = this._parentMaterialMenu
+                        ._hovered()
+                        .pipe(
+                            dt(
+                                (e) =>
+                                    e === this._menuItemInstance && !e.disabled
+                            ),
+                            ur(0, Mn)
+                        )
+                        .subscribe(() => {
+                            (this._openedBy = "mouse"),
+                                this.menu instanceof Di &&
+                                this.menu._isAnimating
+                                    ? this.menu._animationDone
+                                          .pipe(
+                                              ut(1),
+                                              ur(0, Mn),
+                                              mt(
+                                                  this._parentMaterialMenu._hovered()
+                                              )
+                                          )
+                                          .subscribe(() => this.openMenu())
+                                    : this.openMenu();
+                        }));
+            }
+            _getPortal(e) {
+                return (
+                    (!this._portal ||
+                        this._portal.templateRef !== e.templateRef) &&
+                        (this._portal = new Ci(
+                            e.templateRef,
+                            this._viewContainerRef
+                        )),
+                    this._portal
+                );
+            }
+        };
+        (t.ɵfac = function (i) {
+            return new (i || t)(
+                u(we),
+                u(A),
+                u(kt),
+                u(Cu),
+                u(Ea, 8),
+                u(Rn, 10),
+                u(gi, 8),
+                u(wn),
+                u(I)
+            );
+        }),
+            (t.ɵdir = D({
+                type: t,
+                selectors: [
+                    ["", "mat-menu-trigger-for", ""],
+                    ["", "matMenuTriggerFor", ""],
+                ],
+                hostAttrs: [1, "mat-mdc-menu-trigger"],
+                hostVars: 3,
+                hostBindings: function (i, r) {
+                    i & 1 &&
+                        Z("click", function (a) {
+                            return r._handleClick(a);
+                        })("mousedown", function (a) {
+                            return r._handleMousedown(a);
+                        })("keydown", function (a) {
+                            return r._handleKeydown(a);
+                        }),
+                        i & 2 &&
+                            ft("aria-haspopup", r.menu ? "menu" : null)(
+                                "aria-expanded",
+                                r.menuOpen
+                            )(
+                                "aria-controls",
+                                r.menuOpen ? r.menu.panelId : null
+                            );
+                },
+                inputs: {
+                    _deprecatedMatMenuTriggerFor: [
+                        y.None,
+                        "mat-menu-trigger-for",
+                        "_deprecatedMatMenuTriggerFor",
+                    ],
+                    menu: [y.None, "matMenuTriggerFor", "menu"],
+                    menuData: [y.None, "matMenuTriggerData", "menuData"],
+                    restoreFocus: [
+                        y.None,
+                        "matMenuTriggerRestoreFocus",
+                        "restoreFocus",
+                    ],
+                },
+                outputs: {
+                    menuOpened: "menuOpened",
+                    onMenuOpen: "onMenuOpen",
+                    menuClosed: "menuClosed",
+                    onMenuClose: "onMenuClose",
+                },
+                exportAs: ["matMenuTrigger"],
+                standalone: !0,
+            }));
+        let n = t;
+        return n;
+    })(),
+    Eu = (() => {
+        let t = class t {};
+        (t.ɵfac = function (i) {
+            return new (i || t)();
+        }),
+            (t.ɵmod = S({ type: t })),
+            (t.ɵinj = E({ providers: [rb], imports: [Je, Ko, Y, xu, No, Y] }));
+        let n = t;
+        return n;
+    })();
+function ab(n, t) {
+    n & 1 && (x(0, "button", 8), F(1, "Account"), _());
+}
+function lb(n, t) {
+    if (n & 1) {
+        let o = Ft();
+        x(0, "button", 9),
+            Z("click", function () {
+                xt(o);
+                let i = X();
+                return wt(i.logout());
+            }),
+            F(1, "Logout"),
+            _();
+    }
+}
+function cb(n, t) {
+    if (n & 1) {
+        let o = Ft();
+        x(0, "button", 9),
+            Z("click", function () {
+                xt(o);
+                let i = X();
+                return wt(i.authenticateGoogle());
+            }),
+            F(1, "Login"),
+            _();
+    }
+}
+var Su = (() => {
+    let t = class t {
+        constructor(e) {
+            (this.authService = e), (this.isLoggedIn = !1);
+        }
+        ngOnInit() {
+            this.authService.user.subscribe((e) => {
+                this.isLoggedIn = !!e;
+            });
+        }
+        logout() {
+            this.authService.logout();
+        }
+        authenticateGoogle() {
+            this.authService.login();
+        }
+    };
+    (t.ɵfac = function (i) {
+        return new (i || t)(u(Qo));
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["app-navbar"]],
+            decls: 18,
+            vars: 4,
+            consts: [
+                ["accountMenu", "matMenu"],
+                ["color", "primary", 1, "mat-elevation-z8"],
+                ["mat-button", "", "routerLink", "", 2, "font-size", "20px"],
+                [1, "nvHeaderSpace"],
+                ["mat-button", "", "routerLink", "SFL"],
+                ["mat-menu-item", "", "routerLink", "Account", 4, "ngIf"],
+                ["mat-menu-item", "", 3, "click", 4, "ngIf"],
+                ["mat-icon-button", "", 3, "matMenuTriggerFor"],
+                ["mat-menu-item", "", "routerLink", "Account"],
+                ["mat-menu-item", "", 3, "click"],
+            ],
+            template: function (i, r) {
+                if (
+                    (i & 1 &&
+                        (x(0, "mat-toolbar", 1)(1, "a", 2)(2, "mat-icon"),
+                        F(3, "storefront"),
+                        _(),
+                        F(4, "PricePinion "),
+                        _(),
+                        H(5, "div", 3),
+                        x(6, "a", 4)(7, "mat-icon"),
+                        F(8, "favorite"),
+                        _(),
+                        F(9, "\xA0Save\xA0For\xA0Later "),
+                        _(),
+                        x(10, "mat-menu", null, 0),
+                        ot(12, ab, 2, 0, "button", 5)(
+                            13,
+                            lb,
+                            2,
+                            0,
+                            "button",
+                            6
+                        )(14, cb, 2, 0, "button", 6),
+                        _(),
+                        x(15, "a", 7)(16, "mat-icon"),
+                        F(17, "account_circle"),
+                        _()()()),
+                    i & 2)
+                ) {
+                    let s = he(11);
+                    R(12),
+                        L("ngIf", r.isLoggedIn),
+                        R(),
+                        L("ngIf", r.isLoggedIn),
+                        R(),
+                        L("ngIf", !r.isLoggedIn),
+                        R(),
+                        L("matMenuTriggerFor", s);
+                }
+            },
+            dependencies: [Ht, ui, ru, cu, du, er, Di, Rn, Du],
+            styles: [".nvHeaderSpace[_ngcontent-%COMP%]{flex:1 1 auto}"],
+        }));
+    let n = t;
+    return n;
+})();
+var Iu = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵcmp = P({
+            type: t,
+            selectors: [["app-root"]],
+            decls: 2,
+            vars: 0,
+            template: function (i, r) {
+                i & 1 && H(0, "app-navbar")(1, "router-outlet");
+            },
+            dependencies: [xs, Su],
+        }));
+    let n = t;
+    return n;
+})();
+var Ru = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({}));
+    let n = t;
+    return n;
+})();
+var Sa = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({ imports: [Y, Je, pd, Y] }));
+    let n = t;
+    return n;
+})();
+var Mu = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({ imports: [Y, Sa, Sa, Ru, Y] }));
+    let n = t;
+    return n;
+})();
+var ku = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t })),
+        (t.ɵinj = E({ imports: [ua, Y, ua, Y] }));
+    let n = t;
+    return n;
+})();
+var Tu = (() => {
+    let t = class t {};
+    (t.ɵfac = function (i) {
+        return new (i || t)();
+    }),
+        (t.ɵmod = S({ type: t, bootstrap: [Iu] })),
+        (t.ɵinj = E({
+            providers: [ou(), fe],
+            imports: [Al, nu, su, uu, tu, Mu, ku, Qc, Kc, Eu, Wd, Dl],
+        }));
+    let n = t;
+    return n;
+})();
+Tl()
+    .bootstrapModule(Tu)
+    .catch((n) => console.error(n));

--- a/angularDist/polyfills-S3BTP7ME.js
+++ b/angularDist/polyfills-S3BTP7ME.js
@@ -1,2 +1,2129 @@
-var se=globalThis;function ee(e){return(se.__Zone_symbol_prefix||"__zone_symbol__")+e}function ut(){let e=se.performance;function n(A){e&&e.mark&&e.mark(A)}function a(A,r){e&&e.measure&&e.measure(A,r)}n("Zone");let Y=class Y{static assertZonePatched(){if(se.Promise!==N.ZoneAwarePromise)throw new Error("Zone.js has detected that ZoneAwarePromise `(window|global).Promise` has been overwritten.\nMost likely cause is that a Promise polyfill has been loaded after Zone.js (Polyfilling Promise api is not necessary when zone.js is loaded. If you must load one, do so before loading zone.js.)")}static get root(){let r=Y.current;for(;r.parent;)r=r.parent;return r}static get current(){return m.zone}static get currentTask(){return O}static __load_patch(r,i,s=!1){if(N.hasOwnProperty(r)){let v=se[ee("forceDuplicateZoneCheck")]===!0;if(!s&&v)throw Error("Already loaded patch: "+r)}else if(!se["__Zone_disable_"+r]){let v="Zone:"+r;n(v),N[r]=i(se,Y,R),a(v,v)}}get parent(){return this._parent}get name(){return this._name}constructor(r,i){this._parent=r,this._name=i?i.name||"unnamed":"<root>",this._properties=i&&i.properties||{},this._zoneDelegate=new u(this,this._parent&&this._parent._zoneDelegate,i)}get(r){let i=this.getZoneWith(r);if(i)return i._properties[r]}getZoneWith(r){let i=this;for(;i;){if(i._properties.hasOwnProperty(r))return i;i=i._parent}return null}fork(r){if(!r)throw new Error("ZoneSpec required!");return this._zoneDelegate.fork(this,r)}wrap(r,i){if(typeof r!="function")throw new Error("Expecting function got: "+r);let s=this._zoneDelegate.intercept(this,r,i),v=this;return function(){return v.runGuarded(s,this,arguments,i)}}run(r,i,s,v){m={parent:m,zone:this};try{return this._zoneDelegate.invoke(this,r,i,s,v)}finally{m=m.parent}}runGuarded(r,i=null,s,v){m={parent:m,zone:this};try{try{return this._zoneDelegate.invoke(this,r,i,s,v)}catch(x){if(this._zoneDelegate.handleError(this,x))throw x}}finally{m=m.parent}}runTask(r,i,s){if(r.zone!=this)throw new Error("A task can only be run in the zone of creation! (Creation: "+(r.zone||ne).name+"; Execution: "+this.name+")");if(r.state===z&&(r.type===F||r.type===g))return;let v=r.state!=G;v&&r._transitionTo(G,d),r.runCount++;let x=O;O=r,m={parent:m,zone:this};try{r.type==g&&r.data&&!r.data.isPeriodic&&(r.cancelFn=void 0);try{return this._zoneDelegate.invokeTask(this,r,i,s)}catch(M){if(this._zoneDelegate.handleError(this,M))throw M}}finally{r.state!==z&&r.state!==X&&(r.type==F||r.data&&r.data.isPeriodic?v&&r._transitionTo(d,G):(r.runCount=0,this._updateTaskCount(r,-1),v&&r._transitionTo(z,G,z))),m=m.parent,O=x}}scheduleTask(r){if(r.zone&&r.zone!==this){let s=this;for(;s;){if(s===r.zone)throw Error(`can not reschedule task to ${this.name} which is descendants of the original zone ${r.zone.name}`);s=s.parent}}r._transitionTo(k,z);let i=[];r._zoneDelegates=i,r._zone=this;try{r=this._zoneDelegate.scheduleTask(this,r)}catch(s){throw r._transitionTo(X,k,z),this._zoneDelegate.handleError(this,s),s}return r._zoneDelegates===i&&this._updateTaskCount(r,1),r.state==k&&r._transitionTo(d,k),r}scheduleMicroTask(r,i,s,v){return this.scheduleTask(new _(V,r,i,s,v,void 0))}scheduleMacroTask(r,i,s,v,x){return this.scheduleTask(new _(g,r,i,s,v,x))}scheduleEventTask(r,i,s,v,x){return this.scheduleTask(new _(F,r,i,s,v,x))}cancelTask(r){if(r.zone!=this)throw new Error("A task can only be cancelled in the zone of creation! (Creation: "+(r.zone||ne).name+"; Execution: "+this.name+")");if(!(r.state!==d&&r.state!==G)){r._transitionTo(W,d,G);try{this._zoneDelegate.cancelTask(this,r)}catch(i){throw r._transitionTo(X,W),this._zoneDelegate.handleError(this,i),i}return this._updateTaskCount(r,-1),r._transitionTo(z,W),r.runCount=0,r}}_updateTaskCount(r,i){let s=r._zoneDelegates;i==-1&&(r._zoneDelegates=null);for(let v=0;v<s.length;v++)s[v]._updateTaskCount(r.type,i)}};Y.__symbol__=ee;let t=Y,c={name:"",onHasTask:(A,r,i,s)=>A.hasTask(i,s),onScheduleTask:(A,r,i,s)=>A.scheduleTask(i,s),onInvokeTask:(A,r,i,s,v,x)=>A.invokeTask(i,s,v,x),onCancelTask:(A,r,i,s)=>A.cancelTask(i,s)};class u{get zone(){return this._zone}constructor(r,i,s){this._taskCounts={microTask:0,macroTask:0,eventTask:0},this._zone=r,this._parentDelegate=i,this._forkZS=s&&(s&&s.onFork?s:i._forkZS),this._forkDlgt=s&&(s.onFork?i:i._forkDlgt),this._forkCurrZone=s&&(s.onFork?this._zone:i._forkCurrZone),this._interceptZS=s&&(s.onIntercept?s:i._interceptZS),this._interceptDlgt=s&&(s.onIntercept?i:i._interceptDlgt),this._interceptCurrZone=s&&(s.onIntercept?this._zone:i._interceptCurrZone),this._invokeZS=s&&(s.onInvoke?s:i._invokeZS),this._invokeDlgt=s&&(s.onInvoke?i:i._invokeDlgt),this._invokeCurrZone=s&&(s.onInvoke?this._zone:i._invokeCurrZone),this._handleErrorZS=s&&(s.onHandleError?s:i._handleErrorZS),this._handleErrorDlgt=s&&(s.onHandleError?i:i._handleErrorDlgt),this._handleErrorCurrZone=s&&(s.onHandleError?this._zone:i._handleErrorCurrZone),this._scheduleTaskZS=s&&(s.onScheduleTask?s:i._scheduleTaskZS),this._scheduleTaskDlgt=s&&(s.onScheduleTask?i:i._scheduleTaskDlgt),this._scheduleTaskCurrZone=s&&(s.onScheduleTask?this._zone:i._scheduleTaskCurrZone),this._invokeTaskZS=s&&(s.onInvokeTask?s:i._invokeTaskZS),this._invokeTaskDlgt=s&&(s.onInvokeTask?i:i._invokeTaskDlgt),this._invokeTaskCurrZone=s&&(s.onInvokeTask?this._zone:i._invokeTaskCurrZone),this._cancelTaskZS=s&&(s.onCancelTask?s:i._cancelTaskZS),this._cancelTaskDlgt=s&&(s.onCancelTask?i:i._cancelTaskDlgt),this._cancelTaskCurrZone=s&&(s.onCancelTask?this._zone:i._cancelTaskCurrZone),this._hasTaskZS=null,this._hasTaskDlgt=null,this._hasTaskDlgtOwner=null,this._hasTaskCurrZone=null;let v=s&&s.onHasTask,x=i&&i._hasTaskZS;(v||x)&&(this._hasTaskZS=v?s:c,this._hasTaskDlgt=i,this._hasTaskDlgtOwner=this,this._hasTaskCurrZone=this._zone,s.onScheduleTask||(this._scheduleTaskZS=c,this._scheduleTaskDlgt=i,this._scheduleTaskCurrZone=this._zone),s.onInvokeTask||(this._invokeTaskZS=c,this._invokeTaskDlgt=i,this._invokeTaskCurrZone=this._zone),s.onCancelTask||(this._cancelTaskZS=c,this._cancelTaskDlgt=i,this._cancelTaskCurrZone=this._zone))}fork(r,i){return this._forkZS?this._forkZS.onFork(this._forkDlgt,this.zone,r,i):new t(r,i)}intercept(r,i,s){return this._interceptZS?this._interceptZS.onIntercept(this._interceptDlgt,this._interceptCurrZone,r,i,s):i}invoke(r,i,s,v,x){return this._invokeZS?this._invokeZS.onInvoke(this._invokeDlgt,this._invokeCurrZone,r,i,s,v,x):i.apply(s,v)}handleError(r,i){return this._handleErrorZS?this._handleErrorZS.onHandleError(this._handleErrorDlgt,this._handleErrorCurrZone,r,i):!0}scheduleTask(r,i){let s=i;if(this._scheduleTaskZS)this._hasTaskZS&&s._zoneDelegates.push(this._hasTaskDlgtOwner),s=this._scheduleTaskZS.onScheduleTask(this._scheduleTaskDlgt,this._scheduleTaskCurrZone,r,i),s||(s=i);else if(i.scheduleFn)i.scheduleFn(i);else if(i.type==V)U(i);else throw new Error("Task is missing scheduleFn.");return s}invokeTask(r,i,s,v){return this._invokeTaskZS?this._invokeTaskZS.onInvokeTask(this._invokeTaskDlgt,this._invokeTaskCurrZone,r,i,s,v):i.callback.apply(s,v)}cancelTask(r,i){let s;if(this._cancelTaskZS)s=this._cancelTaskZS.onCancelTask(this._cancelTaskDlgt,this._cancelTaskCurrZone,r,i);else{if(!i.cancelFn)throw Error("Task is not cancelable");s=i.cancelFn(i)}return s}hasTask(r,i){try{this._hasTaskZS&&this._hasTaskZS.onHasTask(this._hasTaskDlgt,this._hasTaskCurrZone,r,i)}catch(s){this.handleError(r,s)}}_updateTaskCount(r,i){let s=this._taskCounts,v=s[r],x=s[r]=v+i;if(x<0)throw new Error("More tasks executed then were scheduled.");if(v==0||x==0){let M={microTask:s.microTask>0,macroTask:s.macroTask>0,eventTask:s.eventTask>0,change:r};this.hasTask(this._zone,M)}}}class _{constructor(r,i,s,v,x,M){if(this._zone=null,this.runCount=0,this._zoneDelegates=null,this._state="notScheduled",this.type=r,this.source=i,this.data=v,this.scheduleFn=x,this.cancelFn=M,!s)throw new Error("callback is not defined");this.callback=s;let he=this;r===F&&v&&v.useG?this.invoke=_.invokeTask:this.invoke=function(){return _.invokeTask.call(se,he,this,arguments)}}static invokeTask(r,i,s){r||(r=this),K++;try{return r.runCount++,r.zone.runTask(r,i,s)}finally{K==1&&j(),K--}}get zone(){return this._zone}get state(){return this._state}cancelScheduleRequest(){this._transitionTo(z,k)}_transitionTo(r,i,s){if(this._state===i||this._state===s)this._state=r,r==z&&(this._zoneDelegates=null);else throw new Error(`${this.type} '${this.source}': can not transition to '${r}', expecting state '${i}'${s?" or '"+s+"'":""}, was '${this._state}'.`)}toString(){return this.data&&typeof this.data.handleId<"u"?this.data.handleId.toString():Object.prototype.toString.call(this)}toJSON(){return{type:this.type,state:this.state,source:this.source,zone:this.zone.name,runCount:this.runCount}}}let E=ee("setTimeout"),y=ee("Promise"),C=ee("then"),T=[],I=!1,w;function Z(A){if(w||se[y]&&(w=se[y].resolve(0)),w){let r=w[C];r||(r=w.then),r.call(w,A)}else se[E](A,0)}function U(A){K===0&&T.length===0&&Z(j),A&&T.push(A)}function j(){if(!I){for(I=!0;T.length;){let A=T;T=[];for(let r=0;r<A.length;r++){let i=A[r];try{i.zone.runTask(i,null,null)}catch(s){R.onUnhandledError(s)}}}R.microtaskDrainDone(),I=!1}}let ne={name:"NO ZONE"},z="notScheduled",k="scheduling",d="scheduled",G="running",W="canceling",X="unknown",V="microTask",g="macroTask",F="eventTask",N={},R={symbol:ee,currentZoneFrame:()=>m,onUnhandledError:q,microtaskDrainDone:q,scheduleMicroTask:U,showUncaughtError:()=>!t[ee("ignoreConsoleErrorUncaughtError")],patchEventTarget:()=>[],patchOnProperties:q,patchMethod:()=>q,bindArguments:()=>[],patchThen:()=>q,patchMacroTask:()=>q,patchEventPrototype:()=>q,isIEOrEdge:()=>!1,getGlobalObjects:()=>{},ObjectDefineProperty:()=>q,ObjectGetOwnPropertyDescriptor:()=>{},ObjectCreate:()=>{},ArraySlice:()=>[],patchClass:()=>q,wrapWithCurrentZone:()=>q,filterProperties:()=>[],attachOriginToPatched:()=>q,_redefineProperty:()=>q,patchCallbacks:()=>q,nativeScheduleMicroTask:Z},m={parent:null,zone:new t(null,null)},O=null,K=0;function q(){}return a("Zone","Zone"),t}function ft(){let e=globalThis,n=e[ee("forceDuplicateZoneCheck")]===!0;if(e.Zone&&(n||typeof e.Zone.__symbol__!="function"))throw new Error("Zone already loaded.");return e.Zone??=ut(),e.Zone}var ke=Object.getOwnPropertyDescriptor,Ze=Object.defineProperty,je=Object.getPrototypeOf,ht=Object.create,dt=Array.prototype.slice,Ae="addEventListener",He="removeEventListener",Ne=ee(Ae),Ie=ee(He),ie="true",ce="false",ve=ee("");function xe(e,n){return Zone.current.wrap(e,n)}function Ge(e,n,a,t,c){return Zone.current.scheduleMacroTask(e,n,a,t,c)}var H=ee,Ce=typeof window<"u",Te=Ce?window:void 0,$=Ce&&Te||globalThis,_t="removeAttribute";function Ve(e,n){for(let a=e.length-1;a>=0;a--)typeof e[a]=="function"&&(e[a]=xe(e[a],n+"_"+a));return e}function Et(e,n){let a=e.constructor.name;for(let t=0;t<n.length;t++){let c=n[t],u=e[c];if(u){let _=ke(e,c);if(!Ke(_))continue;e[c]=(E=>{let y=function(){return E.apply(this,Ve(arguments,a+"."+c))};return le(y,E),y})(u)}}}function Ke(e){return e?e.writable===!1?!1:!(typeof e.get=="function"&&typeof e.set>"u"):!0}var Qe=typeof WorkerGlobalScope<"u"&&self instanceof WorkerGlobalScope,Se=!("nw"in $)&&typeof $.process<"u"&&{}.toString.call($.process)==="[object process]",Fe=!Se&&!Qe&&!!(Ce&&Te.HTMLElement),et=typeof $.process<"u"&&{}.toString.call($.process)==="[object process]"&&!Qe&&!!(Ce&&Te.HTMLElement),Re={},Xe=function(e){if(e=e||$.event,!e)return;let n=Re[e.type];n||(n=Re[e.type]=H("ON_PROPERTY"+e.type));let a=this||e.target||$,t=a[n],c;if(Fe&&a===Te&&e.type==="error"){let u=e;c=t&&t.call(this,u.message,u.filename,u.lineno,u.colno,u.error),c===!0&&e.preventDefault()}else c=t&&t.apply(this,arguments),c!=null&&!c&&e.preventDefault();return c};function Ye(e,n,a){let t=ke(e,n);if(!t&&a&&ke(a,n)&&(t={enumerable:!0,configurable:!0}),!t||!t.configurable)return;let c=H("on"+n+"patched");if(e.hasOwnProperty(c)&&e[c])return;delete t.writable,delete t.value;let u=t.get,_=t.set,E=n.slice(2),y=Re[E];y||(y=Re[E]=H("ON_PROPERTY"+E)),t.set=function(C){let T=this;if(!T&&e===$&&(T=$),!T)return;typeof T[y]=="function"&&T.removeEventListener(E,Xe),_&&_.call(T,null),T[y]=C,typeof C=="function"&&T.addEventListener(E,Xe,!1)},t.get=function(){let C=this;if(!C&&e===$&&(C=$),!C)return null;let T=C[y];if(T)return T;if(u){let I=u.call(this);if(I)return t.set.call(this,I),typeof C[_t]=="function"&&C.removeAttribute(n),I}return null},Ze(e,n,t),e[c]=!0}function tt(e,n,a){if(n)for(let t=0;t<n.length;t++)Ye(e,"on"+n[t],a);else{let t=[];for(let c in e)c.slice(0,2)=="on"&&t.push(c);for(let c=0;c<t.length;c++)Ye(e,t[c],a)}}var re=H("originalInstance");function me(e){let n=$[e];if(!n)return;$[H(e)]=n,$[e]=function(){let c=Ve(arguments,e);switch(c.length){case 0:this[re]=new n;break;case 1:this[re]=new n(c[0]);break;case 2:this[re]=new n(c[0],c[1]);break;case 3:this[re]=new n(c[0],c[1],c[2]);break;case 4:this[re]=new n(c[0],c[1],c[2],c[3]);break;default:throw new Error("Arg list too long.")}},le($[e],n);let a=new n(function(){}),t;for(t in a)e==="XMLHttpRequest"&&t==="responseBlob"||function(c){typeof a[c]=="function"?$[e].prototype[c]=function(){return this[re][c].apply(this[re],arguments)}:Ze($[e].prototype,c,{set:function(u){typeof u=="function"?(this[re][c]=xe(u,e+"."+c),le(this[re][c],u)):this[re][c]=u},get:function(){return this[re][c]}})}(t);for(t in n)t!=="prototype"&&n.hasOwnProperty(t)&&($[e][t]=n[t])}function ae(e,n,a){let t=e;for(;t&&!t.hasOwnProperty(n);)t=je(t);!t&&e[n]&&(t=e);let c=H(n),u=null;if(t&&(!(u=t[c])||!t.hasOwnProperty(c))){u=t[c]=t[n];let _=t&&ke(t,n);if(Ke(_)){let E=a(u,c,n);t[n]=function(){return E(this,arguments)},le(t[n],u)}}return u}function Tt(e,n,a){let t=null;function c(u){let _=u.data;return _.args[_.cbIdx]=function(){u.invoke.apply(this,arguments)},t.apply(_.target,_.args),u}t=ae(e,n,u=>function(_,E){let y=a(_,E);return y.cbIdx>=0&&typeof E[y.cbIdx]=="function"?Ge(y.name,E[y.cbIdx],y,c):u.apply(_,E)})}function le(e,n){e[H("OriginalDelegate")]=n}var $e=!1,Me=!1;function gt(){try{let e=Te.navigator.userAgent;if(e.indexOf("MSIE ")!==-1||e.indexOf("Trident/")!==-1)return!0}catch{}return!1}function yt(){if($e)return Me;$e=!0;try{let e=Te.navigator.userAgent;(e.indexOf("MSIE ")!==-1||e.indexOf("Trident/")!==-1||e.indexOf("Edge/")!==-1)&&(Me=!0)}catch{}return Me}var Ee=!1;if(typeof window<"u")try{let e=Object.defineProperty({},"passive",{get:function(){Ee=!0}});window.addEventListener("test",e,e),window.removeEventListener("test",e,e)}catch{Ee=!1}var pt={useG:!0},te={},nt={},rt=new RegExp("^"+ve+"(\\w+)(true|false)$"),ot=H("propagationStopped");function st(e,n){let a=(n?n(e):e)+ce,t=(n?n(e):e)+ie,c=ve+a,u=ve+t;te[e]={},te[e][ce]=c,te[e][ie]=u}function mt(e,n,a,t){let c=t&&t.add||Ae,u=t&&t.rm||He,_=t&&t.listeners||"eventListeners",E=t&&t.rmAll||"removeAllListeners",y=H(c),C="."+c+":",T="prependListener",I="."+T+":",w=function(k,d,G){if(k.isRemoved)return;let W=k.callback;typeof W=="object"&&W.handleEvent&&(k.callback=g=>W.handleEvent(g),k.originalDelegate=W);let X;try{k.invoke(k,d,[G])}catch(g){X=g}let V=k.options;if(V&&typeof V=="object"&&V.once){let g=k.originalDelegate?k.originalDelegate:k.callback;d[u].call(d,G.type,g,V)}return X};function Z(k,d,G){if(d=d||e.event,!d)return;let W=k||d.target||e,X=W[te[d.type][G?ie:ce]];if(X){let V=[];if(X.length===1){let g=w(X[0],W,d);g&&V.push(g)}else{let g=X.slice();for(let F=0;F<g.length&&!(d&&d[ot]===!0);F++){let N=w(g[F],W,d);N&&V.push(N)}}if(V.length===1)throw V[0];for(let g=0;g<V.length;g++){let F=V[g];n.nativeScheduleMicroTask(()=>{throw F})}}}let U=function(k){return Z(this,k,!1)},j=function(k){return Z(this,k,!0)};function ne(k,d){if(!k)return!1;let G=!0;d&&d.useG!==void 0&&(G=d.useG);let W=d&&d.vh,X=!0;d&&d.chkDup!==void 0&&(X=d.chkDup);let V=!1;d&&d.rt!==void 0&&(V=d.rt);let g=k;for(;g&&!g.hasOwnProperty(c);)g=je(g);if(!g&&k[c]&&(g=k),!g||g[y])return!1;let F=d&&d.eventNameToString,N={},R=g[y]=g[c],m=g[H(u)]=g[u],O=g[H(_)]=g[_],K=g[H(E)]=g[E],q;d&&d.prepend&&(q=g[H(d.prepend)]=g[d.prepend]);function Y(o,l){return!Ee&&typeof o=="object"&&o?!!o.capture:!Ee||!l?o:typeof o=="boolean"?{capture:o,passive:!0}:o?typeof o=="object"&&o.passive!==!1?{...o,passive:!0}:o:{passive:!0}}let A=function(o){if(!N.isExisting)return R.call(N.target,N.eventName,N.capture?j:U,N.options)},r=function(o){if(!o.isRemoved){let l=te[o.eventName],h;l&&(h=l[o.capture?ie:ce]);let b=h&&o.target[h];if(b){for(let S=0;S<b.length;S++)if(b[S]===o){b.splice(S,1),o.isRemoved=!0,b.length===0&&(o.allRemoved=!0,o.target[h]=null);break}}}if(o.allRemoved)return m.call(o.target,o.eventName,o.capture?j:U,o.options)},i=function(o){return R.call(N.target,N.eventName,o.invoke,N.options)},s=function(o){return q.call(N.target,N.eventName,o.invoke,N.options)},v=function(o){return m.call(o.target,o.eventName,o.invoke,o.options)},x=G?A:i,M=G?r:v,he=function(o,l){let h=typeof l;return h==="function"&&o.callback===l||h==="object"&&o.originalDelegate===l},ge=d&&d.diff?d.diff:he,ue=Zone[H("UNPATCHED_EVENTS")],be=e[H("PASSIVE_EVENTS")],f=function(o,l,h,b,S=!1,p=!1){return function(){let P=this||e,D=arguments[0];d&&d.transferEventName&&(D=d.transferEventName(D));let L=arguments[1];if(!L)return o.apply(this,arguments);if(Se&&D==="uncaughtException")return o.apply(this,arguments);let B=!1;if(typeof L!="function"){if(!L.handleEvent)return o.apply(this,arguments);B=!0}if(W&&!W(o,L,P,arguments))return;let J=Ee&&!!be&&be.indexOf(D)!==-1,Q=Y(arguments[2],J),ye=Q&&typeof Q=="object"&&Q.signal&&typeof Q.signal=="object"?Q.signal:void 0;if(ye?.aborted)return;if(ue){for(let fe=0;fe<ue.length;fe++)if(D===ue[fe])return J?o.call(P,D,L,Q):o.apply(this,arguments)}let De=Q?typeof Q=="boolean"?!0:Q.capture:!1,Be=Q&&typeof Q=="object"?Q.once:!1,lt=Zone.current,Oe=te[D];Oe||(st(D,F),Oe=te[D]);let Ue=Oe[De?ie:ce],de=P[Ue],We=!1;if(de){if(We=!0,X){for(let fe=0;fe<de.length;fe++)if(ge(de[fe],L))return}}else de=P[Ue]=[];let Pe,qe=P.constructor.name,ze=nt[qe];ze&&(Pe=ze[D]),Pe||(Pe=qe+l+(F?F(D):D)),N.options=Q,Be&&(N.options.once=!1),N.target=P,N.capture=De,N.eventName=D,N.isExisting=We;let pe=G?pt:void 0;pe&&(pe.taskData=N),ye&&(N.options.signal=void 0);let oe=lt.scheduleEventTask(Pe,L,pe,h,b);if(ye&&(N.options.signal=ye,o.call(ye,"abort",()=>{oe.zone.cancelTask(oe)},{once:!0})),N.target=null,pe&&(pe.taskData=null),Be&&(Q.once=!0),!Ee&&typeof oe.options=="boolean"||(oe.options=Q),oe.target=P,oe.capture=De,oe.eventName=D,B&&(oe.originalDelegate=L),p?de.unshift(oe):de.push(oe),S)return P}};return g[c]=f(R,C,x,M,V),q&&(g[T]=f(q,I,s,M,V,!0)),g[u]=function(){let o=this||e,l=arguments[0];d&&d.transferEventName&&(l=d.transferEventName(l));let h=arguments[2],b=h?typeof h=="boolean"?!0:h.capture:!1,S=arguments[1];if(!S)return m.apply(this,arguments);if(W&&!W(m,S,o,arguments))return;let p=te[l],P;p&&(P=p[b?ie:ce]);let D=P&&o[P];if(D)for(let L=0;L<D.length;L++){let B=D[L];if(ge(B,S)){if(D.splice(L,1),B.isRemoved=!0,D.length===0&&(B.allRemoved=!0,o[P]=null,!b&&typeof l=="string")){let J=ve+"ON_PROPERTY"+l;o[J]=null}return B.zone.cancelTask(B),V?o:void 0}}return m.apply(this,arguments)},g[_]=function(){let o=this||e,l=arguments[0];d&&d.transferEventName&&(l=d.transferEventName(l));let h=[],b=it(o,F?F(l):l);for(let S=0;S<b.length;S++){let p=b[S],P=p.originalDelegate?p.originalDelegate:p.callback;h.push(P)}return h},g[E]=function(){let o=this||e,l=arguments[0];if(l){d&&d.transferEventName&&(l=d.transferEventName(l));let h=te[l];if(h){let b=h[ce],S=h[ie],p=o[b],P=o[S];if(p){let D=p.slice();for(let L=0;L<D.length;L++){let B=D[L],J=B.originalDelegate?B.originalDelegate:B.callback;this[u].call(this,l,J,B.options)}}if(P){let D=P.slice();for(let L=0;L<D.length;L++){let B=D[L],J=B.originalDelegate?B.originalDelegate:B.callback;this[u].call(this,l,J,B.options)}}}}else{let h=Object.keys(o);for(let b=0;b<h.length;b++){let S=h[b],p=rt.exec(S),P=p&&p[1];P&&P!=="removeListener"&&this[E].call(this,P)}this[E].call(this,"removeListener")}if(V)return this},le(g[c],R),le(g[u],m),K&&le(g[E],K),O&&le(g[_],O),!0}let z=[];for(let k=0;k<a.length;k++)z[k]=ne(a[k],t);return z}function it(e,n){if(!n){let u=[];for(let _ in e){let E=rt.exec(_),y=E&&E[1];if(y&&(!n||y===n)){let C=e[_];if(C)for(let T=0;T<C.length;T++)u.push(C[T])}}return u}let a=te[n];a||(st(n),a=te[n]);let t=e[a[ce]],c=e[a[ie]];return t?c?t.concat(c):t.slice():c?c.slice():[]}function kt(e,n){let a=e.Event;a&&a.prototype&&n.patchMethod(a.prototype,"stopImmediatePropagation",t=>function(c,u){c[ot]=!0,t&&t.apply(c,u)})}function vt(e,n){n.patchMethod(e,"queueMicrotask",a=>function(t,c){Zone.current.scheduleMicroTask("queueMicrotask",c[0])})}var we=H("zoneTask");function _e(e,n,a,t){let c=null,u=null;n+=t,a+=t;let _={};function E(C){let T=C.data;return T.args[0]=function(){return C.invoke.apply(this,arguments)},T.handleId=c.apply(e,T.args),C}function y(C){return u.call(e,C.data.handleId)}c=ae(e,n,C=>function(T,I){if(typeof I[0]=="function"){let w={isPeriodic:t==="Interval",delay:t==="Timeout"||t==="Interval"?I[1]||0:void 0,args:I},Z=I[0];I[0]=function(){try{return Z.apply(this,arguments)}finally{w.isPeriodic||(typeof w.handleId=="number"?delete _[w.handleId]:w.handleId&&(w.handleId[we]=null))}};let U=Ge(n,I[0],w,E,y);if(!U)return U;let j=U.data.handleId;return typeof j=="number"?_[j]=U:j&&(j[we]=U),j&&j.ref&&j.unref&&typeof j.ref=="function"&&typeof j.unref=="function"&&(U.ref=j.ref.bind(j),U.unref=j.unref.bind(j)),typeof j=="number"||j?j:U}else return C.apply(e,I)}),u=ae(e,a,C=>function(T,I){let w=I[0],Z;typeof w=="number"?Z=_[w]:(Z=w&&w[we],Z||(Z=w)),Z&&typeof Z.type=="string"?Z.state!=="notScheduled"&&(Z.cancelFn&&Z.data.isPeriodic||Z.runCount===0)&&(typeof w=="number"?delete _[w]:w&&(w[we]=null),Z.zone.cancelTask(Z)):C.apply(e,I)})}function bt(e,n){let{isBrowser:a,isMix:t}=n.getGlobalObjects();if(!a&&!t||!e.customElements||!("customElements"in e))return;let c=["connectedCallback","disconnectedCallback","adoptedCallback","attributeChangedCallback","formAssociatedCallback","formDisabledCallback","formResetCallback","formStateRestoreCallback"];n.patchCallbacks(n,e.customElements,"customElements","define",c)}function Pt(e,n){if(Zone[n.symbol("patchEventTarget")])return;let{eventNames:a,zoneSymbolEventNames:t,TRUE_STR:c,FALSE_STR:u,ZONE_SYMBOL_PREFIX:_}=n.getGlobalObjects();for(let y=0;y<a.length;y++){let C=a[y],T=C+u,I=C+c,w=_+T,Z=_+I;t[C]={},t[C][u]=w,t[C][c]=Z}let E=e.EventTarget;if(!(!E||!E.prototype))return n.patchEventTarget(e,n,[E&&E.prototype]),!0}function wt(e,n){n.patchEventPrototype(e,n)}function ct(e,n,a){if(!a||a.length===0)return n;let t=a.filter(u=>u.target===e);if(!t||t.length===0)return n;let c=t[0].ignoreProperties;return n.filter(u=>c.indexOf(u)===-1)}function Je(e,n,a,t){if(!e)return;let c=ct(e,n,a);tt(e,c,t)}function Le(e){return Object.getOwnPropertyNames(e).filter(n=>n.startsWith("on")&&n.length>2).map(n=>n.substring(2))}function Rt(e,n){if(Se&&!et||Zone[e.symbol("patchEvents")])return;let a=n.__Zone_ignore_on_properties,t=[];if(Fe){let c=window;t=t.concat(["Document","SVGElement","Element","HTMLElement","HTMLBodyElement","HTMLMediaElement","HTMLFrameSetElement","HTMLFrameElement","HTMLIFrameElement","HTMLMarqueeElement","Worker"]);let u=gt()?[{target:c,ignoreProperties:["error"]}]:[];Je(c,Le(c),a&&a.concat(u),je(c))}t=t.concat(["XMLHttpRequest","XMLHttpRequestEventTarget","IDBIndex","IDBRequest","IDBOpenDBRequest","IDBDatabase","IDBTransaction","IDBCursor","WebSocket"]);for(let c=0;c<t.length;c++){let u=n[t[c]];u&&u.prototype&&Je(u.prototype,Le(u.prototype),a)}}function Ct(e){e.__load_patch("legacy",n=>{let a=n[e.__symbol__("legacyPatch")];a&&a()}),e.__load_patch("timers",n=>{let a="set",t="clear";_e(n,a,t,"Timeout"),_e(n,a,t,"Interval"),_e(n,a,t,"Immediate")}),e.__load_patch("requestAnimationFrame",n=>{_e(n,"request","cancel","AnimationFrame"),_e(n,"mozRequest","mozCancel","AnimationFrame"),_e(n,"webkitRequest","webkitCancel","AnimationFrame")}),e.__load_patch("blocking",(n,a)=>{let t=["alert","prompt","confirm"];for(let c=0;c<t.length;c++){let u=t[c];ae(n,u,(_,E,y)=>function(C,T){return a.current.run(_,n,T,y)})}}),e.__load_patch("EventTarget",(n,a,t)=>{wt(n,t),Pt(n,t);let c=n.XMLHttpRequestEventTarget;c&&c.prototype&&t.patchEventTarget(n,t,[c.prototype])}),e.__load_patch("MutationObserver",(n,a,t)=>{me("MutationObserver"),me("WebKitMutationObserver")}),e.__load_patch("IntersectionObserver",(n,a,t)=>{me("IntersectionObserver")}),e.__load_patch("FileReader",(n,a,t)=>{me("FileReader")}),e.__load_patch("on_property",(n,a,t)=>{Rt(t,n)}),e.__load_patch("customElements",(n,a,t)=>{bt(n,t)}),e.__load_patch("XHR",(n,a)=>{C(n);let t=H("xhrTask"),c=H("xhrSync"),u=H("xhrListener"),_=H("xhrScheduled"),E=H("xhrURL"),y=H("xhrErrorBeforeScheduled");function C(T){let I=T.XMLHttpRequest;if(!I)return;let w=I.prototype;function Z(R){return R[t]}let U=w[Ne],j=w[Ie];if(!U){let R=T.XMLHttpRequestEventTarget;if(R){let m=R.prototype;U=m[Ne],j=m[Ie]}}let ne="readystatechange",z="scheduled";function k(R){let m=R.data,O=m.target;O[_]=!1,O[y]=!1;let K=O[u];U||(U=O[Ne],j=O[Ie]),K&&j.call(O,ne,K);let q=O[u]=()=>{if(O.readyState===O.DONE)if(!m.aborted&&O[_]&&R.state===z){let A=O[a.__symbol__("loadfalse")];if(O.status!==0&&A&&A.length>0){let r=R.invoke;R.invoke=function(){let i=O[a.__symbol__("loadfalse")];for(let s=0;s<i.length;s++)i[s]===R&&i.splice(s,1);!m.aborted&&R.state===z&&r.call(R)},A.push(R)}else R.invoke()}else!m.aborted&&O[_]===!1&&(O[y]=!0)};return U.call(O,ne,q),O[t]||(O[t]=R),F.apply(O,m.args),O[_]=!0,R}function d(){}function G(R){let m=R.data;return m.aborted=!0,N.apply(m.target,m.args)}let W=ae(w,"open",()=>function(R,m){return R[c]=m[2]==!1,R[E]=m[1],W.apply(R,m)}),X="XMLHttpRequest.send",V=H("fetchTaskAborting"),g=H("fetchTaskScheduling"),F=ae(w,"send",()=>function(R,m){if(a.current[g]===!0||R[c])return F.apply(R,m);{let O={target:R,url:R[E],isPeriodic:!1,args:m,aborted:!1},K=Ge(X,d,O,k,G);R&&R[y]===!0&&!O.aborted&&K.state===z&&K.invoke()}}),N=ae(w,"abort",()=>function(R,m){let O=Z(R);if(O&&typeof O.type=="string"){if(O.cancelFn==null||O.data&&O.data.aborted)return;O.zone.cancelTask(O)}else if(a.current[V]===!0)return N.apply(R,m)})}}),e.__load_patch("geolocation",n=>{n.navigator&&n.navigator.geolocation&&Et(n.navigator.geolocation,["getCurrentPosition","watchPosition"])}),e.__load_patch("PromiseRejectionEvent",(n,a)=>{function t(c){return function(u){it(n,c).forEach(E=>{let y=n.PromiseRejectionEvent;if(y){let C=new y(c,{promise:u.promise,reason:u.rejection});E.invoke(C)}})}}n.PromiseRejectionEvent&&(a[H("unhandledPromiseRejectionHandler")]=t("unhandledrejection"),a[H("rejectionHandledHandler")]=t("rejectionhandled"))}),e.__load_patch("queueMicrotask",(n,a,t)=>{vt(n,t)})}function St(e){e.__load_patch("ZoneAwarePromise",(n,a,t)=>{let c=Object.getOwnPropertyDescriptor,u=Object.defineProperty;function _(f){if(f&&f.toString===Object.prototype.toString){let o=f.constructor&&f.constructor.name;return(o||"")+": "+JSON.stringify(f)}return f?f.toString():Object.prototype.toString.call(f)}let E=t.symbol,y=[],C=n[E("DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION")]!==!1,T=E("Promise"),I=E("then"),w="__creationTrace__";t.onUnhandledError=f=>{if(t.showUncaughtError()){let o=f&&f.rejection;o?console.error("Unhandled Promise rejection:",o instanceof Error?o.message:o,"; Zone:",f.zone.name,"; Task:",f.task&&f.task.source,"; Value:",o,o instanceof Error?o.stack:void 0):console.error(f)}},t.microtaskDrainDone=()=>{for(;y.length;){let f=y.shift();try{f.zone.runGuarded(()=>{throw f.throwOriginal?f.rejection:f})}catch(o){U(o)}}};let Z=E("unhandledPromiseRejectionHandler");function U(f){t.onUnhandledError(f);try{let o=a[Z];typeof o=="function"&&o.call(this,f)}catch{}}function j(f){return f&&f.then}function ne(f){return f}function z(f){return M.reject(f)}let k=E("state"),d=E("value"),G=E("finally"),W=E("parentPromiseValue"),X=E("parentPromiseState"),V="Promise.then",g=null,F=!0,N=!1,R=0;function m(f,o){return l=>{try{Y(f,o,l)}catch(h){Y(f,!1,h)}}}let O=function(){let f=!1;return function(l){return function(){f||(f=!0,l.apply(null,arguments))}}},K="Promise resolved with itself",q=E("currentTaskTrace");function Y(f,o,l){let h=O();if(f===l)throw new TypeError(K);if(f[k]===g){let b=null;try{(typeof l=="object"||typeof l=="function")&&(b=l&&l.then)}catch(S){return h(()=>{Y(f,!1,S)})(),f}if(o!==N&&l instanceof M&&l.hasOwnProperty(k)&&l.hasOwnProperty(d)&&l[k]!==g)r(l),Y(f,l[k],l[d]);else if(o!==N&&typeof b=="function")try{b.call(l,h(m(f,o)),h(m(f,!1)))}catch(S){h(()=>{Y(f,!1,S)})()}else{f[k]=o;let S=f[d];if(f[d]=l,f[G]===G&&o===F&&(f[k]=f[X],f[d]=f[W]),o===N&&l instanceof Error){let p=a.currentTask&&a.currentTask.data&&a.currentTask.data[w];p&&u(l,q,{configurable:!0,enumerable:!1,writable:!0,value:p})}for(let p=0;p<S.length;)i(f,S[p++],S[p++],S[p++],S[p++]);if(S.length==0&&o==N){f[k]=R;let p=l;try{throw new Error("Uncaught (in promise): "+_(l)+(l&&l.stack?`
-`+l.stack:""))}catch(P){p=P}C&&(p.throwOriginal=!0),p.rejection=l,p.promise=f,p.zone=a.current,p.task=a.currentTask,y.push(p),t.scheduleMicroTask()}}}return f}let A=E("rejectionHandledHandler");function r(f){if(f[k]===R){try{let o=a[A];o&&typeof o=="function"&&o.call(this,{rejection:f[d],promise:f})}catch{}f[k]=N;for(let o=0;o<y.length;o++)f===y[o].promise&&y.splice(o,1)}}function i(f,o,l,h,b){r(f);let S=f[k],p=S?typeof h=="function"?h:ne:typeof b=="function"?b:z;o.scheduleMicroTask(V,()=>{try{let P=f[d],D=!!l&&G===l[G];D&&(l[W]=P,l[X]=S);let L=o.run(p,void 0,D&&p!==z&&p!==ne?[]:[P]);Y(l,!0,L)}catch(P){Y(l,!1,P)}},l)}let s="function ZoneAwarePromise() { [native code] }",v=function(){},x=n.AggregateError;class M{static toString(){return s}static resolve(o){return o instanceof M?o:Y(new this(null),F,o)}static reject(o){return Y(new this(null),N,o)}static withResolvers(){let o={};return o.promise=new M((l,h)=>{o.resolve=l,o.reject=h}),o}static any(o){if(!o||typeof o[Symbol.iterator]!="function")return Promise.reject(new x([],"All promises were rejected"));let l=[],h=0;try{for(let p of o)h++,l.push(M.resolve(p))}catch{return Promise.reject(new x([],"All promises were rejected"))}if(h===0)return Promise.reject(new x([],"All promises were rejected"));let b=!1,S=[];return new M((p,P)=>{for(let D=0;D<l.length;D++)l[D].then(L=>{b||(b=!0,p(L))},L=>{S.push(L),h--,h===0&&(b=!0,P(new x(S,"All promises were rejected")))})})}static race(o){let l,h,b=new this((P,D)=>{l=P,h=D});function S(P){l(P)}function p(P){h(P)}for(let P of o)j(P)||(P=this.resolve(P)),P.then(S,p);return b}static all(o){return M.allWithCallback(o)}static allSettled(o){return(this&&this.prototype instanceof M?this:M).allWithCallback(o,{thenCallback:h=>({status:"fulfilled",value:h}),errorCallback:h=>({status:"rejected",reason:h})})}static allWithCallback(o,l){let h,b,S=new this((L,B)=>{h=L,b=B}),p=2,P=0,D=[];for(let L of o){j(L)||(L=this.resolve(L));let B=P;try{L.then(J=>{D[B]=l?l.thenCallback(J):J,p--,p===0&&h(D)},J=>{l?(D[B]=l.errorCallback(J),p--,p===0&&h(D)):b(J)})}catch(J){b(J)}p++,P++}return p-=2,p===0&&h(D),S}constructor(o){let l=this;if(!(l instanceof M))throw new Error("Must be an instanceof Promise.");l[k]=g,l[d]=[];try{let h=O();o&&o(h(m(l,F)),h(m(l,N)))}catch(h){Y(l,!1,h)}}get[Symbol.toStringTag](){return"Promise"}get[Symbol.species](){return M}then(o,l){let h=this.constructor?.[Symbol.species];(!h||typeof h!="function")&&(h=this.constructor||M);let b=new h(v),S=a.current;return this[k]==g?this[d].push(S,b,o,l):i(this,S,b,o,l),b}catch(o){return this.then(null,o)}finally(o){let l=this.constructor?.[Symbol.species];(!l||typeof l!="function")&&(l=M);let h=new l(v);h[G]=G;let b=a.current;return this[k]==g?this[d].push(b,h,o,o):i(this,b,h,o,o),h}}M.resolve=M.resolve,M.reject=M.reject,M.race=M.race,M.all=M.all;let he=n[T]=n.Promise;n.Promise=M;let ge=E("thenPatched");function ue(f){let o=f.prototype,l=c(o,"then");if(l&&(l.writable===!1||!l.configurable))return;let h=o.then;o[I]=h,f.prototype.then=function(b,S){return new M((P,D)=>{h.call(this,P,D)}).then(b,S)},f[ge]=!0}t.patchThen=ue;function be(f){return function(o,l){let h=f.apply(o,l);if(h instanceof M)return h;let b=h.constructor;return b[ge]||ue(b),h}}return he&&(ue(he),ae(n,"fetch",f=>be(f))),Promise[a.__symbol__("uncaughtPromiseErrors")]=y,M})}function Dt(e){e.__load_patch("toString",n=>{let a=Function.prototype.toString,t=H("OriginalDelegate"),c=H("Promise"),u=H("Error"),_=function(){if(typeof this=="function"){let T=this[t];if(T)return typeof T=="function"?a.call(T):Object.prototype.toString.call(T);if(this===Promise){let I=n[c];if(I)return a.call(I)}if(this===Error){let I=n[u];if(I)return a.call(I)}}return a.call(this)};_[t]=a,Function.prototype.toString=_;let E=Object.prototype.toString,y="[object Promise]";Object.prototype.toString=function(){return typeof Promise=="function"&&this instanceof Promise?y:E.call(this)}})}function Ot(e,n,a,t,c){let u=Zone.__symbol__(t);if(n[u])return;let _=n[u]=n[t];n[t]=function(E,y,C){return y&&y.prototype&&c.forEach(function(T){let I=`${a}.${t}::`+T,w=y.prototype;try{if(w.hasOwnProperty(T)){let Z=e.ObjectGetOwnPropertyDescriptor(w,T);Z&&Z.value?(Z.value=e.wrapWithCurrentZone(Z.value,I),e._redefineProperty(y.prototype,T,Z)):w[T]&&(w[T]=e.wrapWithCurrentZone(w[T],I))}else w[T]&&(w[T]=e.wrapWithCurrentZone(w[T],I))}catch{}}),_.call(n,E,y,C)},e.attachOriginToPatched(n[t],_)}function Nt(e){e.__load_patch("util",(n,a,t)=>{let c=Le(n);t.patchOnProperties=tt,t.patchMethod=ae,t.bindArguments=Ve,t.patchMacroTask=Tt;let u=a.__symbol__("BLACK_LISTED_EVENTS"),_=a.__symbol__("UNPATCHED_EVENTS");n[_]&&(n[u]=n[_]),n[u]&&(a[u]=a[_]=n[u]),t.patchEventPrototype=kt,t.patchEventTarget=mt,t.isIEOrEdge=yt,t.ObjectDefineProperty=Ze,t.ObjectGetOwnPropertyDescriptor=ke,t.ObjectCreate=ht,t.ArraySlice=dt,t.patchClass=me,t.wrapWithCurrentZone=xe,t.filterProperties=ct,t.attachOriginToPatched=le,t._redefineProperty=Object.defineProperty,t.patchCallbacks=Ot,t.getGlobalObjects=()=>({globalSources:nt,zoneSymbolEventNames:te,eventNames:c,isBrowser:Fe,isMix:et,isNode:Se,TRUE_STR:ie,FALSE_STR:ce,ZONE_SYMBOL_PREFIX:ve,ADD_EVENT_LISTENER_STR:Ae,REMOVE_EVENT_LISTENER_STR:He})})}function It(e){St(e),Dt(e),Nt(e)}var at=ft();It(at);Ct(at);
+var se = globalThis;
+function ee(e) {
+    return (se.__Zone_symbol_prefix || "__zone_symbol__") + e;
+}
+function ut() {
+    let e = se.performance;
+    function n(A) {
+        e && e.mark && e.mark(A);
+    }
+    function a(A, r) {
+        e && e.measure && e.measure(A, r);
+    }
+    n("Zone");
+    let Y = class Y {
+        static assertZonePatched() {
+            if (se.Promise !== N.ZoneAwarePromise)
+                throw new Error(
+                    "Zone.js has detected that ZoneAwarePromise `(window|global).Promise` has been overwritten.\nMost likely cause is that a Promise polyfill has been loaded after Zone.js (Polyfilling Promise api is not necessary when zone.js is loaded. If you must load one, do so before loading zone.js.)"
+                );
+        }
+        static get root() {
+            let r = Y.current;
+            for (; r.parent; ) r = r.parent;
+            return r;
+        }
+        static get current() {
+            return m.zone;
+        }
+        static get currentTask() {
+            return O;
+        }
+        static __load_patch(r, i, s = !1) {
+            if (N.hasOwnProperty(r)) {
+                let v = se[ee("forceDuplicateZoneCheck")] === !0;
+                if (!s && v) throw Error("Already loaded patch: " + r);
+            } else if (!se["__Zone_disable_" + r]) {
+                let v = "Zone:" + r;
+                n(v), (N[r] = i(se, Y, R)), a(v, v);
+            }
+        }
+        get parent() {
+            return this._parent;
+        }
+        get name() {
+            return this._name;
+        }
+        constructor(r, i) {
+            (this._parent = r),
+                (this._name = i ? i.name || "unnamed" : "<root>"),
+                (this._properties = (i && i.properties) || {}),
+                (this._zoneDelegate = new u(
+                    this,
+                    this._parent && this._parent._zoneDelegate,
+                    i
+                ));
+        }
+        get(r) {
+            let i = this.getZoneWith(r);
+            if (i) return i._properties[r];
+        }
+        getZoneWith(r) {
+            let i = this;
+            for (; i; ) {
+                if (i._properties.hasOwnProperty(r)) return i;
+                i = i._parent;
+            }
+            return null;
+        }
+        fork(r) {
+            if (!r) throw new Error("ZoneSpec required!");
+            return this._zoneDelegate.fork(this, r);
+        }
+        wrap(r, i) {
+            if (typeof r != "function")
+                throw new Error("Expecting function got: " + r);
+            let s = this._zoneDelegate.intercept(this, r, i),
+                v = this;
+            return function () {
+                return v.runGuarded(s, this, arguments, i);
+            };
+        }
+        run(r, i, s, v) {
+            m = { parent: m, zone: this };
+            try {
+                return this._zoneDelegate.invoke(this, r, i, s, v);
+            } finally {
+                m = m.parent;
+            }
+        }
+        runGuarded(r, i = null, s, v) {
+            m = { parent: m, zone: this };
+            try {
+                try {
+                    return this._zoneDelegate.invoke(this, r, i, s, v);
+                } catch (x) {
+                    if (this._zoneDelegate.handleError(this, x)) throw x;
+                }
+            } finally {
+                m = m.parent;
+            }
+        }
+        runTask(r, i, s) {
+            if (r.zone != this)
+                throw new Error(
+                    "A task can only be run in the zone of creation! (Creation: " +
+                        (r.zone || ne).name +
+                        "; Execution: " +
+                        this.name +
+                        ")"
+                );
+            if (r.state === z && (r.type === F || r.type === g)) return;
+            let v = r.state != G;
+            v && r._transitionTo(G, d), r.runCount++;
+            let x = O;
+            (O = r), (m = { parent: m, zone: this });
+            try {
+                r.type == g &&
+                    r.data &&
+                    !r.data.isPeriodic &&
+                    (r.cancelFn = void 0);
+                try {
+                    return this._zoneDelegate.invokeTask(this, r, i, s);
+                } catch (M) {
+                    if (this._zoneDelegate.handleError(this, M)) throw M;
+                }
+            } finally {
+                r.state !== z &&
+                    r.state !== X &&
+                    (r.type == F || (r.data && r.data.isPeriodic)
+                        ? v && r._transitionTo(d, G)
+                        : ((r.runCount = 0),
+                          this._updateTaskCount(r, -1),
+                          v && r._transitionTo(z, G, z))),
+                    (m = m.parent),
+                    (O = x);
+            }
+        }
+        scheduleTask(r) {
+            if (r.zone && r.zone !== this) {
+                let s = this;
+                for (; s; ) {
+                    if (s === r.zone)
+                        throw Error(
+                            `can not reschedule task to ${this.name} which is descendants of the original zone ${r.zone.name}`
+                        );
+                    s = s.parent;
+                }
+            }
+            r._transitionTo(k, z);
+            let i = [];
+            (r._zoneDelegates = i), (r._zone = this);
+            try {
+                r = this._zoneDelegate.scheduleTask(this, r);
+            } catch (s) {
+                throw (
+                    (r._transitionTo(X, k, z),
+                    this._zoneDelegate.handleError(this, s),
+                    s)
+                );
+            }
+            return (
+                r._zoneDelegates === i && this._updateTaskCount(r, 1),
+                r.state == k && r._transitionTo(d, k),
+                r
+            );
+        }
+        scheduleMicroTask(r, i, s, v) {
+            return this.scheduleTask(new _(V, r, i, s, v, void 0));
+        }
+        scheduleMacroTask(r, i, s, v, x) {
+            return this.scheduleTask(new _(g, r, i, s, v, x));
+        }
+        scheduleEventTask(r, i, s, v, x) {
+            return this.scheduleTask(new _(F, r, i, s, v, x));
+        }
+        cancelTask(r) {
+            if (r.zone != this)
+                throw new Error(
+                    "A task can only be cancelled in the zone of creation! (Creation: " +
+                        (r.zone || ne).name +
+                        "; Execution: " +
+                        this.name +
+                        ")"
+                );
+            if (!(r.state !== d && r.state !== G)) {
+                r._transitionTo(W, d, G);
+                try {
+                    this._zoneDelegate.cancelTask(this, r);
+                } catch (i) {
+                    throw (
+                        (r._transitionTo(X, W),
+                        this._zoneDelegate.handleError(this, i),
+                        i)
+                    );
+                }
+                return (
+                    this._updateTaskCount(r, -1),
+                    r._transitionTo(z, W),
+                    (r.runCount = 0),
+                    r
+                );
+            }
+        }
+        _updateTaskCount(r, i) {
+            let s = r._zoneDelegates;
+            i == -1 && (r._zoneDelegates = null);
+            for (let v = 0; v < s.length; v++) s[v]._updateTaskCount(r.type, i);
+        }
+    };
+    Y.__symbol__ = ee;
+    let t = Y,
+        c = {
+            name: "",
+            onHasTask: (A, r, i, s) => A.hasTask(i, s),
+            onScheduleTask: (A, r, i, s) => A.scheduleTask(i, s),
+            onInvokeTask: (A, r, i, s, v, x) => A.invokeTask(i, s, v, x),
+            onCancelTask: (A, r, i, s) => A.cancelTask(i, s),
+        };
+    class u {
+        get zone() {
+            return this._zone;
+        }
+        constructor(r, i, s) {
+            (this._taskCounts = { microTask: 0, macroTask: 0, eventTask: 0 }),
+                (this._zone = r),
+                (this._parentDelegate = i),
+                (this._forkZS = s && (s && s.onFork ? s : i._forkZS)),
+                (this._forkDlgt = s && (s.onFork ? i : i._forkDlgt)),
+                (this._forkCurrZone =
+                    s && (s.onFork ? this._zone : i._forkCurrZone)),
+                (this._interceptZS = s && (s.onIntercept ? s : i._interceptZS)),
+                (this._interceptDlgt =
+                    s && (s.onIntercept ? i : i._interceptDlgt)),
+                (this._interceptCurrZone =
+                    s && (s.onIntercept ? this._zone : i._interceptCurrZone)),
+                (this._invokeZS = s && (s.onInvoke ? s : i._invokeZS)),
+                (this._invokeDlgt = s && (s.onInvoke ? i : i._invokeDlgt)),
+                (this._invokeCurrZone =
+                    s && (s.onInvoke ? this._zone : i._invokeCurrZone)),
+                (this._handleErrorZS =
+                    s && (s.onHandleError ? s : i._handleErrorZS)),
+                (this._handleErrorDlgt =
+                    s && (s.onHandleError ? i : i._handleErrorDlgt)),
+                (this._handleErrorCurrZone =
+                    s &&
+                    (s.onHandleError ? this._zone : i._handleErrorCurrZone)),
+                (this._scheduleTaskZS =
+                    s && (s.onScheduleTask ? s : i._scheduleTaskZS)),
+                (this._scheduleTaskDlgt =
+                    s && (s.onScheduleTask ? i : i._scheduleTaskDlgt)),
+                (this._scheduleTaskCurrZone =
+                    s &&
+                    (s.onScheduleTask ? this._zone : i._scheduleTaskCurrZone)),
+                (this._invokeTaskZS =
+                    s && (s.onInvokeTask ? s : i._invokeTaskZS)),
+                (this._invokeTaskDlgt =
+                    s && (s.onInvokeTask ? i : i._invokeTaskDlgt)),
+                (this._invokeTaskCurrZone =
+                    s && (s.onInvokeTask ? this._zone : i._invokeTaskCurrZone)),
+                (this._cancelTaskZS =
+                    s && (s.onCancelTask ? s : i._cancelTaskZS)),
+                (this._cancelTaskDlgt =
+                    s && (s.onCancelTask ? i : i._cancelTaskDlgt)),
+                (this._cancelTaskCurrZone =
+                    s && (s.onCancelTask ? this._zone : i._cancelTaskCurrZone)),
+                (this._hasTaskZS = null),
+                (this._hasTaskDlgt = null),
+                (this._hasTaskDlgtOwner = null),
+                (this._hasTaskCurrZone = null);
+            let v = s && s.onHasTask,
+                x = i && i._hasTaskZS;
+            (v || x) &&
+                ((this._hasTaskZS = v ? s : c),
+                (this._hasTaskDlgt = i),
+                (this._hasTaskDlgtOwner = this),
+                (this._hasTaskCurrZone = this._zone),
+                s.onScheduleTask ||
+                    ((this._scheduleTaskZS = c),
+                    (this._scheduleTaskDlgt = i),
+                    (this._scheduleTaskCurrZone = this._zone)),
+                s.onInvokeTask ||
+                    ((this._invokeTaskZS = c),
+                    (this._invokeTaskDlgt = i),
+                    (this._invokeTaskCurrZone = this._zone)),
+                s.onCancelTask ||
+                    ((this._cancelTaskZS = c),
+                    (this._cancelTaskDlgt = i),
+                    (this._cancelTaskCurrZone = this._zone)));
+        }
+        fork(r, i) {
+            return this._forkZS
+                ? this._forkZS.onFork(this._forkDlgt, this.zone, r, i)
+                : new t(r, i);
+        }
+        intercept(r, i, s) {
+            return this._interceptZS
+                ? this._interceptZS.onIntercept(
+                      this._interceptDlgt,
+                      this._interceptCurrZone,
+                      r,
+                      i,
+                      s
+                  )
+                : i;
+        }
+        invoke(r, i, s, v, x) {
+            return this._invokeZS
+                ? this._invokeZS.onInvoke(
+                      this._invokeDlgt,
+                      this._invokeCurrZone,
+                      r,
+                      i,
+                      s,
+                      v,
+                      x
+                  )
+                : i.apply(s, v);
+        }
+        handleError(r, i) {
+            return this._handleErrorZS
+                ? this._handleErrorZS.onHandleError(
+                      this._handleErrorDlgt,
+                      this._handleErrorCurrZone,
+                      r,
+                      i
+                  )
+                : !0;
+        }
+        scheduleTask(r, i) {
+            let s = i;
+            if (this._scheduleTaskZS)
+                this._hasTaskZS &&
+                    s._zoneDelegates.push(this._hasTaskDlgtOwner),
+                    (s = this._scheduleTaskZS.onScheduleTask(
+                        this._scheduleTaskDlgt,
+                        this._scheduleTaskCurrZone,
+                        r,
+                        i
+                    )),
+                    s || (s = i);
+            else if (i.scheduleFn) i.scheduleFn(i);
+            else if (i.type == V) U(i);
+            else throw new Error("Task is missing scheduleFn.");
+            return s;
+        }
+        invokeTask(r, i, s, v) {
+            return this._invokeTaskZS
+                ? this._invokeTaskZS.onInvokeTask(
+                      this._invokeTaskDlgt,
+                      this._invokeTaskCurrZone,
+                      r,
+                      i,
+                      s,
+                      v
+                  )
+                : i.callback.apply(s, v);
+        }
+        cancelTask(r, i) {
+            let s;
+            if (this._cancelTaskZS)
+                s = this._cancelTaskZS.onCancelTask(
+                    this._cancelTaskDlgt,
+                    this._cancelTaskCurrZone,
+                    r,
+                    i
+                );
+            else {
+                if (!i.cancelFn) throw Error("Task is not cancelable");
+                s = i.cancelFn(i);
+            }
+            return s;
+        }
+        hasTask(r, i) {
+            try {
+                this._hasTaskZS &&
+                    this._hasTaskZS.onHasTask(
+                        this._hasTaskDlgt,
+                        this._hasTaskCurrZone,
+                        r,
+                        i
+                    );
+            } catch (s) {
+                this.handleError(r, s);
+            }
+        }
+        _updateTaskCount(r, i) {
+            let s = this._taskCounts,
+                v = s[r],
+                x = (s[r] = v + i);
+            if (x < 0)
+                throw new Error("More tasks executed then were scheduled.");
+            if (v == 0 || x == 0) {
+                let M = {
+                    microTask: s.microTask > 0,
+                    macroTask: s.macroTask > 0,
+                    eventTask: s.eventTask > 0,
+                    change: r,
+                };
+                this.hasTask(this._zone, M);
+            }
+        }
+    }
+    class _ {
+        constructor(r, i, s, v, x, M) {
+            if (
+                ((this._zone = null),
+                (this.runCount = 0),
+                (this._zoneDelegates = null),
+                (this._state = "notScheduled"),
+                (this.type = r),
+                (this.source = i),
+                (this.data = v),
+                (this.scheduleFn = x),
+                (this.cancelFn = M),
+                !s)
+            )
+                throw new Error("callback is not defined");
+            this.callback = s;
+            let he = this;
+            r === F && v && v.useG
+                ? (this.invoke = _.invokeTask)
+                : (this.invoke = function () {
+                      return _.invokeTask.call(se, he, this, arguments);
+                  });
+        }
+        static invokeTask(r, i, s) {
+            r || (r = this), K++;
+            try {
+                return r.runCount++, r.zone.runTask(r, i, s);
+            } finally {
+                K == 1 && j(), K--;
+            }
+        }
+        get zone() {
+            return this._zone;
+        }
+        get state() {
+            return this._state;
+        }
+        cancelScheduleRequest() {
+            this._transitionTo(z, k);
+        }
+        _transitionTo(r, i, s) {
+            if (this._state === i || this._state === s)
+                (this._state = r), r == z && (this._zoneDelegates = null);
+            else
+                throw new Error(
+                    `${this.type} '${this.source}': can not transition to '${r}', expecting state '${i}'${s ? " or '" + s + "'" : ""}, was '${this._state}'.`
+                );
+        }
+        toString() {
+            return this.data && typeof this.data.handleId < "u"
+                ? this.data.handleId.toString()
+                : Object.prototype.toString.call(this);
+        }
+        toJSON() {
+            return {
+                type: this.type,
+                state: this.state,
+                source: this.source,
+                zone: this.zone.name,
+                runCount: this.runCount,
+            };
+        }
+    }
+    let E = ee("setTimeout"),
+        y = ee("Promise"),
+        C = ee("then"),
+        T = [],
+        I = !1,
+        w;
+    function Z(A) {
+        if ((w || (se[y] && (w = se[y].resolve(0))), w)) {
+            let r = w[C];
+            r || (r = w.then), r.call(w, A);
+        } else se[E](A, 0);
+    }
+    function U(A) {
+        K === 0 && T.length === 0 && Z(j), A && T.push(A);
+    }
+    function j() {
+        if (!I) {
+            for (I = !0; T.length; ) {
+                let A = T;
+                T = [];
+                for (let r = 0; r < A.length; r++) {
+                    let i = A[r];
+                    try {
+                        i.zone.runTask(i, null, null);
+                    } catch (s) {
+                        R.onUnhandledError(s);
+                    }
+                }
+            }
+            R.microtaskDrainDone(), (I = !1);
+        }
+    }
+    let ne = { name: "NO ZONE" },
+        z = "notScheduled",
+        k = "scheduling",
+        d = "scheduled",
+        G = "running",
+        W = "canceling",
+        X = "unknown",
+        V = "microTask",
+        g = "macroTask",
+        F = "eventTask",
+        N = {},
+        R = {
+            symbol: ee,
+            currentZoneFrame: () => m,
+            onUnhandledError: q,
+            microtaskDrainDone: q,
+            scheduleMicroTask: U,
+            showUncaughtError: () => !t[ee("ignoreConsoleErrorUncaughtError")],
+            patchEventTarget: () => [],
+            patchOnProperties: q,
+            patchMethod: () => q,
+            bindArguments: () => [],
+            patchThen: () => q,
+            patchMacroTask: () => q,
+            patchEventPrototype: () => q,
+            isIEOrEdge: () => !1,
+            getGlobalObjects: () => {},
+            ObjectDefineProperty: () => q,
+            ObjectGetOwnPropertyDescriptor: () => {},
+            ObjectCreate: () => {},
+            ArraySlice: () => [],
+            patchClass: () => q,
+            wrapWithCurrentZone: () => q,
+            filterProperties: () => [],
+            attachOriginToPatched: () => q,
+            _redefineProperty: () => q,
+            patchCallbacks: () => q,
+            nativeScheduleMicroTask: Z,
+        },
+        m = { parent: null, zone: new t(null, null) },
+        O = null,
+        K = 0;
+    function q() {}
+    return a("Zone", "Zone"), t;
+}
+function ft() {
+    let e = globalThis,
+        n = e[ee("forceDuplicateZoneCheck")] === !0;
+    if (e.Zone && (n || typeof e.Zone.__symbol__ != "function"))
+        throw new Error("Zone already loaded.");
+    return (e.Zone ??= ut()), e.Zone;
+}
+var ke = Object.getOwnPropertyDescriptor,
+    Ze = Object.defineProperty,
+    je = Object.getPrototypeOf,
+    ht = Object.create,
+    dt = Array.prototype.slice,
+    Ae = "addEventListener",
+    He = "removeEventListener",
+    Ne = ee(Ae),
+    Ie = ee(He),
+    ie = "true",
+    ce = "false",
+    ve = ee("");
+function xe(e, n) {
+    return Zone.current.wrap(e, n);
+}
+function Ge(e, n, a, t, c) {
+    return Zone.current.scheduleMacroTask(e, n, a, t, c);
+}
+var H = ee,
+    Ce = typeof window < "u",
+    Te = Ce ? window : void 0,
+    $ = (Ce && Te) || globalThis,
+    _t = "removeAttribute";
+function Ve(e, n) {
+    for (let a = e.length - 1; a >= 0; a--)
+        typeof e[a] == "function" && (e[a] = xe(e[a], n + "_" + a));
+    return e;
+}
+function Et(e, n) {
+    let a = e.constructor.name;
+    for (let t = 0; t < n.length; t++) {
+        let c = n[t],
+            u = e[c];
+        if (u) {
+            let _ = ke(e, c);
+            if (!Ke(_)) continue;
+            e[c] = ((E) => {
+                let y = function () {
+                    return E.apply(this, Ve(arguments, a + "." + c));
+                };
+                return le(y, E), y;
+            })(u);
+        }
+    }
+}
+function Ke(e) {
+    return e
+        ? e.writable === !1
+            ? !1
+            : !(typeof e.get == "function" && typeof e.set > "u")
+        : !0;
+}
+var Qe = typeof WorkerGlobalScope < "u" && self instanceof WorkerGlobalScope,
+    Se =
+        !("nw" in $) &&
+        typeof $.process < "u" &&
+        {}.toString.call($.process) === "[object process]",
+    Fe = !Se && !Qe && !!(Ce && Te.HTMLElement),
+    et =
+        typeof $.process < "u" &&
+        {}.toString.call($.process) === "[object process]" &&
+        !Qe &&
+        !!(Ce && Te.HTMLElement),
+    Re = {},
+    Xe = function (e) {
+        if (((e = e || $.event), !e)) return;
+        let n = Re[e.type];
+        n || (n = Re[e.type] = H("ON_PROPERTY" + e.type));
+        let a = this || e.target || $,
+            t = a[n],
+            c;
+        if (Fe && a === Te && e.type === "error") {
+            let u = e;
+            (c =
+                t &&
+                t.call(
+                    this,
+                    u.message,
+                    u.filename,
+                    u.lineno,
+                    u.colno,
+                    u.error
+                )),
+                c === !0 && e.preventDefault();
+        } else
+            (c = t && t.apply(this, arguments)),
+                c != null && !c && e.preventDefault();
+        return c;
+    };
+function Ye(e, n, a) {
+    let t = ke(e, n);
+    if (
+        (!t && a && ke(a, n) && (t = { enumerable: !0, configurable: !0 }),
+        !t || !t.configurable)
+    )
+        return;
+    let c = H("on" + n + "patched");
+    if (e.hasOwnProperty(c) && e[c]) return;
+    delete t.writable, delete t.value;
+    let u = t.get,
+        _ = t.set,
+        E = n.slice(2),
+        y = Re[E];
+    y || (y = Re[E] = H("ON_PROPERTY" + E)),
+        (t.set = function (C) {
+            let T = this;
+            if ((!T && e === $ && (T = $), !T)) return;
+            typeof T[y] == "function" && T.removeEventListener(E, Xe),
+                _ && _.call(T, null),
+                (T[y] = C),
+                typeof C == "function" && T.addEventListener(E, Xe, !1);
+        }),
+        (t.get = function () {
+            let C = this;
+            if ((!C && e === $ && (C = $), !C)) return null;
+            let T = C[y];
+            if (T) return T;
+            if (u) {
+                let I = u.call(this);
+                if (I)
+                    return (
+                        t.set.call(this, I),
+                        typeof C[_t] == "function" && C.removeAttribute(n),
+                        I
+                    );
+            }
+            return null;
+        }),
+        Ze(e, n, t),
+        (e[c] = !0);
+}
+function tt(e, n, a) {
+    if (n) for (let t = 0; t < n.length; t++) Ye(e, "on" + n[t], a);
+    else {
+        let t = [];
+        for (let c in e) c.slice(0, 2) == "on" && t.push(c);
+        for (let c = 0; c < t.length; c++) Ye(e, t[c], a);
+    }
+}
+var re = H("originalInstance");
+function me(e) {
+    let n = $[e];
+    if (!n) return;
+    ($[H(e)] = n),
+        ($[e] = function () {
+            let c = Ve(arguments, e);
+            switch (c.length) {
+                case 0:
+                    this[re] = new n();
+                    break;
+                case 1:
+                    this[re] = new n(c[0]);
+                    break;
+                case 2:
+                    this[re] = new n(c[0], c[1]);
+                    break;
+                case 3:
+                    this[re] = new n(c[0], c[1], c[2]);
+                    break;
+                case 4:
+                    this[re] = new n(c[0], c[1], c[2], c[3]);
+                    break;
+                default:
+                    throw new Error("Arg list too long.");
+            }
+        }),
+        le($[e], n);
+    let a = new n(function () {}),
+        t;
+    for (t in a)
+        (e === "XMLHttpRequest" && t === "responseBlob") ||
+            (function (c) {
+                typeof a[c] == "function"
+                    ? ($[e].prototype[c] = function () {
+                          return this[re][c].apply(this[re], arguments);
+                      })
+                    : Ze($[e].prototype, c, {
+                          set: function (u) {
+                              typeof u == "function"
+                                  ? ((this[re][c] = xe(u, e + "." + c)),
+                                    le(this[re][c], u))
+                                  : (this[re][c] = u);
+                          },
+                          get: function () {
+                              return this[re][c];
+                          },
+                      });
+            })(t);
+    for (t in n) t !== "prototype" && n.hasOwnProperty(t) && ($[e][t] = n[t]);
+}
+function ae(e, n, a) {
+    let t = e;
+    for (; t && !t.hasOwnProperty(n); ) t = je(t);
+    !t && e[n] && (t = e);
+    let c = H(n),
+        u = null;
+    if (t && (!(u = t[c]) || !t.hasOwnProperty(c))) {
+        u = t[c] = t[n];
+        let _ = t && ke(t, n);
+        if (Ke(_)) {
+            let E = a(u, c, n);
+            (t[n] = function () {
+                return E(this, arguments);
+            }),
+                le(t[n], u);
+        }
+    }
+    return u;
+}
+function Tt(e, n, a) {
+    let t = null;
+    function c(u) {
+        let _ = u.data;
+        return (
+            (_.args[_.cbIdx] = function () {
+                u.invoke.apply(this, arguments);
+            }),
+            t.apply(_.target, _.args),
+            u
+        );
+    }
+    t = ae(
+        e,
+        n,
+        (u) =>
+            function (_, E) {
+                let y = a(_, E);
+                return y.cbIdx >= 0 && typeof E[y.cbIdx] == "function"
+                    ? Ge(y.name, E[y.cbIdx], y, c)
+                    : u.apply(_, E);
+            }
+    );
+}
+function le(e, n) {
+    e[H("OriginalDelegate")] = n;
+}
+var $e = !1,
+    Me = !1;
+function gt() {
+    try {
+        let e = Te.navigator.userAgent;
+        if (e.indexOf("MSIE ") !== -1 || e.indexOf("Trident/") !== -1)
+            return !0;
+    } catch {}
+    return !1;
+}
+function yt() {
+    if ($e) return Me;
+    $e = !0;
+    try {
+        let e = Te.navigator.userAgent;
+        (e.indexOf("MSIE ") !== -1 ||
+            e.indexOf("Trident/") !== -1 ||
+            e.indexOf("Edge/") !== -1) &&
+            (Me = !0);
+    } catch {}
+    return Me;
+}
+var Ee = !1;
+if (typeof window < "u")
+    try {
+        let e = Object.defineProperty({}, "passive", {
+            get: function () {
+                Ee = !0;
+            },
+        });
+        window.addEventListener("test", e, e),
+            window.removeEventListener("test", e, e);
+    } catch {
+        Ee = !1;
+    }
+var pt = { useG: !0 },
+    te = {},
+    nt = {},
+    rt = new RegExp("^" + ve + "(\\w+)(true|false)$"),
+    ot = H("propagationStopped");
+function st(e, n) {
+    let a = (n ? n(e) : e) + ce,
+        t = (n ? n(e) : e) + ie,
+        c = ve + a,
+        u = ve + t;
+    (te[e] = {}), (te[e][ce] = c), (te[e][ie] = u);
+}
+function mt(e, n, a, t) {
+    let c = (t && t.add) || Ae,
+        u = (t && t.rm) || He,
+        _ = (t && t.listeners) || "eventListeners",
+        E = (t && t.rmAll) || "removeAllListeners",
+        y = H(c),
+        C = "." + c + ":",
+        T = "prependListener",
+        I = "." + T + ":",
+        w = function (k, d, G) {
+            if (k.isRemoved) return;
+            let W = k.callback;
+            typeof W == "object" &&
+                W.handleEvent &&
+                ((k.callback = (g) => W.handleEvent(g)),
+                (k.originalDelegate = W));
+            let X;
+            try {
+                k.invoke(k, d, [G]);
+            } catch (g) {
+                X = g;
+            }
+            let V = k.options;
+            if (V && typeof V == "object" && V.once) {
+                let g = k.originalDelegate ? k.originalDelegate : k.callback;
+                d[u].call(d, G.type, g, V);
+            }
+            return X;
+        };
+    function Z(k, d, G) {
+        if (((d = d || e.event), !d)) return;
+        let W = k || d.target || e,
+            X = W[te[d.type][G ? ie : ce]];
+        if (X) {
+            let V = [];
+            if (X.length === 1) {
+                let g = w(X[0], W, d);
+                g && V.push(g);
+            } else {
+                let g = X.slice();
+                for (let F = 0; F < g.length && !(d && d[ot] === !0); F++) {
+                    let N = w(g[F], W, d);
+                    N && V.push(N);
+                }
+            }
+            if (V.length === 1) throw V[0];
+            for (let g = 0; g < V.length; g++) {
+                let F = V[g];
+                n.nativeScheduleMicroTask(() => {
+                    throw F;
+                });
+            }
+        }
+    }
+    let U = function (k) {
+            return Z(this, k, !1);
+        },
+        j = function (k) {
+            return Z(this, k, !0);
+        };
+    function ne(k, d) {
+        if (!k) return !1;
+        let G = !0;
+        d && d.useG !== void 0 && (G = d.useG);
+        let W = d && d.vh,
+            X = !0;
+        d && d.chkDup !== void 0 && (X = d.chkDup);
+        let V = !1;
+        d && d.rt !== void 0 && (V = d.rt);
+        let g = k;
+        for (; g && !g.hasOwnProperty(c); ) g = je(g);
+        if ((!g && k[c] && (g = k), !g || g[y])) return !1;
+        let F = d && d.eventNameToString,
+            N = {},
+            R = (g[y] = g[c]),
+            m = (g[H(u)] = g[u]),
+            O = (g[H(_)] = g[_]),
+            K = (g[H(E)] = g[E]),
+            q;
+        d && d.prepend && (q = g[H(d.prepend)] = g[d.prepend]);
+        function Y(o, l) {
+            return !Ee && typeof o == "object" && o
+                ? !!o.capture
+                : !Ee || !l
+                  ? o
+                  : typeof o == "boolean"
+                    ? { capture: o, passive: !0 }
+                    : o
+                      ? typeof o == "object" && o.passive !== !1
+                          ? { ...o, passive: !0 }
+                          : o
+                      : { passive: !0 };
+        }
+        let A = function (o) {
+                if (!N.isExisting)
+                    return R.call(
+                        N.target,
+                        N.eventName,
+                        N.capture ? j : U,
+                        N.options
+                    );
+            },
+            r = function (o) {
+                if (!o.isRemoved) {
+                    let l = te[o.eventName],
+                        h;
+                    l && (h = l[o.capture ? ie : ce]);
+                    let b = h && o.target[h];
+                    if (b) {
+                        for (let S = 0; S < b.length; S++)
+                            if (b[S] === o) {
+                                b.splice(S, 1),
+                                    (o.isRemoved = !0),
+                                    b.length === 0 &&
+                                        ((o.allRemoved = !0),
+                                        (o.target[h] = null));
+                                break;
+                            }
+                    }
+                }
+                if (o.allRemoved)
+                    return m.call(
+                        o.target,
+                        o.eventName,
+                        o.capture ? j : U,
+                        o.options
+                    );
+            },
+            i = function (o) {
+                return R.call(N.target, N.eventName, o.invoke, N.options);
+            },
+            s = function (o) {
+                return q.call(N.target, N.eventName, o.invoke, N.options);
+            },
+            v = function (o) {
+                return m.call(o.target, o.eventName, o.invoke, o.options);
+            },
+            x = G ? A : i,
+            M = G ? r : v,
+            he = function (o, l) {
+                let h = typeof l;
+                return (
+                    (h === "function" && o.callback === l) ||
+                    (h === "object" && o.originalDelegate === l)
+                );
+            },
+            ge = d && d.diff ? d.diff : he,
+            ue = Zone[H("UNPATCHED_EVENTS")],
+            be = e[H("PASSIVE_EVENTS")],
+            f = function (o, l, h, b, S = !1, p = !1) {
+                return function () {
+                    let P = this || e,
+                        D = arguments[0];
+                    d && d.transferEventName && (D = d.transferEventName(D));
+                    let L = arguments[1];
+                    if (!L) return o.apply(this, arguments);
+                    if (Se && D === "uncaughtException")
+                        return o.apply(this, arguments);
+                    let B = !1;
+                    if (typeof L != "function") {
+                        if (!L.handleEvent) return o.apply(this, arguments);
+                        B = !0;
+                    }
+                    if (W && !W(o, L, P, arguments)) return;
+                    let J = Ee && !!be && be.indexOf(D) !== -1,
+                        Q = Y(arguments[2], J),
+                        ye =
+                            Q &&
+                            typeof Q == "object" &&
+                            Q.signal &&
+                            typeof Q.signal == "object"
+                                ? Q.signal
+                                : void 0;
+                    if (ye?.aborted) return;
+                    if (ue) {
+                        for (let fe = 0; fe < ue.length; fe++)
+                            if (D === ue[fe])
+                                return J
+                                    ? o.call(P, D, L, Q)
+                                    : o.apply(this, arguments);
+                    }
+                    let De = Q ? (typeof Q == "boolean" ? !0 : Q.capture) : !1,
+                        Be = Q && typeof Q == "object" ? Q.once : !1,
+                        lt = Zone.current,
+                        Oe = te[D];
+                    Oe || (st(D, F), (Oe = te[D]));
+                    let Ue = Oe[De ? ie : ce],
+                        de = P[Ue],
+                        We = !1;
+                    if (de) {
+                        if (((We = !0), X)) {
+                            for (let fe = 0; fe < de.length; fe++)
+                                if (ge(de[fe], L)) return;
+                        }
+                    } else de = P[Ue] = [];
+                    let Pe,
+                        qe = P.constructor.name,
+                        ze = nt[qe];
+                    ze && (Pe = ze[D]),
+                        Pe || (Pe = qe + l + (F ? F(D) : D)),
+                        (N.options = Q),
+                        Be && (N.options.once = !1),
+                        (N.target = P),
+                        (N.capture = De),
+                        (N.eventName = D),
+                        (N.isExisting = We);
+                    let pe = G ? pt : void 0;
+                    pe && (pe.taskData = N), ye && (N.options.signal = void 0);
+                    let oe = lt.scheduleEventTask(Pe, L, pe, h, b);
+                    if (
+                        (ye &&
+                            ((N.options.signal = ye),
+                            o.call(
+                                ye,
+                                "abort",
+                                () => {
+                                    oe.zone.cancelTask(oe);
+                                },
+                                { once: !0 }
+                            )),
+                        (N.target = null),
+                        pe && (pe.taskData = null),
+                        Be && (Q.once = !0),
+                        (!Ee && typeof oe.options == "boolean") ||
+                            (oe.options = Q),
+                        (oe.target = P),
+                        (oe.capture = De),
+                        (oe.eventName = D),
+                        B && (oe.originalDelegate = L),
+                        p ? de.unshift(oe) : de.push(oe),
+                        S)
+                    )
+                        return P;
+                };
+            };
+        return (
+            (g[c] = f(R, C, x, M, V)),
+            q && (g[T] = f(q, I, s, M, V, !0)),
+            (g[u] = function () {
+                let o = this || e,
+                    l = arguments[0];
+                d && d.transferEventName && (l = d.transferEventName(l));
+                let h = arguments[2],
+                    b = h ? (typeof h == "boolean" ? !0 : h.capture) : !1,
+                    S = arguments[1];
+                if (!S) return m.apply(this, arguments);
+                if (W && !W(m, S, o, arguments)) return;
+                let p = te[l],
+                    P;
+                p && (P = p[b ? ie : ce]);
+                let D = P && o[P];
+                if (D)
+                    for (let L = 0; L < D.length; L++) {
+                        let B = D[L];
+                        if (ge(B, S)) {
+                            if (
+                                (D.splice(L, 1),
+                                (B.isRemoved = !0),
+                                D.length === 0 &&
+                                    ((B.allRemoved = !0),
+                                    (o[P] = null),
+                                    !b && typeof l == "string"))
+                            ) {
+                                let J = ve + "ON_PROPERTY" + l;
+                                o[J] = null;
+                            }
+                            return B.zone.cancelTask(B), V ? o : void 0;
+                        }
+                    }
+                return m.apply(this, arguments);
+            }),
+            (g[_] = function () {
+                let o = this || e,
+                    l = arguments[0];
+                d && d.transferEventName && (l = d.transferEventName(l));
+                let h = [],
+                    b = it(o, F ? F(l) : l);
+                for (let S = 0; S < b.length; S++) {
+                    let p = b[S],
+                        P = p.originalDelegate
+                            ? p.originalDelegate
+                            : p.callback;
+                    h.push(P);
+                }
+                return h;
+            }),
+            (g[E] = function () {
+                let o = this || e,
+                    l = arguments[0];
+                if (l) {
+                    d && d.transferEventName && (l = d.transferEventName(l));
+                    let h = te[l];
+                    if (h) {
+                        let b = h[ce],
+                            S = h[ie],
+                            p = o[b],
+                            P = o[S];
+                        if (p) {
+                            let D = p.slice();
+                            for (let L = 0; L < D.length; L++) {
+                                let B = D[L],
+                                    J = B.originalDelegate
+                                        ? B.originalDelegate
+                                        : B.callback;
+                                this[u].call(this, l, J, B.options);
+                            }
+                        }
+                        if (P) {
+                            let D = P.slice();
+                            for (let L = 0; L < D.length; L++) {
+                                let B = D[L],
+                                    J = B.originalDelegate
+                                        ? B.originalDelegate
+                                        : B.callback;
+                                this[u].call(this, l, J, B.options);
+                            }
+                        }
+                    }
+                } else {
+                    let h = Object.keys(o);
+                    for (let b = 0; b < h.length; b++) {
+                        let S = h[b],
+                            p = rt.exec(S),
+                            P = p && p[1];
+                        P && P !== "removeListener" && this[E].call(this, P);
+                    }
+                    this[E].call(this, "removeListener");
+                }
+                if (V) return this;
+            }),
+            le(g[c], R),
+            le(g[u], m),
+            K && le(g[E], K),
+            O && le(g[_], O),
+            !0
+        );
+    }
+    let z = [];
+    for (let k = 0; k < a.length; k++) z[k] = ne(a[k], t);
+    return z;
+}
+function it(e, n) {
+    if (!n) {
+        let u = [];
+        for (let _ in e) {
+            let E = rt.exec(_),
+                y = E && E[1];
+            if (y && (!n || y === n)) {
+                let C = e[_];
+                if (C) for (let T = 0; T < C.length; T++) u.push(C[T]);
+            }
+        }
+        return u;
+    }
+    let a = te[n];
+    a || (st(n), (a = te[n]));
+    let t = e[a[ce]],
+        c = e[a[ie]];
+    return t ? (c ? t.concat(c) : t.slice()) : c ? c.slice() : [];
+}
+function kt(e, n) {
+    let a = e.Event;
+    a &&
+        a.prototype &&
+        n.patchMethod(
+            a.prototype,
+            "stopImmediatePropagation",
+            (t) =>
+                function (c, u) {
+                    (c[ot] = !0), t && t.apply(c, u);
+                }
+        );
+}
+function vt(e, n) {
+    n.patchMethod(
+        e,
+        "queueMicrotask",
+        (a) =>
+            function (t, c) {
+                Zone.current.scheduleMicroTask("queueMicrotask", c[0]);
+            }
+    );
+}
+var we = H("zoneTask");
+function _e(e, n, a, t) {
+    let c = null,
+        u = null;
+    (n += t), (a += t);
+    let _ = {};
+    function E(C) {
+        let T = C.data;
+        return (
+            (T.args[0] = function () {
+                return C.invoke.apply(this, arguments);
+            }),
+            (T.handleId = c.apply(e, T.args)),
+            C
+        );
+    }
+    function y(C) {
+        return u.call(e, C.data.handleId);
+    }
+    (c = ae(
+        e,
+        n,
+        (C) =>
+            function (T, I) {
+                if (typeof I[0] == "function") {
+                    let w = {
+                            isPeriodic: t === "Interval",
+                            delay:
+                                t === "Timeout" || t === "Interval"
+                                    ? I[1] || 0
+                                    : void 0,
+                            args: I,
+                        },
+                        Z = I[0];
+                    I[0] = function () {
+                        try {
+                            return Z.apply(this, arguments);
+                        } finally {
+                            w.isPeriodic ||
+                                (typeof w.handleId == "number"
+                                    ? delete _[w.handleId]
+                                    : w.handleId && (w.handleId[we] = null));
+                        }
+                    };
+                    let U = Ge(n, I[0], w, E, y);
+                    if (!U) return U;
+                    let j = U.data.handleId;
+                    return (
+                        typeof j == "number" ? (_[j] = U) : j && (j[we] = U),
+                        j &&
+                            j.ref &&
+                            j.unref &&
+                            typeof j.ref == "function" &&
+                            typeof j.unref == "function" &&
+                            ((U.ref = j.ref.bind(j)),
+                            (U.unref = j.unref.bind(j))),
+                        typeof j == "number" || j ? j : U
+                    );
+                } else return C.apply(e, I);
+            }
+    )),
+        (u = ae(
+            e,
+            a,
+            (C) =>
+                function (T, I) {
+                    let w = I[0],
+                        Z;
+                    typeof w == "number"
+                        ? (Z = _[w])
+                        : ((Z = w && w[we]), Z || (Z = w)),
+                        Z && typeof Z.type == "string"
+                            ? Z.state !== "notScheduled" &&
+                              ((Z.cancelFn && Z.data.isPeriodic) ||
+                                  Z.runCount === 0) &&
+                              (typeof w == "number"
+                                  ? delete _[w]
+                                  : w && (w[we] = null),
+                              Z.zone.cancelTask(Z))
+                            : C.apply(e, I);
+                }
+        ));
+}
+function bt(e, n) {
+    let { isBrowser: a, isMix: t } = n.getGlobalObjects();
+    if ((!a && !t) || !e.customElements || !("customElements" in e)) return;
+    let c = [
+        "connectedCallback",
+        "disconnectedCallback",
+        "adoptedCallback",
+        "attributeChangedCallback",
+        "formAssociatedCallback",
+        "formDisabledCallback",
+        "formResetCallback",
+        "formStateRestoreCallback",
+    ];
+    n.patchCallbacks(n, e.customElements, "customElements", "define", c);
+}
+function Pt(e, n) {
+    if (Zone[n.symbol("patchEventTarget")]) return;
+    let {
+        eventNames: a,
+        zoneSymbolEventNames: t,
+        TRUE_STR: c,
+        FALSE_STR: u,
+        ZONE_SYMBOL_PREFIX: _,
+    } = n.getGlobalObjects();
+    for (let y = 0; y < a.length; y++) {
+        let C = a[y],
+            T = C + u,
+            I = C + c,
+            w = _ + T,
+            Z = _ + I;
+        (t[C] = {}), (t[C][u] = w), (t[C][c] = Z);
+    }
+    let E = e.EventTarget;
+    if (!(!E || !E.prototype))
+        return n.patchEventTarget(e, n, [E && E.prototype]), !0;
+}
+function wt(e, n) {
+    n.patchEventPrototype(e, n);
+}
+function ct(e, n, a) {
+    if (!a || a.length === 0) return n;
+    let t = a.filter((u) => u.target === e);
+    if (!t || t.length === 0) return n;
+    let c = t[0].ignoreProperties;
+    return n.filter((u) => c.indexOf(u) === -1);
+}
+function Je(e, n, a, t) {
+    if (!e) return;
+    let c = ct(e, n, a);
+    tt(e, c, t);
+}
+function Le(e) {
+    return Object.getOwnPropertyNames(e)
+        .filter((n) => n.startsWith("on") && n.length > 2)
+        .map((n) => n.substring(2));
+}
+function Rt(e, n) {
+    if ((Se && !et) || Zone[e.symbol("patchEvents")]) return;
+    let a = n.__Zone_ignore_on_properties,
+        t = [];
+    if (Fe) {
+        let c = window;
+        t = t.concat([
+            "Document",
+            "SVGElement",
+            "Element",
+            "HTMLElement",
+            "HTMLBodyElement",
+            "HTMLMediaElement",
+            "HTMLFrameSetElement",
+            "HTMLFrameElement",
+            "HTMLIFrameElement",
+            "HTMLMarqueeElement",
+            "Worker",
+        ]);
+        let u = gt() ? [{ target: c, ignoreProperties: ["error"] }] : [];
+        Je(c, Le(c), a && a.concat(u), je(c));
+    }
+    t = t.concat([
+        "XMLHttpRequest",
+        "XMLHttpRequestEventTarget",
+        "IDBIndex",
+        "IDBRequest",
+        "IDBOpenDBRequest",
+        "IDBDatabase",
+        "IDBTransaction",
+        "IDBCursor",
+        "WebSocket",
+    ]);
+    for (let c = 0; c < t.length; c++) {
+        let u = n[t[c]];
+        u && u.prototype && Je(u.prototype, Le(u.prototype), a);
+    }
+}
+function Ct(e) {
+    e.__load_patch("legacy", (n) => {
+        let a = n[e.__symbol__("legacyPatch")];
+        a && a();
+    }),
+        e.__load_patch("timers", (n) => {
+            let a = "set",
+                t = "clear";
+            _e(n, a, t, "Timeout"),
+                _e(n, a, t, "Interval"),
+                _e(n, a, t, "Immediate");
+        }),
+        e.__load_patch("requestAnimationFrame", (n) => {
+            _e(n, "request", "cancel", "AnimationFrame"),
+                _e(n, "mozRequest", "mozCancel", "AnimationFrame"),
+                _e(n, "webkitRequest", "webkitCancel", "AnimationFrame");
+        }),
+        e.__load_patch("blocking", (n, a) => {
+            let t = ["alert", "prompt", "confirm"];
+            for (let c = 0; c < t.length; c++) {
+                let u = t[c];
+                ae(
+                    n,
+                    u,
+                    (_, E, y) =>
+                        function (C, T) {
+                            return a.current.run(_, n, T, y);
+                        }
+                );
+            }
+        }),
+        e.__load_patch("EventTarget", (n, a, t) => {
+            wt(n, t), Pt(n, t);
+            let c = n.XMLHttpRequestEventTarget;
+            c && c.prototype && t.patchEventTarget(n, t, [c.prototype]);
+        }),
+        e.__load_patch("MutationObserver", (n, a, t) => {
+            me("MutationObserver"), me("WebKitMutationObserver");
+        }),
+        e.__load_patch("IntersectionObserver", (n, a, t) => {
+            me("IntersectionObserver");
+        }),
+        e.__load_patch("FileReader", (n, a, t) => {
+            me("FileReader");
+        }),
+        e.__load_patch("on_property", (n, a, t) => {
+            Rt(t, n);
+        }),
+        e.__load_patch("customElements", (n, a, t) => {
+            bt(n, t);
+        }),
+        e.__load_patch("XHR", (n, a) => {
+            C(n);
+            let t = H("xhrTask"),
+                c = H("xhrSync"),
+                u = H("xhrListener"),
+                _ = H("xhrScheduled"),
+                E = H("xhrURL"),
+                y = H("xhrErrorBeforeScheduled");
+            function C(T) {
+                let I = T.XMLHttpRequest;
+                if (!I) return;
+                let w = I.prototype;
+                function Z(R) {
+                    return R[t];
+                }
+                let U = w[Ne],
+                    j = w[Ie];
+                if (!U) {
+                    let R = T.XMLHttpRequestEventTarget;
+                    if (R) {
+                        let m = R.prototype;
+                        (U = m[Ne]), (j = m[Ie]);
+                    }
+                }
+                let ne = "readystatechange",
+                    z = "scheduled";
+                function k(R) {
+                    let m = R.data,
+                        O = m.target;
+                    (O[_] = !1), (O[y] = !1);
+                    let K = O[u];
+                    U || ((U = O[Ne]), (j = O[Ie])), K && j.call(O, ne, K);
+                    let q = (O[u] = () => {
+                        if (O.readyState === O.DONE)
+                            if (!m.aborted && O[_] && R.state === z) {
+                                let A = O[a.__symbol__("loadfalse")];
+                                if (O.status !== 0 && A && A.length > 0) {
+                                    let r = R.invoke;
+                                    (R.invoke = function () {
+                                        let i = O[a.__symbol__("loadfalse")];
+                                        for (let s = 0; s < i.length; s++)
+                                            i[s] === R && i.splice(s, 1);
+                                        !m.aborted &&
+                                            R.state === z &&
+                                            r.call(R);
+                                    }),
+                                        A.push(R);
+                                } else R.invoke();
+                            } else !m.aborted && O[_] === !1 && (O[y] = !0);
+                    });
+                    return (
+                        U.call(O, ne, q),
+                        O[t] || (O[t] = R),
+                        F.apply(O, m.args),
+                        (O[_] = !0),
+                        R
+                    );
+                }
+                function d() {}
+                function G(R) {
+                    let m = R.data;
+                    return (m.aborted = !0), N.apply(m.target, m.args);
+                }
+                let W = ae(
+                        w,
+                        "open",
+                        () =>
+                            function (R, m) {
+                                return (
+                                    (R[c] = m[2] == !1),
+                                    (R[E] = m[1]),
+                                    W.apply(R, m)
+                                );
+                            }
+                    ),
+                    X = "XMLHttpRequest.send",
+                    V = H("fetchTaskAborting"),
+                    g = H("fetchTaskScheduling"),
+                    F = ae(
+                        w,
+                        "send",
+                        () =>
+                            function (R, m) {
+                                if (a.current[g] === !0 || R[c])
+                                    return F.apply(R, m);
+                                {
+                                    let O = {
+                                            target: R,
+                                            url: R[E],
+                                            isPeriodic: !1,
+                                            args: m,
+                                            aborted: !1,
+                                        },
+                                        K = Ge(X, d, O, k, G);
+                                    R &&
+                                        R[y] === !0 &&
+                                        !O.aborted &&
+                                        K.state === z &&
+                                        K.invoke();
+                                }
+                            }
+                    ),
+                    N = ae(
+                        w,
+                        "abort",
+                        () =>
+                            function (R, m) {
+                                let O = Z(R);
+                                if (O && typeof O.type == "string") {
+                                    if (
+                                        O.cancelFn == null ||
+                                        (O.data && O.data.aborted)
+                                    )
+                                        return;
+                                    O.zone.cancelTask(O);
+                                } else if (a.current[V] === !0)
+                                    return N.apply(R, m);
+                            }
+                    );
+            }
+        }),
+        e.__load_patch("geolocation", (n) => {
+            n.navigator &&
+                n.navigator.geolocation &&
+                Et(n.navigator.geolocation, [
+                    "getCurrentPosition",
+                    "watchPosition",
+                ]);
+        }),
+        e.__load_patch("PromiseRejectionEvent", (n, a) => {
+            function t(c) {
+                return function (u) {
+                    it(n, c).forEach((E) => {
+                        let y = n.PromiseRejectionEvent;
+                        if (y) {
+                            let C = new y(c, {
+                                promise: u.promise,
+                                reason: u.rejection,
+                            });
+                            E.invoke(C);
+                        }
+                    });
+                };
+            }
+            n.PromiseRejectionEvent &&
+                ((a[H("unhandledPromiseRejectionHandler")] =
+                    t("unhandledrejection")),
+                (a[H("rejectionHandledHandler")] = t("rejectionhandled")));
+        }),
+        e.__load_patch("queueMicrotask", (n, a, t) => {
+            vt(n, t);
+        });
+}
+function St(e) {
+    e.__load_patch("ZoneAwarePromise", (n, a, t) => {
+        let c = Object.getOwnPropertyDescriptor,
+            u = Object.defineProperty;
+        function _(f) {
+            if (f && f.toString === Object.prototype.toString) {
+                let o = f.constructor && f.constructor.name;
+                return (o || "") + ": " + JSON.stringify(f);
+            }
+            return f ? f.toString() : Object.prototype.toString.call(f);
+        }
+        let E = t.symbol,
+            y = [],
+            C = n[E("DISABLE_WRAPPING_UNCAUGHT_PROMISE_REJECTION")] !== !1,
+            T = E("Promise"),
+            I = E("then"),
+            w = "__creationTrace__";
+        (t.onUnhandledError = (f) => {
+            if (t.showUncaughtError()) {
+                let o = f && f.rejection;
+                o
+                    ? console.error(
+                          "Unhandled Promise rejection:",
+                          o instanceof Error ? o.message : o,
+                          "; Zone:",
+                          f.zone.name,
+                          "; Task:",
+                          f.task && f.task.source,
+                          "; Value:",
+                          o,
+                          o instanceof Error ? o.stack : void 0
+                      )
+                    : console.error(f);
+            }
+        }),
+            (t.microtaskDrainDone = () => {
+                for (; y.length; ) {
+                    let f = y.shift();
+                    try {
+                        f.zone.runGuarded(() => {
+                            throw f.throwOriginal ? f.rejection : f;
+                        });
+                    } catch (o) {
+                        U(o);
+                    }
+                }
+            });
+        let Z = E("unhandledPromiseRejectionHandler");
+        function U(f) {
+            t.onUnhandledError(f);
+            try {
+                let o = a[Z];
+                typeof o == "function" && o.call(this, f);
+            } catch {}
+        }
+        function j(f) {
+            return f && f.then;
+        }
+        function ne(f) {
+            return f;
+        }
+        function z(f) {
+            return M.reject(f);
+        }
+        let k = E("state"),
+            d = E("value"),
+            G = E("finally"),
+            W = E("parentPromiseValue"),
+            X = E("parentPromiseState"),
+            V = "Promise.then",
+            g = null,
+            F = !0,
+            N = !1,
+            R = 0;
+        function m(f, o) {
+            return (l) => {
+                try {
+                    Y(f, o, l);
+                } catch (h) {
+                    Y(f, !1, h);
+                }
+            };
+        }
+        let O = function () {
+                let f = !1;
+                return function (l) {
+                    return function () {
+                        f || ((f = !0), l.apply(null, arguments));
+                    };
+                };
+            },
+            K = "Promise resolved with itself",
+            q = E("currentTaskTrace");
+        function Y(f, o, l) {
+            let h = O();
+            if (f === l) throw new TypeError(K);
+            if (f[k] === g) {
+                let b = null;
+                try {
+                    (typeof l == "object" || typeof l == "function") &&
+                        (b = l && l.then);
+                } catch (S) {
+                    return (
+                        h(() => {
+                            Y(f, !1, S);
+                        })(),
+                        f
+                    );
+                }
+                if (
+                    o !== N &&
+                    l instanceof M &&
+                    l.hasOwnProperty(k) &&
+                    l.hasOwnProperty(d) &&
+                    l[k] !== g
+                )
+                    r(l), Y(f, l[k], l[d]);
+                else if (o !== N && typeof b == "function")
+                    try {
+                        b.call(l, h(m(f, o)), h(m(f, !1)));
+                    } catch (S) {
+                        h(() => {
+                            Y(f, !1, S);
+                        })();
+                    }
+                else {
+                    f[k] = o;
+                    let S = f[d];
+                    if (
+                        ((f[d] = l),
+                        f[G] === G && o === F && ((f[k] = f[X]), (f[d] = f[W])),
+                        o === N && l instanceof Error)
+                    ) {
+                        let p =
+                            a.currentTask &&
+                            a.currentTask.data &&
+                            a.currentTask.data[w];
+                        p &&
+                            u(l, q, {
+                                configurable: !0,
+                                enumerable: !1,
+                                writable: !0,
+                                value: p,
+                            });
+                    }
+                    for (let p = 0; p < S.length; )
+                        i(f, S[p++], S[p++], S[p++], S[p++]);
+                    if (S.length == 0 && o == N) {
+                        f[k] = R;
+                        let p = l;
+                        try {
+                            throw new Error(
+                                "Uncaught (in promise): " +
+                                    _(l) +
+                                    (l && l.stack
+                                        ? `
+` + l.stack
+                                        : "")
+                            );
+                        } catch (P) {
+                            p = P;
+                        }
+                        C && (p.throwOriginal = !0),
+                            (p.rejection = l),
+                            (p.promise = f),
+                            (p.zone = a.current),
+                            (p.task = a.currentTask),
+                            y.push(p),
+                            t.scheduleMicroTask();
+                    }
+                }
+            }
+            return f;
+        }
+        let A = E("rejectionHandledHandler");
+        function r(f) {
+            if (f[k] === R) {
+                try {
+                    let o = a[A];
+                    o &&
+                        typeof o == "function" &&
+                        o.call(this, { rejection: f[d], promise: f });
+                } catch {}
+                f[k] = N;
+                for (let o = 0; o < y.length; o++)
+                    f === y[o].promise && y.splice(o, 1);
+            }
+        }
+        function i(f, o, l, h, b) {
+            r(f);
+            let S = f[k],
+                p = S
+                    ? typeof h == "function"
+                        ? h
+                        : ne
+                    : typeof b == "function"
+                      ? b
+                      : z;
+            o.scheduleMicroTask(
+                V,
+                () => {
+                    try {
+                        let P = f[d],
+                            D = !!l && G === l[G];
+                        D && ((l[W] = P), (l[X] = S));
+                        let L = o.run(
+                            p,
+                            void 0,
+                            D && p !== z && p !== ne ? [] : [P]
+                        );
+                        Y(l, !0, L);
+                    } catch (P) {
+                        Y(l, !1, P);
+                    }
+                },
+                l
+            );
+        }
+        let s = "function ZoneAwarePromise() { [native code] }",
+            v = function () {},
+            x = n.AggregateError;
+        class M {
+            static toString() {
+                return s;
+            }
+            static resolve(o) {
+                return o instanceof M ? o : Y(new this(null), F, o);
+            }
+            static reject(o) {
+                return Y(new this(null), N, o);
+            }
+            static withResolvers() {
+                let o = {};
+                return (
+                    (o.promise = new M((l, h) => {
+                        (o.resolve = l), (o.reject = h);
+                    })),
+                    o
+                );
+            }
+            static any(o) {
+                if (!o || typeof o[Symbol.iterator] != "function")
+                    return Promise.reject(
+                        new x([], "All promises were rejected")
+                    );
+                let l = [],
+                    h = 0;
+                try {
+                    for (let p of o) h++, l.push(M.resolve(p));
+                } catch {
+                    return Promise.reject(
+                        new x([], "All promises were rejected")
+                    );
+                }
+                if (h === 0)
+                    return Promise.reject(
+                        new x([], "All promises were rejected")
+                    );
+                let b = !1,
+                    S = [];
+                return new M((p, P) => {
+                    for (let D = 0; D < l.length; D++)
+                        l[D].then(
+                            (L) => {
+                                b || ((b = !0), p(L));
+                            },
+                            (L) => {
+                                S.push(L),
+                                    h--,
+                                    h === 0 &&
+                                        ((b = !0),
+                                        P(
+                                            new x(
+                                                S,
+                                                "All promises were rejected"
+                                            )
+                                        ));
+                            }
+                        );
+                });
+            }
+            static race(o) {
+                let l,
+                    h,
+                    b = new this((P, D) => {
+                        (l = P), (h = D);
+                    });
+                function S(P) {
+                    l(P);
+                }
+                function p(P) {
+                    h(P);
+                }
+                for (let P of o) j(P) || (P = this.resolve(P)), P.then(S, p);
+                return b;
+            }
+            static all(o) {
+                return M.allWithCallback(o);
+            }
+            static allSettled(o) {
+                return (
+                    this && this.prototype instanceof M ? this : M
+                ).allWithCallback(o, {
+                    thenCallback: (h) => ({ status: "fulfilled", value: h }),
+                    errorCallback: (h) => ({ status: "rejected", reason: h }),
+                });
+            }
+            static allWithCallback(o, l) {
+                let h,
+                    b,
+                    S = new this((L, B) => {
+                        (h = L), (b = B);
+                    }),
+                    p = 2,
+                    P = 0,
+                    D = [];
+                for (let L of o) {
+                    j(L) || (L = this.resolve(L));
+                    let B = P;
+                    try {
+                        L.then(
+                            (J) => {
+                                (D[B] = l ? l.thenCallback(J) : J),
+                                    p--,
+                                    p === 0 && h(D);
+                            },
+                            (J) => {
+                                l
+                                    ? ((D[B] = l.errorCallback(J)),
+                                      p--,
+                                      p === 0 && h(D))
+                                    : b(J);
+                            }
+                        );
+                    } catch (J) {
+                        b(J);
+                    }
+                    p++, P++;
+                }
+                return (p -= 2), p === 0 && h(D), S;
+            }
+            constructor(o) {
+                let l = this;
+                if (!(l instanceof M))
+                    throw new Error("Must be an instanceof Promise.");
+                (l[k] = g), (l[d] = []);
+                try {
+                    let h = O();
+                    o && o(h(m(l, F)), h(m(l, N)));
+                } catch (h) {
+                    Y(l, !1, h);
+                }
+            }
+            get [Symbol.toStringTag]() {
+                return "Promise";
+            }
+            get [Symbol.species]() {
+                return M;
+            }
+            then(o, l) {
+                let h = this.constructor?.[Symbol.species];
+                (!h || typeof h != "function") && (h = this.constructor || M);
+                let b = new h(v),
+                    S = a.current;
+                return (
+                    this[k] == g
+                        ? this[d].push(S, b, o, l)
+                        : i(this, S, b, o, l),
+                    b
+                );
+            }
+            catch(o) {
+                return this.then(null, o);
+            }
+            finally(o) {
+                let l = this.constructor?.[Symbol.species];
+                (!l || typeof l != "function") && (l = M);
+                let h = new l(v);
+                h[G] = G;
+                let b = a.current;
+                return (
+                    this[k] == g
+                        ? this[d].push(b, h, o, o)
+                        : i(this, b, h, o, o),
+                    h
+                );
+            }
+        }
+        (M.resolve = M.resolve),
+            (M.reject = M.reject),
+            (M.race = M.race),
+            (M.all = M.all);
+        let he = (n[T] = n.Promise);
+        n.Promise = M;
+        let ge = E("thenPatched");
+        function ue(f) {
+            let o = f.prototype,
+                l = c(o, "then");
+            if (l && (l.writable === !1 || !l.configurable)) return;
+            let h = o.then;
+            (o[I] = h),
+                (f.prototype.then = function (b, S) {
+                    return new M((P, D) => {
+                        h.call(this, P, D);
+                    }).then(b, S);
+                }),
+                (f[ge] = !0);
+        }
+        t.patchThen = ue;
+        function be(f) {
+            return function (o, l) {
+                let h = f.apply(o, l);
+                if (h instanceof M) return h;
+                let b = h.constructor;
+                return b[ge] || ue(b), h;
+            };
+        }
+        return (
+            he && (ue(he), ae(n, "fetch", (f) => be(f))),
+            (Promise[a.__symbol__("uncaughtPromiseErrors")] = y),
+            M
+        );
+    });
+}
+function Dt(e) {
+    e.__load_patch("toString", (n) => {
+        let a = Function.prototype.toString,
+            t = H("OriginalDelegate"),
+            c = H("Promise"),
+            u = H("Error"),
+            _ = function () {
+                if (typeof this == "function") {
+                    let T = this[t];
+                    if (T)
+                        return typeof T == "function"
+                            ? a.call(T)
+                            : Object.prototype.toString.call(T);
+                    if (this === Promise) {
+                        let I = n[c];
+                        if (I) return a.call(I);
+                    }
+                    if (this === Error) {
+                        let I = n[u];
+                        if (I) return a.call(I);
+                    }
+                }
+                return a.call(this);
+            };
+        (_[t] = a), (Function.prototype.toString = _);
+        let E = Object.prototype.toString,
+            y = "[object Promise]";
+        Object.prototype.toString = function () {
+            return typeof Promise == "function" && this instanceof Promise
+                ? y
+                : E.call(this);
+        };
+    });
+}
+function Ot(e, n, a, t, c) {
+    let u = Zone.__symbol__(t);
+    if (n[u]) return;
+    let _ = (n[u] = n[t]);
+    (n[t] = function (E, y, C) {
+        return (
+            y &&
+                y.prototype &&
+                c.forEach(function (T) {
+                    let I = `${a}.${t}::` + T,
+                        w = y.prototype;
+                    try {
+                        if (w.hasOwnProperty(T)) {
+                            let Z = e.ObjectGetOwnPropertyDescriptor(w, T);
+                            Z && Z.value
+                                ? ((Z.value = e.wrapWithCurrentZone(
+                                      Z.value,
+                                      I
+                                  )),
+                                  e._redefineProperty(y.prototype, T, Z))
+                                : w[T] &&
+                                  (w[T] = e.wrapWithCurrentZone(w[T], I));
+                        } else w[T] && (w[T] = e.wrapWithCurrentZone(w[T], I));
+                    } catch {}
+                }),
+            _.call(n, E, y, C)
+        );
+    }),
+        e.attachOriginToPatched(n[t], _);
+}
+function Nt(e) {
+    e.__load_patch("util", (n, a, t) => {
+        let c = Le(n);
+        (t.patchOnProperties = tt),
+            (t.patchMethod = ae),
+            (t.bindArguments = Ve),
+            (t.patchMacroTask = Tt);
+        let u = a.__symbol__("BLACK_LISTED_EVENTS"),
+            _ = a.__symbol__("UNPATCHED_EVENTS");
+        n[_] && (n[u] = n[_]),
+            n[u] && (a[u] = a[_] = n[u]),
+            (t.patchEventPrototype = kt),
+            (t.patchEventTarget = mt),
+            (t.isIEOrEdge = yt),
+            (t.ObjectDefineProperty = Ze),
+            (t.ObjectGetOwnPropertyDescriptor = ke),
+            (t.ObjectCreate = ht),
+            (t.ArraySlice = dt),
+            (t.patchClass = me),
+            (t.wrapWithCurrentZone = xe),
+            (t.filterProperties = ct),
+            (t.attachOriginToPatched = le),
+            (t._redefineProperty = Object.defineProperty),
+            (t.patchCallbacks = Ot),
+            (t.getGlobalObjects = () => ({
+                globalSources: nt,
+                zoneSymbolEventNames: te,
+                eventNames: c,
+                isBrowser: Fe,
+                isMix: et,
+                isNode: Se,
+                TRUE_STR: ie,
+                FALSE_STR: ce,
+                ZONE_SYMBOL_PREFIX: ve,
+                ADD_EVENT_LISTENER_STR: Ae,
+                REMOVE_EVENT_LISTENER_STR: He,
+            }));
+    });
+}
+function It(e) {
+    St(e), Dt(e), Nt(e);
+}
+var at = ft();
+It(at);
+Ct(at);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,7 @@
                 "mongoose": "^8.3.2",
                 "passport": "^0.7.0",
                 "passport-google-oauth20": "^2.0.0",
-                "puppeteer": "^22.6.1",
-                "puppeteer-extra": "^3.3.6",
-                "puppeteer-extra-plugin-stealth": "^2.11.2",
+                "puppeteer": "npm:rebrowser-puppeteer@^23.3.1",
                 "winston": "^3.13.0"
             },
             "devDependencies": {
@@ -202,86 +200,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/@puppeteer/browsers": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.2.2.tgz",
-            "integrity": "sha512-hZ/JhxPIceWaGSEzUZp83/8M49CoxlkuThfTR7t4AoCu5+ZvJ3vktLm60Otww2TXeROB5igiZ8D9oPQh6ckBVg==",
-            "dependencies": {
-                "debug": "4.3.4",
-                "extract-zip": "2.0.1",
-                "progress": "2.0.3",
-                "proxy-agent": "6.4.0",
-                "semver": "7.6.0",
-                "tar-fs": "3.0.5",
-                "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.2"
-            },
-            "bin": {
-                "browsers": "lib/cjs/main-cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/@puppeteer/browsers/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@sinonjs/commons": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -367,14 +285,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/debug": {
-            "version": "4.1.12",
-            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-            "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
-            "dependencies": {
-                "@types/ms": "*"
-            }
-        },
         "node_modules/@types/express": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
@@ -421,11 +331,6 @@
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.6.tgz",
             "integrity": "sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==",
             "dev": true
-        },
-        "node_modules/@types/ms": {
-            "version": "0.7.34",
-            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-            "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
         },
         "node_modules/@types/node": {
             "version": "20.12.7",
@@ -629,14 +534,6 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         },
-        "node_modules/arr-union": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -698,54 +595,56 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
         },
         "node_modules/b4a": {
-            "version": "1.6.6",
-            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
-            "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+            "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "node_modules/bare-events": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
-            "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
+            "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
             "optional": true
         },
         "node_modules/bare-fs": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
-            "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
+            "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
             "optional": true,
             "dependencies": {
                 "bare-events": "^2.0.0",
                 "bare-path": "^2.0.0",
-                "bare-stream": "^1.0.0"
+                "bare-stream": "^2.0.0"
             }
         },
         "node_modules/bare-os": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
-            "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
+            "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
             "optional": true
         },
         "node_modules/bare-path": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.1.tgz",
-            "integrity": "sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
+            "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
             "optional": true,
             "dependencies": {
                 "bare-os": "^2.1.0"
             }
         },
         "node_modules/bare-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
-            "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.0.tgz",
+            "integrity": "sha512-pVRWciewGUeCyKEuRxwv06M079r+fRjAQjBEK2P6OYGrO43O+Z0LrPZZEjlc4mB6C2RpZ9AxJ1s7NLEtOHO6eA==",
             "optional": true,
             "dependencies": {
-                "streamx": "^2.16.1"
+                "b4a": "^1.6.6",
+                "streamx": "^2.20.0"
             }
         },
         "node_modules/base64-js": {
@@ -801,9 +700,9 @@
             "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/body-parser": {
-            "version": "1.20.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-            "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+            "version": "1.20.3",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+            "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.5",
@@ -813,7 +712,7 @@
                 "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "on-finished": "2.4.1",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "raw-body": "2.5.2",
                 "type-is": "~1.6.18",
                 "unpipe": "1.0.0"
@@ -833,12 +732,12 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -977,20 +876,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/chai-http/node_modules/qs": {
-            "version": "6.12.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.12.1.tgz",
-            "integrity": "sha512-zWmv4RSuB9r2mYQw3zxQuHWeU+42aKi1wWig/j4ele4ygELZ7PEO6MM7rim9oAQH2A5MWfsAVf/jPvTPgCbvUQ==",
-            "dependencies": {
-                "side-channel": "^1.0.6"
-            },
-            "engines": {
-                "node": ">=0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1066,19 +951,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chromium-bidi": {
-            "version": "0.5.17",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.17.tgz",
-            "integrity": "sha512-BqOuIWUgTPj8ayuBFJUYCCuwIcwjBsb3/614P7tt1bEPJ4i1M0kCdIl0Wi9xhtswBXnfO2bTpTMkHD71H8rJMg==",
-            "dependencies": {
-                "mitt": "3.0.1",
-                "urlpattern-polyfill": "10.0.0",
-                "zod": "3.22.4"
-            },
-            "peerDependencies": {
-                "devtools-protocol": "*"
-            }
-        },
         "node_modules/cliui": {
             "version": "7.0.4",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1088,21 +960,6 @@
                 "string-width": "^4.2.0",
                 "strip-ansi": "^6.0.0",
                 "wrap-ansi": "^7.0.0"
-            }
-        },
-        "node_modules/clone-deep": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-            "integrity": "sha512-we+NuQo2DHhSl+DP6jlUiAhyAjBQrYnpOk15rN6c6JSPScjiCLh8IbSU+VTcph6YS3o7mASE8a0+gbZ7ChLpgg==",
-            "dependencies": {
-                "for-own": "^0.1.3",
-                "is-plain-object": "^2.0.1",
-                "kind-of": "^3.0.2",
-                "lazy-cache": "^1.0.3",
-                "shallow-clone": "^0.1.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/color": {
@@ -1192,7 +1049,8 @@
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true
         },
         "node_modules/connect-mongo": {
             "version": "5.1.0",
@@ -1351,14 +1209,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/deepmerge": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/define-data-property": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -1412,11 +1262,6 @@
                 "node": ">= 0.8",
                 "npm": "1.2.8000 || >= 1.4.16"
             }
-        },
-        "node_modules/devtools-protocol": {
-            "version": "0.0.1273771",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1273771.tgz",
-            "integrity": "sha512-QDbb27xcTVReQQW/GHJsdQqGKwYBE7re7gxehj467kKP2DKuYBUj6i2k5LRiAC66J1yZG/9gsxooz/s9pcm0Og=="
         },
         "node_modules/dezalgo": {
             "version": "1.0.4",
@@ -1475,9 +1320,9 @@
             "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
         },
         "node_modules/encodeurl": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -1607,36 +1452,36 @@
             }
         },
         "node_modules/express": {
-            "version": "4.19.2",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-            "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+            "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.20.2",
+                "body-parser": "1.20.3",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
                 "cookie": "0.6.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "2.0.0",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.2.0",
+                "finalhandler": "1.3.1",
                 "fresh": "0.5.2",
                 "http-errors": "2.0.0",
-                "merge-descriptors": "1.0.1",
+                "merge-descriptors": "1.0.3",
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.7",
+                "path-to-regexp": "0.1.10",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.11.0",
+                "qs": "6.13.0",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.18.0",
-                "serve-static": "1.15.0",
+                "send": "0.19.0",
+                "serve-static": "1.16.2",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "type-is": "~1.6.18",
@@ -1759,9 +1604,9 @@
             "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -1771,12 +1616,12 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
             "dependencies": {
                 "debug": "2.6.9",
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
@@ -1816,25 +1661,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
             "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-        },
-        "node_modules/for-in": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
-            "dependencies": {
-                "for-in": "^1.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/form-data": {
             "version": "4.0.0",
@@ -1895,7 +1721,8 @@
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+            "dev": true
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
@@ -2285,6 +2112,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -2338,19 +2166,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/is-buffer": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        },
-        "node_modules/is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/is-extglob": {
@@ -2411,17 +2226,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-plain-object": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dependencies": {
-                "isobject": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -2443,14 +2247,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/isobject": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/js-tokens": {
@@ -2516,17 +2312,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/kind-of": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-            "dependencies": {
-                "is-buffer": "^1.1.5"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/kruptein": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.6.tgz",
@@ -2542,14 +2327,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
             "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
-        },
-        "node_modules/lazy-cache": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-            "integrity": "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
@@ -2650,23 +2427,13 @@
             "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
             "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
         },
-        "node_modules/merge-deep": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.3.tgz",
-            "integrity": "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==",
-            "dependencies": {
-                "arr-union": "^3.1.0",
-                "clone-deep": "^0.2.4",
-                "kind-of": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/merge-descriptors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -2686,12 +2453,12 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -2758,26 +2525,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
             "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
-        },
-        "node_modules/mixin-object": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-            "integrity": "sha512-ALGF1Jt9ouehcaXaHhn6t1yGWRqGaHkPFndtFVHfZXOvkIZ/yoGaSi0AHVTafb3ZBGg4dr/bDwnaEKqCXzchMA==",
-            "dependencies": {
-                "for-in": "^0.1.3",
-                "is-extendable": "^0.1.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/mixin-object/node_modules/for-in": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-            "integrity": "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/mocha": {
             "version": "10.4.0",
@@ -3011,9 +2758,9 @@
             }
         },
         "node_modules/nise/node_modules/path-to-regexp": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-            "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+            "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
             "dev": true
         },
         "node_modules/nodemon": {
@@ -3371,18 +3118,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-to-regexp": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
         },
         "node_modules/path-type": {
             "version": "4.0.0",
@@ -3544,251 +3283,79 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "22.7.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.7.0.tgz",
-            "integrity": "sha512-s1ulKFZKW3lwWCtNu0VrRLfRaanFHxIv7F8UFYpLo8dPTZcI4wB4EAOD0sKT3SKP+1Rsjodb9WFsK78yKQ6i9Q==",
+            "name": "rebrowser-puppeteer",
+            "version": "23.3.1",
+            "resolved": "https://registry.npmjs.org/rebrowser-puppeteer/-/rebrowser-puppeteer-23.3.1.tgz",
+            "integrity": "sha512-ValE72zHO1+5ut+niwdbk+2AYbz70FdlKg1EcQxnsaaIDADze0y4ew2toLOf2lkfcSKe6xKxaJUoxv87yIo5FQ==",
             "hasInstallScript": true,
             "dependencies": {
-                "@puppeteer/browsers": "2.2.2",
-                "cosmiconfig": "9.0.0",
-                "devtools-protocol": "0.0.1273771",
-                "puppeteer-core": "22.7.0"
+                "@puppeteer/browsers": "2.4.0",
+                "chromium-bidi": "0.6.5",
+                "cosmiconfig": "^9.0.0",
+                "devtools-protocol": "0.0.1330662",
+                "puppeteer-core": "npm:rebrowser-puppeteer-core@~23.3.1",
+                "typed-query-selector": "^2.12.0"
             },
             "bin": {
-                "puppeteer": "lib/esm/puppeteer/node/cli.js"
+                "rebrowser-puppeteer": "lib/cjs/puppeteer/node/cli.js"
             },
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/puppeteer-core": {
-            "version": "22.7.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.7.0.tgz",
-            "integrity": "sha512-9Q+L3VD7cfhXnxv6AqwTHsVb/+/uXENByhPrgvwQ49wvzQwtf1d6b7v6gpoG3tpRdwYjxoV1eHTD8tFahww09g==",
+        "node_modules/puppeteer/node_modules/@puppeteer/browsers": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.4.0.tgz",
+            "integrity": "sha512-x8J1csfIygOwf6D6qUAZ0ASk3z63zPb7wkNeHRerCMh82qWKUrOgkuP005AJC8lDL6/evtXETGEJVcwykKT4/g==",
             "dependencies": {
-                "@puppeteer/browsers": "2.2.2",
-                "chromium-bidi": "0.5.17",
-                "debug": "4.3.4",
-                "devtools-protocol": "0.0.1273771",
-                "ws": "8.16.0"
+                "debug": "^4.3.6",
+                "extract-zip": "^2.0.1",
+                "progress": "^2.0.3",
+                "proxy-agent": "^6.4.0",
+                "semver": "^7.6.3",
+                "tar-fs": "^3.0.6",
+                "unbzip2-stream": "^1.4.3",
+                "yargs": "^17.7.2"
+            },
+            "bin": {
+                "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
                 "node": ">=18"
             }
         },
-        "node_modules/puppeteer-core/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+        "node_modules/puppeteer/node_modules/chromium-bidi": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.6.5.tgz",
+            "integrity": "sha512-RuLrmzYrxSb0s9SgpB+QN5jJucPduZQ/9SIe76MDxYJuecPW5mxMdacJ1f4EtgiV+R0p3sCkznTMvH0MPGFqjA==",
             "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-core/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/puppeteer-extra": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/puppeteer-extra/-/puppeteer-extra-3.3.6.tgz",
-            "integrity": "sha512-rsLBE/6mMxAjlLd06LuGacrukP2bqbzKCLzV1vrhHFavqQE/taQ2UXv3H5P0Ls7nsrASa+6x3bDbXHpqMwq+7A==",
-            "dependencies": {
-                "@types/debug": "^4.1.0",
-                "debug": "^4.1.1",
-                "deepmerge": "^4.2.2"
-            },
-            "engines": {
-                "node": ">=8"
+                "mitt": "3.0.1",
+                "urlpattern-polyfill": "10.0.0",
+                "zod": "3.23.8"
             },
             "peerDependencies": {
-                "@types/puppeteer": "*",
-                "puppeteer": "*",
-                "puppeteer-core": "*"
-            },
-            "peerDependenciesMeta": {
-                "@types/puppeteer": {
-                    "optional": true
-                },
-                "puppeteer": {
-                    "optional": true
-                },
-                "puppeteer-core": {
-                    "optional": true
-                }
+                "devtools-protocol": "*"
             }
         },
-        "node_modules/puppeteer-extra-plugin": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin/-/puppeteer-extra-plugin-3.2.3.tgz",
-            "integrity": "sha512-6RNy0e6pH8vaS3akPIKGg28xcryKscczt4wIl0ePciZENGE2yoaQJNd17UiEbdmh5/6WW6dPcfRWT9lxBwCi2Q==",
+        "node_modules/puppeteer/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "dependencies": {
-                "@types/debug": "^4.1.0",
-                "debug": "^4.1.1",
-                "merge-deep": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=9.11.2"
-            },
-            "peerDependencies": {
-                "playwright-extra": "*",
-                "puppeteer-extra": "*"
-            },
-            "peerDependenciesMeta": {
-                "playwright-extra": {
-                    "optional": true
-                },
-                "puppeteer-extra": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-extra-plugin-stealth": {
-            "version": "2.11.2",
-            "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-stealth/-/puppeteer-extra-plugin-stealth-2.11.2.tgz",
-            "integrity": "sha512-bUemM5XmTj9i2ZerBzsk2AN5is0wHMNE6K0hXBzBXOzP5m5G3Wl0RHhiqKeHToe/uIH8AoZiGhc1tCkLZQPKTQ==",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "puppeteer-extra-plugin": "^3.2.3",
-                "puppeteer-extra-plugin-user-preferences": "^2.4.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "peerDependencies": {
-                "playwright-extra": "*",
-                "puppeteer-extra": "*"
-            },
-            "peerDependenciesMeta": {
-                "playwright-extra": {
-                    "optional": true
-                },
-                "puppeteer-extra": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-extra-plugin-stealth/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-extra-plugin-stealth/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/puppeteer-extra-plugin-user-data-dir": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-data-dir/-/puppeteer-extra-plugin-user-data-dir-2.4.1.tgz",
-            "integrity": "sha512-kH1GnCcqEDoBXO7epAse4TBPJh9tEpVEK/vkedKfjOVOhZAvLkHGc9swMs5ChrJbRnf8Hdpug6TJlEuimXNQ+g==",
-            "dependencies": {
-                "debug": "^4.1.1",
-                "fs-extra": "^10.0.0",
-                "puppeteer-extra-plugin": "^3.2.3",
-                "rimraf": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "peerDependencies": {
-                "playwright-extra": "*",
-                "puppeteer-extra": "*"
-            },
-            "peerDependenciesMeta": {
-                "playwright-extra": {
-                    "optional": true
-                },
-                "puppeteer-extra": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/fs-extra": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-            "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
             },
             "engines": {
                 "node": ">=12"
             }
         },
-        "node_modules/puppeteer-extra-plugin-user-data-dir/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/puppeteer-extra-plugin-user-preferences": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/puppeteer-extra-plugin-user-preferences/-/puppeteer-extra-plugin-user-preferences-2.4.1.tgz",
-            "integrity": "sha512-i1oAZxRbc1bk8MZufKCruCEC3CCafO9RKMkkodZltI4OqibLFXF3tj6HZ4LZ9C5vCXZjYcDWazgtY69mnmrQ9A==",
+        "node_modules/puppeteer/node_modules/debug": {
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+            "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
             "dependencies": {
-                "debug": "^4.1.1",
-                "deepmerge": "^4.2.2",
-                "puppeteer-extra-plugin": "^3.2.3",
-                "puppeteer-extra-plugin-user-data-dir": "^2.4.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "peerDependencies": {
-                "playwright-extra": "*",
-                "puppeteer-extra": "*"
-            },
-            "peerDependenciesMeta": {
-                "playwright-extra": {
-                    "optional": true
-                },
-                "puppeteer-extra": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/puppeteer-extra-plugin-user-preferences/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-            "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -3799,59 +3366,64 @@
                 }
             }
         },
-        "node_modules/puppeteer-extra-plugin-user-preferences/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "node_modules/puppeteer/node_modules/devtools-protocol": {
+            "version": "0.0.1330662",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1330662.tgz",
+            "integrity": "sha512-pzh6YQ8zZfz3iKlCvgzVCu22NdpZ8hNmwU6WnQjNVquh0A9iVosPtNLWDwaWVGyrntQlltPFztTMK5Cg6lfCuw=="
         },
-        "node_modules/puppeteer-extra-plugin/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+        "node_modules/puppeteer/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "node_modules/puppeteer/node_modules/puppeteer-core": {
+            "name": "rebrowser-puppeteer-core",
+            "version": "23.3.1",
+            "resolved": "https://registry.npmjs.org/rebrowser-puppeteer-core/-/rebrowser-puppeteer-core-23.3.1.tgz",
+            "integrity": "sha512-+BB6leL2aSnpR/DYc0cqcdue3PCzPzT6t0b3IUFbhfQVjfr0WHXNpEd5/AECTg42O/3YdMkLLXNyfzmd+aiFsw==",
             "dependencies": {
-                "ms": "2.1.2"
+                "@puppeteer/browsers": "2.4.0",
+                "chromium-bidi": "0.6.5",
+                "debug": "^4.3.7",
+                "devtools-protocol": "0.0.1330662",
+                "typed-query-selector": "^2.12.0",
+                "ws": "^8.18.0"
             },
             "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">=18"
             }
         },
-        "node_modules/puppeteer-extra-plugin/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/puppeteer-extra/node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+        "node_modules/puppeteer/node_modules/yargs": {
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dependencies": {
-                "ms": "2.1.2"
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
+                "node": ">=12"
             }
         },
-        "node_modules/puppeteer-extra/node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "node_modules/puppeteer/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/qs": {
-            "version": "6.11.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-            "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+            "version": "6.13.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+            "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
             "dependencies": {
-                "side-channel": "^1.0.4"
+                "side-channel": "^1.0.6"
             },
             "engines": {
                 "node": ">=0.6"
@@ -3984,59 +3556,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/rimraf/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4093,12 +3612,9 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/semver": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -4106,21 +3622,10 @@
                 "node": ">=10"
             }
         },
-        "node_modules/semver/node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/send": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
@@ -4140,6 +3645,14 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/send/node_modules/encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/send/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4155,14 +3668,14 @@
             }
         },
         "node_modules/serve-static": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "dependencies": {
-                "encodeurl": "~1.0.2",
+                "encodeurl": "~2.0.0",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.18.0"
+                "send": "0.19.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -4188,39 +3701,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
-        },
-        "node_modules/shallow-clone": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-            "integrity": "sha512-J1zdXCky5GmNnuauESROVu31MQSnLoYvlyEn6j2Ztk6Q5EHFIhxkMhYcv6vuDzl2XEzoRr856QwzMgWM/TmZgw==",
-            "dependencies": {
-                "is-extendable": "^0.1.1",
-                "kind-of": "^2.0.1",
-                "lazy-cache": "^0.2.3",
-                "mixin-object": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/shallow-clone/node_modules/kind-of": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-            "integrity": "sha512-0u8i1NZ/mg0b+W3MGGw5I7+6Eib2nx72S/QvXa0hYjEkjTknYmEYQJwGu3mLC0BrhtJjtQafTkyRUQ75Kx0LVg==",
-            "dependencies": {
-                "is-buffer": "^1.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/shallow-clone/node_modules/lazy-cache": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-            "integrity": "sha512-gkX52wvU/R8DVMMt78ATVPFMJqfW8FPz1GZ1sVHBVQHmu/WvhIWE4cE1GBzhJNFicDeYhnwp6Rl35BcAIM3YOQ==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/side-channel": {
             "version": "1.0.6",
@@ -4422,12 +3902,13 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
-            "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
+            "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
             "dependencies": {
-                "fast-fifo": "^1.1.0",
-                "queue-tick": "^1.0.1"
+                "fast-fifo": "^1.3.2",
+                "queue-tick": "^1.0.1",
+                "text-decoder": "^1.1.0"
             },
             "optionalDependencies": {
                 "bare-events": "^2.2.0"
@@ -4555,9 +4036,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
-            "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
+            "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
             "dependencies": {
                 "pump": "^3.0.0",
                 "tar-stream": "^3.1.5"
@@ -4575,6 +4056,14 @@
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
+            }
+        },
+        "node_modules/text-decoder": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.0.tgz",
+            "integrity": "sha512-n1yg1mOj9DNpk3NeZOx7T6jchTbyJS3i3cucbNN6FcdPriMZx7NsgrGpWWdWZZGxD7ES1XB+3uoqHMgOKaN+fg==",
+            "dependencies": {
+                "b4a": "^1.6.4"
             }
         },
         "node_modules/text-hex": {
@@ -4729,6 +4218,11 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/typed-query-selector": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+            "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
         },
         "node_modules/typescript": {
             "version": "5.4.5",
@@ -4903,9 +4397,9 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/ws": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -4929,11 +4423,6 @@
             "engines": {
                 "node": ">=10"
             }
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yargs": {
             "version": "16.2.0",
@@ -5008,9 +4497,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.22.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-            "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+            "version": "3.23.8",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+            "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package.json
+++ b/package.json
@@ -51,9 +51,7 @@
         "mongoose": "^8.3.2",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
-        "puppeteer": "^22.6.1",
-        "puppeteer-extra": "^3.3.6",
-        "puppeteer-extra-plugin-stealth": "^2.11.2",
+        "puppeteer": "npm:rebrowser-puppeteer@^23.3.1",
         "winston": "^3.13.0"
     }
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -25,14 +25,13 @@ class App {
 
     // Run configuration methods on the Express instance.
     constructor(mongoDBConnection: string) {
-        console.log("MongoDB Connection String: ", mongoDBConnection);
         this.expressApp = express();
         this.middleware(mongoDBConnection);
         this.routes();
         this.Products = new ProductModel(mongoDBConnection);
         this.Customer = new CustomerModel(mongoDBConnection, this.Products);
         // Uncomment this to populate the DB
-        // this.scrapeAllStores();
+        //this.scrapeAllStores();
     }
 
     // Configure the express middleware

--- a/src/WebScraping/ProductProcessor.ts
+++ b/src/WebScraping/ProductProcessor.ts
@@ -61,7 +61,6 @@ class ProductProcessor {
                         currProduct.productName,
                         currProduct.storeName
                     );
-                // TODO: Create update product function, if the product exists in the DB update it. Currently only add the product if it does not exist yet.
                 // If the product does not exist at the current store we will add it to the product comparison section
                 if (!doesProductExistAtCurrStore) {
                     await this.addToProductComparison(
@@ -117,7 +116,6 @@ class ProductProcessor {
             productRecord.productComparison.push(currProduct);
             await productRecord.save();
         }
-        // TODO: If the product does exist in the product comparison array, see if we need to update any of the fields
     }
 }
 export { ProductProcessor };

--- a/src/WebScraping/Utils/CreateBrowserInstance.ts
+++ b/src/WebScraping/Utils/CreateBrowserInstance.ts
@@ -10,9 +10,10 @@ class BrowserInstance {
     public async createBrowserInstance(runHeadless: boolean): Promise<Browser> {
         // Create a browser instance
         // Disabling the chrome headless automation controlled flag, so now we are extra sneaky.
-        const browser = await puppeteer.launch({ headless: runHeadless, args:[
-            '--disable-blink-features=AutomationControlled',
-        ] });
+        const browser = await puppeteer.launch({
+            headless: runHeadless,
+            args: ["--disable-blink-features=AutomationControlled"],
+        });
         // Return the browser instance we created.
         return browser;
     }

--- a/src/WebScraping/Utils/CreateBrowserInstance.ts
+++ b/src/WebScraping/Utils/CreateBrowserInstance.ts
@@ -1,6 +1,5 @@
 import { Browser } from "puppeteer";
-import puppeteer from "puppeteer-extra";
-import StealthPlugin from "puppeteer-extra-plugin-stealth";
+import puppeteer from "puppeteer";
 
 class BrowserInstance {
     /**
@@ -9,10 +8,11 @@ class BrowserInstance {
      * @returns {Promise<Browser>} browser instance that the webscraper can utilize.
      */
     public async createBrowserInstance(runHeadless: boolean): Promise<Browser> {
-        // Tell the puppeteer object to use the Stealth plugin to avoid sites detecting that we are scraping them.
-        puppeteer.use(StealthPlugin());
         // Create a browser instance
-        const browser = await puppeteer.launch({ headless: runHeadless });
+        // Disabling the chrome headless automation controlled flag, so now we are extra sneaky.
+        const browser = await puppeteer.launch({ headless: runHeadless, args:[
+            '--disable-blink-features=AutomationControlled',
+        ] });
         // Return the browser instance we created.
         return browser;
     }

--- a/src/model/ProductModel.ts
+++ b/src/model/ProductModel.ts
@@ -33,7 +33,6 @@ class ProductModel {
     public async createModel() {
         try {
             await Mongoose.connect(this.dbConnectionString);
-            console.log("Connected to MongoDB", Mongoose.models);
             if (Mongoose.models.Products) {
                 this.model = Mongoose.model<IProductModel>("Products");
             } else {

--- a/tests/routes/Route.test.ts
+++ b/tests/routes/Route.test.ts
@@ -4,7 +4,7 @@ import "mocha";
 import { AnyObject } from "mongoose";
 
 chai.use(chaiHTTP);
-const azureUrl= "https://pricepinion.azurewebsites.net";
+const azureUrl = "https://pricepinion.azurewebsites.net";
 describe("Get All Products", () => {
     let response: ChaiHttp.Response;
     // Before all tests make a call to our server to get all products and store the response


### PR DESCRIPTION
### Issue
This project relied heavily on the Puppeteer Stealth Tweaks, unfortunately this library is no longer maintained.  Kroger and Wholefoods have improved their detection systems, so the scrapers failed to collect data. 

### Fix
Replaced Puppeteer and Puppeteer Stealth with the rebrowser-puppeteer package. This is a drop in replacement for puppeteer.  You will still see Puppeteer import statements however, the package in package.json has been aliased to "npm:rebrowser-puppeteer@^23.3.1" the library still functions the exact same way as Puppeteer did but with some extra tweaks.